### PR TITLE
Disable release workflow + fix changesets config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,5 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch",
-  "ignore": ["x402b"]
+  "updateInternalDependencies": "patch"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Opt JS-action runtimes onto Node 24 ahead of GitHub's June 2026 forced
+# migration so checkout/setup-node/etc. don't print Node-20 deprecation
+# warnings on every run.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-test-lint:
     name: build / test / lint (node ${{ matrix.node }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,16 @@
 name: Release
 
+# Disabled until the @bosonprotocol/x402-* packages are ready to publish.
+# Re-enable by restoring the `push: branches: [main]` trigger below.
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

The release workflow failed on the post-merge run of #4 ([logs](https://github.com/bosonprotocol/x402B/actions/runs/25540285614)) for two reasons:

1. **Changesets config error** — `"ignore": ["x402b"]` referenced the root package, which is `private: true` and therefore already excluded from the changesets package list. Listing it then resolves to a non-existent package and trips `ValidationError`. Drop the line; private roots are auto-skipped.

2. **Release should not run yet** — no `@bosonprotocol/x402-*` package is publish-ready, so triggering on every push to `main` produces only noise (and would fail at the `npm publish` step once the config is fixed, since `NPM_TOKEN` isn't configured either). Switch the trigger to `workflow_dispatch` so the workflow stays as documentation but only runs on manual dispatch. Restore the `push: branches: [main]` trigger when the first package is ready to publish.

Also opts JS-action runtimes onto Node 24 via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` (in both workflows) so `checkout` / `setup-node` / `pnpm-action-setup` stop printing Node-20 deprecation warnings on every run. GitHub forces the migration on June 2nd 2026 anyway.

## Test plan

- [x] `pnpm format:check` passes
- [x] CI workflow runs green on this PR (matrix on Node 22 + 24, no deprecation warnings)
- [x] Release workflow shows `workflow_dispatch` trigger only on the Actions tab; doesn't fire on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)