### PR TITLE
Add escrow scheme types, JSON schemas, and zod validators

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@types/node':
         specifier: ^20.17.10
         version: 20.19.40
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
@@ -823,6 +826,9 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -1054,6 +1060,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1197,6 +1206,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1429,6 +1441,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2401,6 +2417,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
@@ -2664,6 +2687,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.2: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -2792,6 +2817,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -2988,6 +3015,8 @@ snapshots:
       strip-bom: 3.0.0
 
   readdirp@4.1.2: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**", "package.json", "tsconfig.json", "tsup.config.ts"],
+      "inputs": ["src/**", "scripts/**", "package.json", "tsconfig.json", "tsup.config.ts"],
       "outputs": ["dist/**"]
     },
     "test": {

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -28,7 +28,13 @@
       "types": "./dist/cjs/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "./schemes/escrow": {
+      "types": "./dist/cjs/schemes/escrow/index.d.ts",
+      "import": "./dist/esm/schemes/escrow/index.js",
+      "require": "./dist/cjs/schemes/escrow/index.js"
+    },
+    "./schemas/*": "./dist/schemas/*"
   },
   "files": [
     "dist",
@@ -39,7 +45,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node scripts/postbuild.mjs",
     "test": "vitest run --passWithNoTests",
     "lint": "eslint src --max-warnings 0",
     "clean": "rm -rf dist .turbo"
@@ -51,6 +57,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.17.10",
+    "ajv": "^8.17.1",
     "tsup": "^8.3.5",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"

--- a/typescript/packages/core/scripts/postbuild.mjs
+++ b/typescript/packages/core/scripts/postbuild.mjs
@@ -8,7 +8,7 @@
 //    subtree under the correct module dialect without a
 //    MODULE_TYPELESS_PACKAGE_JSON warning at consume time.
 
-import { readdir, mkdir, copyFile, writeFile } from "node:fs/promises";
+import { readdir, mkdir, rm, copyFile, writeFile } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -26,6 +26,9 @@ async function* walk(dir) {
   }
 }
 
+// Wipe `dist/schemas/` first so renamed or removed source schemas don't
+// leak into published tarballs.
+await rm(schemasRoot, { recursive: true, force: true });
 await mkdir(schemasRoot, { recursive: true });
 
 let schemaCount = 0;

--- a/typescript/packages/core/scripts/postbuild.mjs
+++ b/typescript/packages/core/scripts/postbuild.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Post-build housekeeping after `tsup`:
+//
+// 1. Copy `src/**/schemas/*.json` flat into `dist/schemas/` so the
+//    `./schemas/*` package export resolves at runtime.
+// 2. Write `dist/esm/package.json` ({"type":"module"}) and
+//    `dist/cjs/package.json` ({"type":"commonjs"}) so Node treats each
+//    subtree under the correct module dialect without a
+//    MODULE_TYPELESS_PACKAGE_JSON warning at consume time.
+
+import { readdir, mkdir, copyFile, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const srcRoot = join(here, "..", "src");
+const distRoot = join(here, "..", "dist");
+const schemasRoot = join(distRoot, "schemas");
+
+async function* walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else yield p;
+  }
+}
+
+await mkdir(schemasRoot, { recursive: true });
+
+let schemaCount = 0;
+for await (const file of walk(srcRoot)) {
+  if (!file.endsWith(".json")) continue;
+  const rel = relative(srcRoot, file);
+  if (!rel.split(/[\\/]/).includes("schemas")) continue;
+  const name = file.split(/[\\/]/).pop();
+  await copyFile(file, join(schemasRoot, name));
+  schemaCount += 1;
+}
+
+await writeFile(
+  join(distRoot, "esm", "package.json"),
+  JSON.stringify({ type: "module" }, null, 2) + "\n",
+);
+await writeFile(
+  join(distRoot, "cjs", "package.json"),
+  JSON.stringify({ type: "commonjs" }, null, 2) + "\n",
+);
+
+console.log(
+  `postbuild: ${schemaCount} schema(s) -> ${relative(process.cwd(), schemasRoot)}, wrote module-type markers in dist/{esm,cjs}/package.json`,
+);

--- a/typescript/packages/core/src/schemes/escrow/index.ts
+++ b/typescript/packages/core/src/schemes/escrow/index.ts
@@ -1,0 +1,10 @@
+// Public surface for the `escrow` scheme.
+// See docs/boson-impl-01-escrow-scheme.md for the wire format.
+
+export * from "./types.js";
+export * from "./payment-requirements.js";
+export * from "./payment-payload.js";
+
+/** Stable identifier for the scheme. Use this in place of the raw string `"escrow"` to avoid typos. */
+export const ESCROW_SCHEME = "escrow" as const;
+export type EscrowScheme = typeof ESCROW_SCHEME;

--- a/typescript/packages/core/src/schemes/escrow/payment-payload.ts
+++ b/typescript/packages/core/src/schemes/escrow/payment-payload.ts
@@ -35,7 +35,7 @@ const metaTxSchema = z
     from: addressSchema,
     nonce: decimalUintSchema,
     functionName: z.string().min(1),
-    functionArgs: hexBytesSchema,
+    functionSignature: hexBytesSchema,
     sig: sigSchema,
   })
   .strict();

--- a/typescript/packages/core/src/schemes/escrow/payment-payload.ts
+++ b/typescript/packages/core/src/schemes/escrow/payment-payload.ts
@@ -1,0 +1,156 @@
+// `escrow` scheme PaymentPayload (client -> server, base64'd in `X-PAYMENT`).
+// Source of truth: docs/boson-impl-01-escrow-scheme.md §3.
+
+import { z } from "zod";
+
+import {
+  TOKEN_AUTH_STRATEGIES,
+  type Address,
+  type BosonMetaTx,
+  type BosonTokenAuth,
+  type EvmNetwork,
+  type FullOffer,
+  type Hex,
+  type TokenAuthStrategy,
+} from "./types.js";
+import {
+  addressSchema,
+  decimalUintSchema,
+  evmNetworkSchema,
+  hex32Schema,
+  hexBytesSchema,
+  hexSchema,
+} from "./validators.js";
+
+const sigSchema = z
+  .object({
+    v: z.number().int(),
+    r: hex32Schema,
+    s: hex32Schema,
+  })
+  .strict();
+
+const metaTxSchema = z
+  .object({
+    from: addressSchema,
+    nonce: decimalUintSchema,
+    functionName: z.string().min(1),
+    functionArgs: hexBytesSchema,
+    sig: sigSchema,
+  })
+  .strict();
+
+const erc3009DataSchema = z
+  .object({
+    from: addressSchema,
+    to: addressSchema,
+    value: decimalUintSchema,
+    validAfter: z.number().int().nonnegative(),
+    validBefore: z.number().int().nonnegative(),
+    nonce: hex32Schema,
+    v: z.number().int(),
+    r: hex32Schema,
+    s: hex32Schema,
+  })
+  .strict();
+
+const permitDataSchema = z
+  .object({
+    owner: addressSchema,
+    spender: addressSchema,
+    value: decimalUintSchema,
+    deadline: z.number().int().nonnegative(),
+    nonce: decimalUintSchema,
+    v: z.number().int(),
+    r: hex32Schema,
+    s: hex32Schema,
+  })
+  .strict();
+
+const permit2DataSchema = z
+  .object({
+    permitted: z
+      .object({
+        token: addressSchema,
+        amount: decimalUintSchema,
+      })
+      .strict(),
+    spender: addressSchema,
+    nonce: decimalUintSchema,
+    deadline: z.number().int().nonnegative(),
+    signature: hexSchema,
+  })
+  .strict();
+
+const tokenAuthSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("erc3009"), data: erc3009DataSchema }).strict(),
+  z.object({ kind: z.literal("permit"), data: permitDataSchema }).strict(),
+  z.object({ kind: z.literal("permit2"), data: permit2DataSchema }).strict(),
+]);
+
+const tokenAuthStrategySchema = z.enum(
+  TOKEN_AUTH_STRATEGIES as readonly [TokenAuthStrategy, ...TokenAuthStrategy[]],
+);
+
+/** Inner `payload` field of `EscrowPaymentPayload`. */
+export interface EscrowPaymentPayloadInner {
+  action: string;
+  tokenAuthStrategy: TokenAuthStrategy;
+  offerRef: { fullOffer: FullOffer; sellerSig: Hex };
+  buyer: Address;
+  metaTx: BosonMetaTx;
+  /** Required iff `tokenAuthStrategy !== "none"`. */
+  tokenAuth?: BosonTokenAuth;
+}
+
+/**
+ * Wire-format type for the `escrow` PaymentPayload that a client base64's into
+ * the `X-PAYMENT` header. See docs/boson-impl-01-escrow-scheme.md §3.
+ */
+export interface EscrowPaymentPayload {
+  x402Version: number;
+  scheme: "escrow";
+  network: EvmNetwork;
+  payload: EscrowPaymentPayloadInner;
+  fulfillment?: { option: string; data: Record<string, unknown> };
+}
+
+/**
+ * Zod validator paired with `payment_payload.schema.json`. Note: this only
+ * validates structural shape; cross-field rules (per docs/boson-impl-01 §5)
+ * such as "tokenAuth must be omitted iff tokenAuthStrategy === 'none'" are
+ * enforced server-side and are not part of this schema.
+ */
+export const escrowPaymentPayloadSchema = z
+  .object({
+    x402Version: z.number().int(),
+    scheme: z.literal("escrow"),
+    network: evmNetworkSchema,
+    payload: z
+      .object({
+        action: z.string().min(1),
+        tokenAuthStrategy: tokenAuthStrategySchema,
+        offerRef: z
+          .object({
+            fullOffer: z.record(z.unknown()),
+            sellerSig: hexSchema,
+          })
+          .strict(),
+        buyer: addressSchema,
+        metaTx: metaTxSchema,
+        tokenAuth: tokenAuthSchema.optional(),
+      })
+      .strict(),
+    fulfillment: z
+      .object({
+        option: z.string().min(1),
+        data: z.record(z.unknown()),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+export function parseEscrowPaymentPayload(value: unknown): EscrowPaymentPayload {
+  return escrowPaymentPayloadSchema.parse(value);
+}

--- a/typescript/packages/core/src/schemes/escrow/payment-requirements.ts
+++ b/typescript/packages/core/src/schemes/escrow/payment-requirements.ts
@@ -1,0 +1,121 @@
+// `escrow` scheme PaymentRequirements (server -> client, in 402 body).
+// Source of truth: docs/boson-impl-01-escrow-scheme.md §2.
+
+import { z } from "zod";
+
+import {
+  ACTION_CHANNELS,
+  TOKEN_AUTH_STRATEGIES,
+  type ActionChannel,
+  type ActionsEnvelope,
+  type Address,
+  type BosonOfferRef,
+  type EvmNetwork,
+  type FulfillmentRequirements,
+  type TokenAuthStrategy,
+} from "./types.js";
+import { addressSchema, decimalUintSchema, evmNetworkSchema, hexSchema } from "./validators.js";
+
+const offerRefSchema = z
+  .object({
+    fullOffer: z.record(z.unknown()),
+    sellerSig: hexSchema,
+    creator: addressSchema,
+  })
+  .strict();
+
+const tokenAuthStrategySchema = z.enum(
+  TOKEN_AUTH_STRATEGIES as readonly [TokenAuthStrategy, ...TokenAuthStrategy[]],
+);
+
+const fulfillmentSchema = z
+  .object({
+    required: z.boolean(),
+    options: z.array(
+      z
+        .object({
+          id: z.string().min(1),
+          schema: z.union([z.record(z.unknown()), z.null()]),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
+const actionsSchema = z
+  .object({
+    next: z
+      .array(
+        z
+          .object({
+            id: z.string().min(1),
+            channels: z
+              .array(z.enum(ACTION_CHANNELS as readonly [ActionChannel, ...ActionChannel[]]))
+              .min(1),
+            endpoints: z.record(z.string()).optional(),
+          })
+          .strict(),
+      )
+      .min(1),
+    fallback: z
+      .object({
+        xmtp: z.string().optional(),
+        mcp: z.string().optional(),
+        onchainHints: z
+          .object({
+            escrow: addressSchema,
+            metaTxFacet: z.string().min(1),
+            metaTxEntrypoint: z.string().min(1),
+            actionFacets: z.record(z.string()),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+/**
+ * Wire-format type for the `escrow` PaymentRequirements that a server emits
+ * inside a 402 `accepts[]` entry. See docs/boson-impl-01-escrow-scheme.md §2
+ * for field semantics.
+ */
+export interface EscrowPaymentRequirements {
+  scheme: "escrow";
+  network: EvmNetwork;
+  asset: Address;
+  /** Atomic units, decimal string. */
+  amount: string;
+  /** Address of the Boson escrow contract — the custodian. */
+  escrowAddress: Address;
+  /** Routing-only seller identifier. May be a numeric `sellerId`, a `did:boson:seller:N`, or a wallet address. */
+  recipientId: string;
+  maxTimeoutSeconds: number;
+  offer: BosonOfferRef;
+  tokenAuthStrategies: TokenAuthStrategy[];
+  fulfillment?: FulfillmentRequirements;
+  actions: ActionsEnvelope;
+}
+
+/** Zod validator paired with `payment_requirements.schema.json`. */
+export const escrowPaymentRequirementsSchema = z
+  .object({
+    scheme: z.literal("escrow"),
+    network: evmNetworkSchema,
+    asset: addressSchema,
+    amount: decimalUintSchema,
+    escrowAddress: addressSchema,
+    recipientId: z.string().min(1),
+    maxTimeoutSeconds: z.number().int().positive(),
+    offer: offerRefSchema,
+    tokenAuthStrategies: z.array(tokenAuthStrategySchema).min(1),
+    fulfillment: fulfillmentSchema.optional(),
+    actions: actionsSchema,
+  })
+  .strict();
+
+/** Type-guard form. Returns the parsed value on success, throws on failure (with a `ZodError` carrying the field path). */
+export function parseEscrowPaymentRequirements(value: unknown): EscrowPaymentRequirements {
+  return escrowPaymentRequirementsSchema.parse(value);
+}

--- a/typescript/packages/core/src/schemes/escrow/payment-requirements.ts
+++ b/typescript/packages/core/src/schemes/escrow/payment-requirements.ts
@@ -51,7 +51,10 @@ const actionsSchema = z
             id: z.string().min(1),
             channels: z
               .array(z.enum(ACTION_CHANNELS as readonly [ActionChannel, ...ActionChannel[]]))
-              .min(1),
+              .min(1)
+              .refine((channels) => new Set(channels).size === channels.length, {
+                message: "channels must contain unique items",
+              }),
             endpoints: z.record(z.string()).optional(),
           })
           .strict(),
@@ -109,7 +112,12 @@ export const escrowPaymentRequirementsSchema = z
     recipientId: z.string().min(1),
     maxTimeoutSeconds: z.number().int().positive(),
     offer: offerRefSchema,
-    tokenAuthStrategies: z.array(tokenAuthStrategySchema).min(1),
+    tokenAuthStrategies: z
+      .array(tokenAuthStrategySchema)
+      .min(1)
+      .refine((strategies) => new Set(strategies).size === strategies.length, {
+        message: "tokenAuthStrategies must not contain duplicates",
+      }),
     fulfillment: fulfillmentSchema.optional(),
     actions: actionsSchema,
   })

--- a/typescript/packages/core/src/schemes/escrow/schemas/payment_payload.schema.json
+++ b/typescript/packages/core/src/schemes/escrow/schemas/payment_payload.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bosonprotocol.io/schemas/x402-core/payment_payload.schema.json",
+  "title": "x402B escrow PaymentPayload",
+  "description": "Wire-format PaymentPayload for the `escrow` scheme (carried base64-encoded in the `X-PAYMENT` header). Source: docs/boson-impl-01-escrow-scheme.md §3.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["x402Version", "scheme", "network", "payload"],
+  "definitions": {
+    "address": { "type": "string", "pattern": "^0x[a-fA-F0-9]{40}$" },
+    "hex": { "type": "string", "pattern": "^0x[a-fA-F0-9]+$" },
+    "hexBytes": { "type": "string", "pattern": "^0x[a-fA-F0-9]*$" },
+    "hex32": { "type": "string", "pattern": "^0x[a-fA-F0-9]{64}$" },
+    "decimalUint": { "type": "string", "pattern": "^(0|[1-9][0-9]*)$" },
+    "sig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["v", "r", "s"],
+      "properties": {
+        "v": { "type": "integer" },
+        "r": { "$ref": "#/definitions/hex32" },
+        "s": { "$ref": "#/definitions/hex32" }
+      }
+    },
+    "metaTx": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "nonce", "functionName", "functionArgs", "sig"],
+      "properties": {
+        "from": { "$ref": "#/definitions/address" },
+        "nonce": { "$ref": "#/definitions/decimalUint" },
+        "functionName": { "type": "string", "minLength": 1 },
+        "functionArgs": { "$ref": "#/definitions/hexBytes" },
+        "sig": { "$ref": "#/definitions/sig" }
+      }
+    },
+    "erc3009Auth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "data"],
+      "properties": {
+        "kind": { "const": "erc3009" },
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["from", "to", "value", "validAfter", "validBefore", "nonce", "v", "r", "s"],
+          "properties": {
+            "from": { "$ref": "#/definitions/address" },
+            "to": { "$ref": "#/definitions/address" },
+            "value": { "$ref": "#/definitions/decimalUint" },
+            "validAfter": { "type": "integer", "minimum": 0 },
+            "validBefore": { "type": "integer", "minimum": 0 },
+            "nonce": { "$ref": "#/definitions/hex32" },
+            "v": { "type": "integer" },
+            "r": { "$ref": "#/definitions/hex32" },
+            "s": { "$ref": "#/definitions/hex32" }
+          }
+        }
+      }
+    },
+    "permitAuth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "data"],
+      "properties": {
+        "kind": { "const": "permit" },
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["owner", "spender", "value", "deadline", "nonce", "v", "r", "s"],
+          "properties": {
+            "owner": { "$ref": "#/definitions/address" },
+            "spender": { "$ref": "#/definitions/address" },
+            "value": { "$ref": "#/definitions/decimalUint" },
+            "deadline": { "type": "integer", "minimum": 0 },
+            "nonce": { "$ref": "#/definitions/decimalUint" },
+            "v": { "type": "integer" },
+            "r": { "$ref": "#/definitions/hex32" },
+            "s": { "$ref": "#/definitions/hex32" }
+          }
+        }
+      }
+    },
+    "permit2Auth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "data"],
+      "properties": {
+        "kind": { "const": "permit2" },
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["permitted", "spender", "nonce", "deadline", "signature"],
+          "properties": {
+            "permitted": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["token", "amount"],
+              "properties": {
+                "token": { "$ref": "#/definitions/address" },
+                "amount": { "$ref": "#/definitions/decimalUint" }
+              }
+            },
+            "spender": { "$ref": "#/definitions/address" },
+            "nonce": { "$ref": "#/definitions/decimalUint" },
+            "deadline": { "type": "integer", "minimum": 0 },
+            "signature": { "$ref": "#/definitions/hex" }
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "x402Version": { "type": "integer" },
+    "scheme": { "const": "escrow" },
+    "network": { "type": "string", "pattern": "^eip155:[1-9][0-9]*$" },
+    "payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "tokenAuthStrategy", "offerRef", "buyer", "metaTx"],
+      "properties": {
+        "action": { "type": "string", "minLength": 1 },
+        "tokenAuthStrategy": { "enum": ["none", "erc3009", "permit", "permit2"] },
+        "offerRef": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["fullOffer", "sellerSig"],
+          "properties": {
+            "fullOffer": { "type": "object" },
+            "sellerSig": { "$ref": "#/definitions/hex" }
+          }
+        },
+        "buyer": { "$ref": "#/definitions/address" },
+        "metaTx": { "$ref": "#/definitions/metaTx" },
+        "tokenAuth": {
+          "oneOf": [
+            { "$ref": "#/definitions/erc3009Auth" },
+            { "$ref": "#/definitions/permitAuth" },
+            { "$ref": "#/definitions/permit2Auth" }
+          ]
+        }
+      }
+    },
+    "fulfillment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["option", "data"],
+      "properties": {
+        "option": { "type": "string", "minLength": 1 },
+        "data": { "type": "object" }
+      }
+    }
+  }
+}

--- a/typescript/packages/core/src/schemes/escrow/schemas/payment_payload.schema.json
+++ b/typescript/packages/core/src/schemes/escrow/schemas/payment_payload.schema.json
@@ -25,12 +25,12 @@
     "metaTx": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["from", "nonce", "functionName", "functionArgs", "sig"],
+      "required": ["from", "nonce", "functionName", "functionSignature", "sig"],
       "properties": {
         "from": { "$ref": "#/definitions/address" },
         "nonce": { "$ref": "#/definitions/decimalUint" },
         "functionName": { "type": "string", "minLength": 1 },
-        "functionArgs": { "$ref": "#/definitions/hexBytes" },
+        "functionSignature": { "$ref": "#/definitions/hexBytes" },
         "sig": { "$ref": "#/definitions/sig" }
       }
     },

--- a/typescript/packages/core/src/schemes/escrow/schemas/payment_requirements.schema.json
+++ b/typescript/packages/core/src/schemes/escrow/schemas/payment_requirements.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bosonprotocol.io/schemas/x402-core/payment_requirements.schema.json",
+  "title": "x402B escrow PaymentRequirements",
+  "description": "Wire-format PaymentRequirements for the `escrow` scheme. Source: docs/boson-impl-01-escrow-scheme.md §2.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "scheme",
+    "network",
+    "asset",
+    "amount",
+    "escrowAddress",
+    "recipientId",
+    "maxTimeoutSeconds",
+    "offer",
+    "tokenAuthStrategies",
+    "actions"
+  ],
+  "properties": {
+    "scheme": { "const": "escrow" },
+    "network": { "type": "string", "pattern": "^eip155:[1-9][0-9]*$" },
+    "asset": { "type": "string", "pattern": "^0x[a-fA-F0-9]{40}$" },
+    "amount": { "type": "string", "pattern": "^(0|[1-9][0-9]*)$" },
+    "escrowAddress": { "type": "string", "pattern": "^0x[a-fA-F0-9]{40}$" },
+    "recipientId": { "type": "string", "minLength": 1 },
+    "maxTimeoutSeconds": { "type": "integer", "minimum": 1 },
+    "offer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fullOffer", "sellerSig", "creator"],
+      "properties": {
+        "fullOffer": { "type": "object" },
+        "sellerSig": { "type": "string", "pattern": "^0x[a-fA-F0-9]+$" },
+        "creator": { "type": "string", "pattern": "^0x[a-fA-F0-9]{40}$" }
+      }
+    },
+    "tokenAuthStrategies": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "enum": ["none", "erc3009", "permit", "permit2"] }
+    },
+    "fulfillment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "options"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "schema"],
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "schema": {
+                "oneOf": [{ "type": "object" }, { "type": "null" }]
+              }
+            }
+          }
+        }
+      }
+    },
+    "actions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["next"],
+      "properties": {
+        "next": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "channels"],
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "channels": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "enum": ["server", "facilitator", "onchain", "mcp", "xmtp"]
+                }
+              },
+              "endpoints": {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+              }
+            }
+          }
+        },
+        "fallback": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "xmtp": { "type": "string" },
+            "mcp": { "type": "string" },
+            "onchainHints": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["escrow", "metaTxFacet", "metaTxEntrypoint", "actionFacets"],
+              "properties": {
+                "escrow": { "type": "string", "pattern": "^0x[a-fA-F0-9]{40}$" },
+                "metaTxFacet": { "type": "string", "minLength": 1 },
+                "metaTxEntrypoint": { "type": "string", "minLength": 1 },
+                "actionFacets": {
+                  "type": "object",
+                  "additionalProperties": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/typescript/packages/core/src/schemes/escrow/types.ts
+++ b/typescript/packages/core/src/schemes/escrow/types.ts
@@ -98,8 +98,13 @@ export interface BosonMetaTx {
   /** Decimal string. */
   nonce: string;
   functionName: string;
-  /** ABI-encoded function args as a `0x`-prefixed hex string. */
-  functionArgs: Hex;
+  /**
+   * ABI-encoded function-call data as a `0x`-prefixed hex string. Named
+   * `functionSignature` to match the on-chain `MetaTransactionsHandlerFacet`
+   * struct field — the value is the encoded calldata, not just the function
+   * selector.
+   */
+  functionSignature: Hex;
   sig: { v: number; r: Hex; s: Hex };
 }
 

--- a/typescript/packages/core/src/schemes/escrow/types.ts
+++ b/typescript/packages/core/src/schemes/escrow/types.ts
@@ -1,0 +1,147 @@
+// Shared wire-format types for the `escrow` scheme.
+// Source of truth: docs/boson-impl-01-escrow-scheme.md.
+
+/**
+ * CAIP-2 network identifier for an EVM chain. Constrained to `eip155:<chainId>`
+ * shape at runtime by the JSON Schema and zod regex; aliased to `string` here
+ * for the same reason as `Address` / `Hex` — the wire format is JSON, where
+ * everything is a string, and template-literal types cause friction with
+ * zod's regex-based validators.
+ */
+export type EvmNetwork = string;
+
+/** BPIP-12 token-authorization strategies. */
+export type TokenAuthStrategy = "none" | "erc3009" | "permit" | "permit2";
+export const TOKEN_AUTH_STRATEGIES: readonly TokenAuthStrategy[] = [
+  "none",
+  "erc3009",
+  "permit",
+  "permit2",
+] as const;
+
+/** Boson commit-time action ids advertised by the server. */
+export type BosonCommitActionId = "boson-createOfferAndCommit" | "boson-createOfferCommitAndRedeem";
+
+/** Channels through which a `nextAction` can be performed. */
+export type ActionChannel = "server" | "facilitator" | "onchain" | "mcp" | "xmtp";
+export const ACTION_CHANNELS: readonly ActionChannel[] = [
+  "server",
+  "facilitator",
+  "onchain",
+  "mcp",
+  "xmtp",
+] as const;
+
+/**
+ * BPIP-10 FullOffer. Treated as opaque at this layer — the on-chain shape lives
+ * in `@bosonprotocol/core-sdk`, and validation against the protocol struct is
+ * the EIP-712 builder's job. Here it's just "an object echoed verbatim".
+ */
+export type FullOffer = Record<string, unknown>;
+
+/**
+ * 0x-prefixed hex string. Aliased to `string` in the wire format so JSON
+ * shapes are easy to construct; runtime validation is handled by the JSON
+ * Schema and zod regex. The strongly-typed `\`0x${string}\`` form is reserved
+ * for the EIP-712 builder layer where viem's brands matter.
+ */
+export type Hex = string;
+/** 0x-prefixed 40-char hex string. See `Hex` for typing rationale. */
+export type Address = string;
+
+/** Off-chain offer reference signed by the seller. */
+export interface BosonOfferRef {
+  fullOffer: FullOffer;
+  sellerSig: Hex;
+  creator: Address;
+}
+
+export interface FulfillmentOption {
+  id: string;
+  /** JSON-Schema-shaped `type: object` description of the data the buyer must supply, or `null` for atomic. */
+  schema: Record<string, unknown> | null;
+}
+
+export interface FulfillmentRequirements {
+  required: boolean;
+  options: FulfillmentOption[];
+}
+
+export interface NextAction {
+  id: string;
+  channels: ActionChannel[];
+  endpoints?: Record<string, string>;
+}
+
+export interface OnchainHints {
+  /** Address of the Boson escrow contract. */
+  escrow: Address;
+  metaTxFacet: string;
+  metaTxEntrypoint: string;
+  actionFacets: Record<string, string>;
+}
+
+export interface ActionsFallback {
+  xmtp?: string;
+  mcp?: string;
+  onchainHints?: OnchainHints;
+}
+
+export interface ActionsEnvelope {
+  next: NextAction[];
+  fallback?: ActionsFallback;
+}
+
+/** Boson protocol meta-transaction envelope (signed by the buyer). */
+export interface BosonMetaTx {
+  from: Address;
+  /** Decimal string. */
+  nonce: string;
+  functionName: string;
+  /** ABI-encoded function args as a `0x`-prefixed hex string. */
+  functionArgs: Hex;
+  sig: { v: number; r: Hex; s: Hex };
+}
+
+export interface Erc3009AuthData {
+  from: Address;
+  to: Address;
+  /** Atomic units, decimal string. */
+  value: string;
+  validAfter: number;
+  validBefore: number;
+  /** 32-byte hex string. */
+  nonce: Hex;
+  v: number;
+  r: Hex;
+  s: Hex;
+}
+
+export interface PermitAuthData {
+  owner: Address;
+  spender: Address;
+  /** Atomic units, decimal string. */
+  value: string;
+  deadline: number;
+  /** Token-internal sequential nonce, decimal string. */
+  nonce: string;
+  v: number;
+  r: Hex;
+  s: Hex;
+}
+
+export interface Permit2AuthData {
+  permitted: { token: Address; amount: string };
+  spender: Address;
+  /** Permit2 word-bitmap nonce, decimal string. */
+  nonce: string;
+  deadline: number;
+  /** Concatenated 65-byte ECDSA signature. */
+  signature: Hex;
+}
+
+/** Discriminated union of all token-authorization payloads. `none` is encoded by the absence of this field on the payload. */
+export type BosonTokenAuth =
+  | { kind: "erc3009"; data: Erc3009AuthData }
+  | { kind: "permit"; data: PermitAuthData }
+  | { kind: "permit2"; data: Permit2AuthData };

--- a/typescript/packages/core/src/schemes/escrow/validators.ts
+++ b/typescript/packages/core/src/schemes/escrow/validators.ts
@@ -1,0 +1,31 @@
+// Shared regex patterns + scalar zod schemas used across the `escrow`
+// scheme's payment-requirements and payment-payload validators. Keeping
+// them in one place ensures the JSON Schema's patterns and the zod regexes
+// stay in sync (see `schemas/*.json` for the JSON Schema source of truth).
+
+import { z } from "zod";
+
+/** 0x-prefixed hex string, at least one nibble. */
+export const HEX = /^0x[a-fA-F0-9]+$/;
+
+/** 0x-prefixed hex string, allowing the empty `0x` form for empty bytes. */
+export const HEX_BYTES = /^0x[a-fA-F0-9]*$/;
+
+/** 0x-prefixed 32-byte (64-nibble) hex string. */
+export const HEX32 = /^0x[a-fA-F0-9]{64}$/;
+
+/** 0x-prefixed 20-byte (40-nibble) hex address. */
+export const ADDRESS = /^0x[a-fA-F0-9]{40}$/;
+
+/** Decimal unsigned integer string, no leading zeros (except "0" itself). */
+export const DECIMAL_UINT = /^(0|[1-9][0-9]*)$/;
+
+/** CAIP-2 EVM network identifier: `eip155:<chainId>`. */
+export const EVM_NETWORK = /^eip155:[1-9][0-9]*$/;
+
+export const addressSchema = z.string().regex(ADDRESS);
+export const hexSchema = z.string().regex(HEX);
+export const hexBytesSchema = z.string().regex(HEX_BYTES);
+export const hex32Schema = z.string().regex(HEX32);
+export const decimalUintSchema = z.string().regex(DECIMAL_UINT);
+export const evmNetworkSchema = z.string().regex(EVM_NETWORK);

--- a/typescript/packages/core/test/schemes/escrow/fixtures.ts
+++ b/typescript/packages/core/test/schemes/escrow/fixtures.ts
@@ -1,0 +1,160 @@
+// Reusable fixtures for the `escrow` scheme tests.
+// Shapes match docs/boson-impl-01-escrow-scheme.md §2 and §3.
+
+import type {
+  EscrowPaymentPayload,
+  EscrowPaymentRequirements,
+} from "../../../src/schemes/escrow/index.js";
+
+export const ESCROW = "0xdddddddddddddddddddddddddddddddddddddddd" as const;
+export const USDC_BASE = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" as const;
+export const SELLER_ASSISTANT = "0x1111111111111111111111111111111111111111" as const;
+export const BUYER = "0x2222222222222222222222222222222222222222" as const;
+
+const HEX64_R = "0x" + "11".repeat(32);
+const HEX64_S = "0x" + "22".repeat(32);
+const HEX64_NONCE = "0x" + "ab".repeat(32);
+const HEX_SIG = "0x" + "cd".repeat(65);
+
+export const validRequirements: EscrowPaymentRequirements = {
+  scheme: "escrow",
+  network: "eip155:8453",
+  asset: USDC_BASE,
+  amount: "1000000",
+  escrowAddress: ESCROW,
+  recipientId: "did:boson:seller:12345",
+  maxTimeoutSeconds: 300,
+  offer: {
+    fullOffer: { id: "0", price: "1000000" },
+    sellerSig: "0xdeadbeef",
+    creator: SELLER_ASSISTANT,
+  },
+  tokenAuthStrategies: ["none", "erc3009", "permit", "permit2"],
+  fulfillment: {
+    required: true,
+    options: [
+      { id: "atomic-http", schema: null },
+      { id: "email", schema: { type: "object", required: ["email"] } },
+    ],
+  },
+  actions: {
+    next: [
+      {
+        id: "boson-createOfferAndCommit",
+        channels: ["server", "facilitator", "onchain"],
+        endpoints: { server: "https://seller.example/x402B/commit" },
+      },
+      {
+        id: "boson-createOfferCommitAndRedeem",
+        channels: ["server", "facilitator", "onchain", "mcp"],
+        endpoints: {
+          server: "https://seller.example/x402B/commit-and-redeem",
+        },
+      },
+    ],
+    fallback: {
+      xmtp: "0xSellerXMTP",
+      mcp: "boson://seller/12345",
+      onchainHints: {
+        escrow: ESCROW,
+        metaTxFacet: "MetaTransactionsHandlerFacet",
+        metaTxEntrypoint: "executeMetaTransactionWithTokenTransferAuthorization",
+        actionFacets: {
+          "boson-createOfferAndCommit": "ExchangeCommitFacet",
+          "boson-createOfferCommitAndRedeem": "OrchestrationHandlerFacet2",
+        },
+      },
+    },
+  },
+};
+
+const baseInner = {
+  action: "boson-createOfferCommitAndRedeem",
+  offerRef: {
+    fullOffer: { id: "0", price: "1000000" },
+    sellerSig: "0xdeadbeef" as const,
+  },
+  buyer: BUYER,
+  metaTx: {
+    from: BUYER,
+    nonce: "0",
+    functionName: "createOfferCommitAndRedeem(...)",
+    functionArgs: "0xabcd1234",
+    sig: { v: 27, r: HEX64_R, s: HEX64_S },
+  },
+} as const;
+
+export const validPayloadNone: EscrowPaymentPayload = {
+  x402Version: 2,
+  scheme: "escrow",
+  network: "eip155:8453",
+  payload: { ...baseInner, tokenAuthStrategy: "none" },
+};
+
+export const validPayloadErc3009: EscrowPaymentPayload = {
+  x402Version: 2,
+  scheme: "escrow",
+  network: "eip155:8453",
+  payload: {
+    ...baseInner,
+    tokenAuthStrategy: "erc3009",
+    tokenAuth: {
+      kind: "erc3009",
+      data: {
+        from: BUYER,
+        to: ESCROW,
+        value: "1000000",
+        validAfter: 0,
+        validBefore: 1_900_000_000,
+        nonce: HEX64_NONCE,
+        v: 27,
+        r: HEX64_R,
+        s: HEX64_S,
+      },
+    },
+  },
+  fulfillment: { option: "email", data: { email: "buyer@example.com" } },
+};
+
+export const validPayloadPermit: EscrowPaymentPayload = {
+  x402Version: 2,
+  scheme: "escrow",
+  network: "eip155:8453",
+  payload: {
+    ...baseInner,
+    tokenAuthStrategy: "permit",
+    tokenAuth: {
+      kind: "permit",
+      data: {
+        owner: BUYER,
+        spender: ESCROW,
+        value: "1000000",
+        deadline: 1_900_000_000,
+        nonce: "0",
+        v: 27,
+        r: HEX64_R,
+        s: HEX64_S,
+      },
+    },
+  },
+};
+
+export const validPayloadPermit2: EscrowPaymentPayload = {
+  x402Version: 2,
+  scheme: "escrow",
+  network: "eip155:8453",
+  payload: {
+    ...baseInner,
+    tokenAuthStrategy: "permit2",
+    tokenAuth: {
+      kind: "permit2",
+      data: {
+        permitted: { token: USDC_BASE, amount: "1000000" },
+        spender: ESCROW,
+        nonce: "0",
+        deadline: 1_900_000_000,
+        signature: HEX_SIG,
+      },
+    },
+  },
+};

--- a/typescript/packages/core/test/schemes/escrow/fixtures.ts
+++ b/typescript/packages/core/test/schemes/escrow/fixtures.ts
@@ -79,7 +79,7 @@ const baseInner = {
     from: BUYER,
     nonce: "0",
     functionName: "createOfferCommitAndRedeem(...)",
-    functionArgs: "0xabcd1234",
+    functionSignature: "0xabcd1234",
     sig: { v: 27, r: HEX64_R, s: HEX64_S },
   },
 } as const;

--- a/typescript/packages/core/test/schemes/escrow/payment-payload.test.ts
+++ b/typescript/packages/core/test/schemes/escrow/payment-payload.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+import Ajv, { type ValidateFunction } from "ajv";
+import { describe, expect, it } from "vitest";
+
+import {
+  escrowPaymentPayloadSchema,
+  parseEscrowPaymentPayload,
+} from "../../../src/schemes/escrow/index.js";
+import {
+  validPayloadErc3009,
+  validPayloadNone,
+  validPayloadPermit,
+  validPayloadPermit2,
+} from "./fixtures.js";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const schemaPath = join(
+  here,
+  "..",
+  "..",
+  "..",
+  "src",
+  "schemes",
+  "escrow",
+  "schemas",
+  "payment_payload.schema.json",
+);
+const jsonSchema = JSON.parse(readFileSync(schemaPath, "utf8"));
+const ajv = new Ajv({ allErrors: true, strict: false });
+const ajvValidate: ValidateFunction = ajv.compile(jsonSchema);
+
+const fixtures = {
+  none: validPayloadNone,
+  erc3009: validPayloadErc3009,
+  permit: validPayloadPermit,
+  permit2: validPayloadPermit2,
+} as const;
+
+describe("EscrowPaymentPayload — happy path", () => {
+  for (const [strategy, fixture] of Object.entries(fixtures)) {
+    it(`zod and ajv both accept the ${strategy} fixture`, () => {
+      expect(() => parseEscrowPaymentPayload(fixture)).not.toThrow();
+      const ok = ajvValidate(fixture);
+      expect(ajvValidate.errors ?? null).toBeNull();
+      expect(ok).toBe(true);
+    });
+  }
+});
+
+describe("EscrowPaymentPayload — rejection cases", () => {
+  it("rejects wrong scheme literal", () => {
+    const bad = JSON.parse(JSON.stringify(validPayloadErc3009));
+    bad.scheme = "exact";
+    expect(escrowPaymentPayloadSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects mismatched discriminator (kind=permit but erc3009-shaped data)", () => {
+    const bad = JSON.parse(JSON.stringify(validPayloadErc3009));
+    bad.payload.tokenAuth.kind = "permit";
+    expect(escrowPaymentPayloadSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects metaTx.sig.r that is not 32 bytes", () => {
+    const bad = JSON.parse(JSON.stringify(validPayloadNone));
+    bad.payload.metaTx.sig.r = "0xabcd";
+    const zod = escrowPaymentPayloadSchema.safeParse(bad);
+    expect(zod.success).toBe(false);
+    if (!zod.success) {
+      const path = zod.error.issues[0]?.path.join(".") ?? "";
+      expect(path).toContain("metaTx");
+    }
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects unknown tokenAuthStrategy", () => {
+    const bad = JSON.parse(JSON.stringify(validPayloadErc3009));
+    bad.payload.tokenAuthStrategy = "uniswap-v4";
+    expect(escrowPaymentPayloadSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects extra unknown field on the payload", () => {
+    const bad = JSON.parse(JSON.stringify(validPayloadNone));
+    bad.payload.extra = "nope";
+    expect(escrowPaymentPayloadSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects negative validBefore in erc3009", () => {
+    const bad = JSON.parse(JSON.stringify(validPayloadErc3009));
+    bad.payload.tokenAuth.data.validBefore = -1;
+    expect(escrowPaymentPayloadSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+});

--- a/typescript/packages/core/test/schemes/escrow/payment-requirements.test.ts
+++ b/typescript/packages/core/test/schemes/escrow/payment-requirements.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+import Ajv, { type ValidateFunction } from "ajv";
+import { describe, expect, it } from "vitest";
+
+import {
+  escrowPaymentRequirementsSchema,
+  parseEscrowPaymentRequirements,
+} from "../../../src/schemes/escrow/index.js";
+import { validRequirements } from "./fixtures.js";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const schemaPath = join(
+  here,
+  "..",
+  "..",
+  "..",
+  "src",
+  "schemes",
+  "escrow",
+  "schemas",
+  "payment_requirements.schema.json",
+);
+const jsonSchema = JSON.parse(readFileSync(schemaPath, "utf8"));
+const ajv = new Ajv({ allErrors: true, strict: false });
+const ajvValidate: ValidateFunction = ajv.compile(jsonSchema);
+
+const cloneFixture = (): typeof validRequirements => JSON.parse(JSON.stringify(validRequirements));
+
+describe("EscrowPaymentRequirements — happy path", () => {
+  it("zod accepts the canonical fixture", () => {
+    expect(() => parseEscrowPaymentRequirements(validRequirements)).not.toThrow();
+  });
+
+  it("ajv accepts the canonical fixture", () => {
+    const ok = ajvValidate(validRequirements);
+    expect(ajvValidate.errors ?? null).toBeNull();
+    expect(ok).toBe(true);
+  });
+
+  it("zod and ajv agree on the canonical fixture", () => {
+    const zodOk = escrowPaymentRequirementsSchema.safeParse(validRequirements).success;
+    const ajvOk = ajvValidate(validRequirements);
+    expect(zodOk).toBe(ajvOk);
+  });
+});
+
+describe("EscrowPaymentRequirements — rejection cases", () => {
+  it("rejects wrong scheme", () => {
+    const bad = cloneFixture() as unknown as Record<string, unknown>;
+    bad.scheme = "exact";
+    expect(escrowPaymentRequirementsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects non-EVM network", () => {
+    const bad = cloneFixture() as unknown as Record<string, unknown>;
+    bad.network = "solana:mainnet";
+    expect(escrowPaymentRequirementsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects missing offer", () => {
+    const bad = cloneFixture() as unknown as Record<string, unknown>;
+    delete bad.offer;
+    const zod = escrowPaymentRequirementsSchema.safeParse(bad);
+    expect(zod.success).toBe(false);
+    if (!zod.success) {
+      expect(zod.error.issues.some((i) => i.path.includes("offer"))).toBe(true);
+    }
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects empty tokenAuthStrategies", () => {
+    const bad = cloneFixture();
+    bad.tokenAuthStrategies = [];
+    expect(escrowPaymentRequirementsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects malformed escrowAddress", () => {
+    const bad = cloneFixture() as unknown as Record<string, unknown>;
+    bad.escrowAddress = "not-an-address";
+    expect(escrowPaymentRequirementsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects amount with leading zeros", () => {
+    const bad = cloneFixture();
+    bad.amount = "01000";
+    expect(escrowPaymentRequirementsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects unknown top-level field", () => {
+    const bad = cloneFixture() as unknown as Record<string, unknown>;
+    bad.surprise = "extra";
+    expect(escrowPaymentRequirementsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects empty actions.next", () => {
+    const bad = cloneFixture();
+    bad.actions.next = [];
+    expect(escrowPaymentRequirementsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+});

--- a/typescript/packages/core/tsup.config.ts
+++ b/typescript/packages/core/tsup.config.ts
@@ -1,12 +1,17 @@
 import { defineConfig } from "tsup";
 
 // Dual CJS + ESM build with type declarations.
-// JSON schemas under src/**/schemas/*.json are copied to dist/schemas/ so
-// consumers can resolve them via `@bosonprotocol/x402-core/schemas/<name>.json`
-// once schemas are added (PR 3).
+//
+// `entry` globs every `index.ts` under `src/` so any subpath under
+// `src/<subdir>/index.ts` builds as `@bosonprotocol/x402-core/<subdir>`
+// without further config changes. JSON schemas under
+// `src/**/schemas/*.json` are copied flat into `dist/schemas/` by the
+// `postbuild` step chained from package.json's `build` script.
+const entry = ["src/index.ts", "src/**/index.ts"];
+
 export default defineConfig([
   {
-    entry: ["src/index.ts"],
+    entry,
     format: "esm",
     outDir: "dist/esm",
     outExtension: () => ({ js: ".js" }),
@@ -17,7 +22,7 @@ export default defineConfig([
     treeshake: true,
   },
   {
-    entry: ["src/index.ts"],
+    entry,
     format: "cjs",
     outDir: "dist/cjs",
     outExtension: () => ({ js: ".js" }),

--- a/typescript/packages/core/tsup.config.ts
+++ b/typescript/packages/core/tsup.config.ts
@@ -2,12 +2,13 @@ import { defineConfig } from "tsup";
 
 // Dual CJS + ESM build with type declarations.
 //
-// `entry` globs every `index.ts` under `src/` so any subpath under
-// `src/<subdir>/index.ts` builds as `@bosonprotocol/x402-core/<subdir>`
-// without further config changes. JSON schemas under
-// `src/**/schemas/*.json` are copied flat into `dist/schemas/` by the
-// `postbuild` step chained from package.json's `build` script.
-const entry = ["src/index.ts", "src/**/index.ts"];
+// `entry` globs every `index.ts` under `src/`, including the root
+// `src/index.ts`, so any subpath under `src/<subdir>/index.ts` builds as
+// `@bosonprotocol/x402-core/<subdir>` without further config changes. JSON
+// schemas under `src/**/schemas/*.json` are copied flat into
+// `dist/schemas/` by the `postbuild` step chained from package.json's
+// `build` script.
+const entry = ["src/**/index.ts"];
 
 export default defineConfig([
   {


### PR DESCRIPTION
## Summary

Implements the wire-format primitives for the `escrow` scheme on `@bosonprotocol/x402-core`, per [docs/boson-impl-01-escrow-scheme.md](./docs/boson-impl-01-escrow-scheme.md). Adds two new public exports — `./schemes/escrow` and `./schemas/*` — backed by hand-written TypeScript types, paired zod validators, and JSON Schema (draft-07) source-of-truth files.

### Public surface (new `./schemes/escrow`)

- `EscrowPaymentRequirements` + `escrowPaymentRequirementsSchema` + `parseEscrowPaymentRequirements` — server→client (402 body)
- `EscrowPaymentPayload` + `escrowPaymentPayloadSchema` + `parseEscrowPaymentPayload` — client→server (`X-PAYMENT` header)
- Shared types: `TokenAuthStrategy`, `BosonCommitActionId`, `ActionChannel`, `BosonOfferRef`, `BosonMetaTx`, `BosonTokenAuth` (`erc3009` / `permit` / `permit2` discriminated union), `ActionsEnvelope`, `FulfillmentRequirements`
- `ESCROW_SCHEME` constant

### Public surface (new `./schemas/*`)

`@bosonprotocol/x402-core/schemas/payment_requirements.schema.json` and `/schemas/payment_payload.schema.json` — JSON Schemas (draft-07) shipped as static assets in the published tarball.

### Design notes

- **Wire-format types use plain `string`** for `Hex` / `Address` / `EvmNetwork`, documented inline. Branded ``\`0x${string}\``` would collide with zod's regex-based validators without buying anything at this layer; viem's brands belong at the EIP-712 builder layer.
- **Cross-field validation** (e.g. "`tokenAuth` must be omitted iff `tokenAuthStrategy === 'none'`", amount-equals checks) is the server's job per [§5 of the spec](./docs/boson-impl-01-escrow-scheme.md). The JSON Schema and zod here only validate structural shape.

### Build / infra deltas

- `tsup.config.ts`: `entry` now globs `src/**/index.ts` so any subpath builds without further config changes.
- `scripts/postbuild.mjs`: copies JSON schemas into `dist/schemas/` flat, and writes `dist/{esm,cjs}/package.json` module-type markers. The markers eliminate Node's `MODULE_TYPELESS_PACKAGE_JSON` warning that fired for ESM consumers.
- `turbo.json`: `scripts/**` added to the `build` task inputs so postbuild changes invalidate the cache.
- `package.json`: `./schemes/escrow` + `./schemas/*` exports, `ajv@^8` devDep for the JSON-Schema-side tests, `build` script now chains `tsup` with the postbuild step.

### Test plan

- [x] 21 vitest cases pass — each fixture validated by **both** zod and ajv; rejection cases similarly checked against both engines
- [x] Fixtures cover all four token-auth strategies (`none`, `erc3009`, `permit`, `permit2`)
- [x] `pnpm build` clean (ESM + CJS + `.d.ts` for root and `schemes/escrow`, schemas in `dist/schemas/`, module-type markers in `dist/{esm,cjs}/package.json`)
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] `pnpm publish --dry-run --filter @bosonprotocol/x402-core` packs 17 files at 16.0 kB; tarball includes both schemas and module-type markers
- [x] Node smoke: `require("@bosonprotocol/x402-core/schemes/escrow")` and `import("@bosonprotocol/x402-core/schemes/escrow")` both resolve; `require("@bosonprotocol/x402-core/schemas/payment_requirements.schema.json")` returns a JSON object — no module-type warnings
- [x] CI green on Node 22 + 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)