### PR TITLE
Add eip712 builders for FullOffer and MetaTransaction

### DIFF
--- a/docs/boson-impl-01-escrow-scheme.md
+++ b/docs/boson-impl-01-escrow-scheme.md
@@ -203,7 +203,7 @@ The header value is base64(JSON):
 ### 4.1 Seller — `FullOffer` (protocol EIP-712 domain)
 
 ```
-domain:  { name: "Boson Protocol", version: "V2", chainId, verifyingContract: <Diamond> }
+domain:  { name: "Boson Protocol", version: "V2", salt: bytes32(chainId), verifyingContract: <Diamond> }
 type:    FullOffer(
            Offer offer,
            OfferDates offerDates,

--- a/docs/boson-impl-01-escrow-scheme.md
+++ b/docs/boson-impl-01-escrow-scheme.md
@@ -203,7 +203,7 @@ The header value is base64(JSON):
 ### 4.1 Seller — `FullOffer` (protocol EIP-712 domain)
 
 ```
-domain:  { name: "BosonProtocol", version: "V2", chainId, verifyingContract: <Diamond> }
+domain:  { name: "Boson Protocol", version: "V2", chainId, verifyingContract: <Diamond> }
 type:    FullOffer(
            Offer offer,
            OfferDates offerDates,
@@ -223,7 +223,7 @@ Nested structs `Offer`, `OfferDates`, `OfferDurations`, `DRParameters`, `Conditi
 The buyer signs **one** EIP-712 meta-tx authorising execution of `<action>` on the protocol Diamond. This is the only Boson-side signature required regardless of which token-auth strategy the buyer picks.
 
 ```
-domain:  { name: "BosonProtocol", version: "V2", chainId, verifyingContract: <Diamond> }
+domain:  { name: "Boson Protocol", version: "V2", chainId, verifyingContract: <Diamond> }
 type:    MetaTransaction(
            uint256 nonce,
            address from,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,10 +70,6 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
 
-  typescript/packages/core/dist/cjs: {}
-
-  typescript/packages/core/dist/esm: {}
-
 packages:
 
   '@adraffy/ens-normalize@1.10.1':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.10
-        version: 2.31.0(@types/node@20.19.40)
+        version: 2.31.0(@types/node@22.7.5)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.18.0
         version: 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
@@ -34,13 +34,22 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@20.19.40)
+        version: 2.1.9(@types/node@22.7.5)
 
   typescript/packages/core:
     dependencies:
+      '@bosonprotocol/common':
+        specifier: ^1.32.2
+        version: 1.32.2
+      '@bosonprotocol/core-sdk':
+        specifier: 1.46.1
+        version: 1.46.1
       '@x402/core':
         specifier: ^2.11.0
         version: 2.11.0
+      lodash:
+        specifier: ^4.18.1
+        version: 4.18.1
       viem:
         specifier: ^2.39.3
         version: 2.48.11(typescript@5.9.3)(zod@3.25.76)
@@ -61,7 +70,14 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
 
+  typescript/packages/core/dist/cjs: {}
+
+  typescript/packages/core/dist/esm: {}
+
 packages:
+
+  '@adraffy/ens-normalize@1.10.1':
+    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
@@ -69,6 +85,18 @@ packages:
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
+
+  '@bosonprotocol/common@1.32.2':
+    resolution: {integrity: sha512-SXaUvMIEHT1yGxcTNlbxoWzyPUqoacrKSIYXpIUJVVOU/5uLYrojULx2htZlqF5OKl6XDxXHSPLyjUxuIEe5lg==}
+
+  '@bosonprotocol/core-sdk@1.46.1':
+    resolution: {integrity: sha512-T8DlfmWJNrD5vAosvjoZcvEiRWRj81NQRGQtStpEOAVHycsbHAO3zuiHK8Csz4yYeitzHZKMauLUP58Xef3p1g==}
+
+  '@bosonprotocol/metadata-storage@1.0.1':
+    resolution: {integrity: sha512-f2W2SQAvY5IKD6L9JwaiNye7gGRIIPd/HOB0i+otWLzMPBlwQtbN4JeWSuKeJvuaqu8tyMy7CHzN8EkhrJDB+A==}
+
+  '@bosonprotocol/metadata@1.16.3':
+    resolution: {integrity: sha512-9SDhtoq2DwrRiGvT4MDfHO9rU6iNE961rldbwbVAXOjwqGa/wpKiASE37Ip68hr5GZ/Da07Db4OqQsYDHuz3Rw==}
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -457,6 +485,63 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@ethersproject/abi@5.8.0':
+    resolution: {integrity: sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==}
+
+  '@ethersproject/abstract-provider@5.8.0':
+    resolution: {integrity: sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==}
+
+  '@ethersproject/abstract-signer@5.8.0':
+    resolution: {integrity: sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==}
+
+  '@ethersproject/address@5.8.0':
+    resolution: {integrity: sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==}
+
+  '@ethersproject/base64@5.8.0':
+    resolution: {integrity: sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==}
+
+  '@ethersproject/bignumber@5.8.0':
+    resolution: {integrity: sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==}
+
+  '@ethersproject/bytes@5.8.0':
+    resolution: {integrity: sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==}
+
+  '@ethersproject/constants@5.8.0':
+    resolution: {integrity: sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==}
+
+  '@ethersproject/hash@5.8.0':
+    resolution: {integrity: sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==}
+
+  '@ethersproject/keccak256@5.8.0':
+    resolution: {integrity: sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==}
+
+  '@ethersproject/logger@5.8.0':
+    resolution: {integrity: sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==}
+
+  '@ethersproject/networks@5.8.0':
+    resolution: {integrity: sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==}
+
+  '@ethersproject/properties@5.8.0':
+    resolution: {integrity: sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==}
+
+  '@ethersproject/rlp@5.8.0':
+    resolution: {integrity: sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==}
+
+  '@ethersproject/signing-key@5.8.0':
+    resolution: {integrity: sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==}
+
+  '@ethersproject/strings@5.8.0':
+    resolution: {integrity: sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==}
+
+  '@ethersproject/transactions@5.8.0':
+    resolution: {integrity: sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==}
+
+  '@ethersproject/units@5.8.0':
+    resolution: {integrity: sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==}
+
+  '@ethersproject/web@5.8.0':
+    resolution: {integrity: sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -509,9 +594,16 @@ packages:
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.9.1':
     resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -528,6 +620,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opensea/seaport-js@4.1.2':
+    resolution: {integrity: sha512-UFJ5f/4gqQEvRjjOJJhammWkOeOaXz8trxhquhzcbcqCNScR4+4MSLiSiBA5G7U89F8wN68B3F6AL5XUQTXYcg==}
+    engines: {node: '>=20.0.0'}
 
   '@rollup/rollup-android-arm-eabi@4.60.3':
     resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
@@ -708,6 +804,9 @@ packages:
   '@types/node@20.19.40':
     resolution: {integrity: sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==}
 
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+
   '@typescript-eslint/eslint-plugin@8.59.2':
     resolution: {integrity: sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -820,6 +919,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -852,6 +954,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -862,6 +967,12 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
+  bn.js@5.2.3:
+    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -874,6 +985,12 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  brorand@1.1.0:
+    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
+
+  buffer-reverse@1.0.1:
+    resolution: {integrity: sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==}
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -884,9 +1001,17 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  camelcase@4.1.0:
+    resolution: {integrity: sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==}
+    engines: {node: '>=4'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -914,6 +1039,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -928,9 +1057,19 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+
+  dashify@2.0.0:
+    resolution: {integrity: sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==}
+    engines: {node: '>=4'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -948,6 +1087,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -956,12 +1099,35 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
+
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -1031,6 +1197,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
+    engines: {node: '>=14.0.0'}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -1040,6 +1210,10 @@ packages:
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
+  extract-files@9.0.0:
+    resolution: {integrity: sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==}
+    engines: {node: ^10.17.0 || ^12.0.0 || >= 13.7.0}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1092,6 +1266,10 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  form-data@3.0.4:
+    resolution: {integrity: sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==}
+    engines: {node: '>= 6'}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -1104,6 +1282,17 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1121,12 +1310,43 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphql-request@4.3.0:
+    resolution: {integrity: sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==}
+    peerDependencies:
+      graphql: 14 - 16
+
+  graphql@16.14.0:
+    resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hmac-drbg@1.0.1:
+    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -1151,6 +1371,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1183,6 +1406,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-sha3@0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
@@ -1236,19 +1462,44 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  merkletreejs@0.6.0:
+    resolution: {integrity: sha512-cyiratjG7fyHsa4DVfYVPxcoAh3zmUuOPItIfZex8f0pUVptNEmiiTOoeS0JnDDTWy+n3FKnI0K1gCzti7rGMg==}
+    engines: {node: '>= 7.6.0'}
+
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
+  minimalistic-crypto-utils@1.0.1:
+    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1267,6 +1518,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -1278,9 +1533,23 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  opensea-js@7.4.0:
+    resolution: {integrity: sha512-jHg84OO6Rt1OEOQjQk0b+KoDktWtTsZIpi6p09xRzKupWlAlCO8D3qMqKjNDYQaIbstJNi6z1DQAqx+wzxvfIw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: This package has been renamed to @opensea/sdk. Install @opensea/sdk instead.
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1412,6 +1681,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  property-expr@2.0.6:
+    resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1452,6 +1724,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  schema-to-yup@1.12.18:
+    resolution: {integrity: sha512-rzMtnIQpkokOzyb6JfsuCB+/BklFB5J7pFcvc/SnybOtmks8uW4SJXfMpzMQT98f826XgI3/mlPGQf0HBhF8FQ==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1529,6 +1804,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-case@1.0.3:
+    resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1555,9 +1833,19 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toposort@2.0.2:
+    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+
+  treeify@1.1.0:
+    resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
+    engines: {node: '>=0.6'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -1567,6 +1855,9 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
   tsup@8.5.1:
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
@@ -1595,6 +1886,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1603,12 +1898,22 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  uniq@1.0.1:
+    resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  uppercamelcase@3.0.0:
+    resolution: {integrity: sha512-zTWmRiOJACCdFGWjzye3L5cjSuVdZ/c8C0iHIwVbfORFD8IhGNAO6BOWkZ+fj+SI6/aFbdjGXE6gwPG780H4gQ==}
+    engines: {node: '>=4'}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1682,6 +1987,12 @@ packages:
       jsdom:
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1695,6 +2006,18 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -1712,14 +2035,56 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  yup@1.7.1:
+    resolution: {integrity: sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==}
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
+  '@adraffy/ens-normalize@1.10.1': {}
+
   '@adraffy/ens-normalize@1.11.1': {}
 
   '@babel/runtime@7.29.2': {}
+
+  '@bosonprotocol/common@1.32.2':
+    dependencies:
+      '@bosonprotocol/metadata': 1.16.3
+      '@ethersproject/abi': 5.8.0
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/units': 5.8.0
+
+  '@bosonprotocol/core-sdk@1.46.1':
+    dependencies:
+      '@bosonprotocol/common': 1.32.2
+      '@ethersproject/abi': 5.8.0
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/units': 5.8.0
+      cross-fetch: 3.2.0
+      graphql: 16.14.0
+      graphql-request: 4.3.0(graphql@16.14.0)
+      mustache: 4.2.0
+      opensea-js: 7.4.0
+      schema-to-yup: 1.12.18
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@bosonprotocol/metadata-storage@1.0.1': {}
+
+  '@bosonprotocol/metadata@1.16.3':
+    dependencies:
+      '@bosonprotocol/metadata-storage': 1.0.1
+      schema-to-yup: 1.12.18
+      yup: 1.7.1
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -1750,7 +2115,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.31.0(@types/node@20.19.40)':
+  '@changesets/cli@2.31.0(@types/node@22.7.5)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -1766,7 +2131,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@20.19.40)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.7.5)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -2057,6 +2422,135 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@ethersproject/abi@5.8.0':
+    dependencies:
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/hash': 5.8.0
+      '@ethersproject/keccak256': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/strings': 5.8.0
+
+  '@ethersproject/abstract-provider@5.8.0':
+    dependencies:
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/networks': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/transactions': 5.8.0
+      '@ethersproject/web': 5.8.0
+
+  '@ethersproject/abstract-signer@5.8.0':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/properties': 5.8.0
+
+  '@ethersproject/address@5.8.0':
+    dependencies:
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/keccak256': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/rlp': 5.8.0
+
+  '@ethersproject/base64@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+
+  '@ethersproject/bignumber@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      bn.js: 5.2.3
+
+  '@ethersproject/bytes@5.8.0':
+    dependencies:
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/constants@5.8.0':
+    dependencies:
+      '@ethersproject/bignumber': 5.8.0
+
+  '@ethersproject/hash@5.8.0':
+    dependencies:
+      '@ethersproject/abstract-signer': 5.8.0
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/base64': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/keccak256': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/strings': 5.8.0
+
+  '@ethersproject/keccak256@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      js-sha3: 0.8.0
+
+  '@ethersproject/logger@5.8.0': {}
+
+  '@ethersproject/networks@5.8.0':
+    dependencies:
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/properties@5.8.0':
+    dependencies:
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/rlp@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/signing-key@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      bn.js: 5.2.3
+      elliptic: 6.6.1
+      hash.js: 1.1.7
+
+  '@ethersproject/strings@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/transactions@5.8.0':
+    dependencies:
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/keccak256': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/rlp': 5.8.0
+      '@ethersproject/signing-key': 5.8.0
+
+  '@ethersproject/units@5.8.0':
+    dependencies:
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/web@5.8.0':
+    dependencies:
+      '@ethersproject/base64': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/logger': 5.8.0
+      '@ethersproject/properties': 5.8.0
+      '@ethersproject/strings': 5.8.0
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -2073,12 +2567,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/external-editor@1.0.3(@types/node@20.19.40)':
+  '@inquirer/external-editor@1.0.3(@types/node@22.7.5)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 20.19.40
+      '@types/node': 22.7.5
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2112,9 +2606,15 @@ snapshots:
 
   '@noble/ciphers@1.3.0': {}
 
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
   '@noble/curves@1.9.1':
     dependencies:
       '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.8.0': {}
 
@@ -2129,6 +2629,14 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@opensea/seaport-js@4.1.2':
+    dependencies:
+      ethers: 6.16.0
+      merkletreejs: 0.6.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@rollup/rollup-android-arm-eabi@4.60.3':
     optional: true
@@ -2248,6 +2756,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
+
   '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -2354,6 +2866,14 @@ snapshots:
     optionalDependencies:
       vite: 5.4.21(@types/node@20.19.40)
 
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.7.5))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.7.5)
+
   '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
@@ -2394,6 +2914,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  aes-js@4.0.0-beta.5: {}
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -2421,6 +2943,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -2428,6 +2952,10 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bn.js@4.12.3: {}
+
+  bn.js@5.2.3: {}
 
   brace-expansion@1.1.14:
     dependencies:
@@ -2442,6 +2970,10 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  brorand@1.1.0: {}
+
+  buffer-reverse@1.0.1: {}
+
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
       esbuild: 0.27.7
@@ -2449,7 +2981,14 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   callsites@3.1.0: {}
+
+  camelcase@4.1.0: {}
 
   chai@5.3.3:
     dependencies:
@@ -2478,6 +3017,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@4.1.1: {}
 
   concat-map@0.0.1: {}
@@ -2486,11 +3029,21 @@ snapshots:
 
   consola@3.4.2: {}
 
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crypto-js@4.2.0: {}
+
+  dashify@2.0.0: {}
 
   debug@4.4.3:
     dependencies:
@@ -2500,18 +3053,51 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
   detect-indent@6.1.0: {}
 
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  elliptic@6.6.1:
+    dependencies:
+      bn.js: 4.12.3
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+
   enquirer@2.4.1:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -2644,11 +3230,26 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  ethers@6.16.0:
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   eventemitter3@5.0.1: {}
 
   expect-type@1.3.0: {}
 
   extendable-error@0.1.7: {}
+
+  extract-files@9.0.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -2703,6 +3304,14 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  form-data@3.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -2717,6 +3326,26 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   glob-parent@5.1.2:
     dependencies:
@@ -2737,9 +3366,43 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
+  graphql-request@4.3.0(graphql@16.14.0):
+    dependencies:
+      cross-fetch: 3.2.0
+      extract-files: 9.0.0
+      form-data: 3.0.4
+      graphql: 16.14.0
+    transitivePeerDependencies:
+      - encoding
+
+  graphql@16.14.0: {}
+
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hmac-drbg@1.0.1:
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
 
   human-id@4.1.3: {}
 
@@ -2757,6 +3420,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   is-extglob@2.1.1: {}
 
@@ -2779,6 +3444,8 @@ snapshots:
       ws: 8.18.3
 
   joycon@3.1.1: {}
+
+  js-sha3@0.8.0: {}
 
   js-yaml@3.14.2:
     dependencies:
@@ -2826,18 +3493,38 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  lodash@4.18.1: {}
+
   loupe@3.2.1: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
   merge2@1.4.1: {}
+
+  merkletreejs@0.6.0:
+    dependencies:
+      buffer-reverse: 1.0.1
+      crypto-js: 4.2.0
+      treeify: 1.1.0
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  minimalistic-assert@1.0.1: {}
+
+  minimalistic-crypto-utils@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -2858,6 +3545,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mustache@4.2.0: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -2868,7 +3557,19 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   object-assign@4.1.1: {}
+
+  opensea-js@7.4.0:
+    dependencies:
+      '@opensea/seaport-js': 4.1.2
+      ethers: 6.16.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   optionator@0.9.4:
     dependencies:
@@ -2974,6 +3675,8 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  property-expr@2.0.6: {}
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
@@ -3031,6 +3734,13 @@ snapshots:
       queue-microtask: 1.2.3
 
   safer-buffer@2.1.2: {}
+
+  schema-to-yup@1.12.18:
+    dependencies:
+      dashify: 2.0.0
+      uniq: 1.0.1
+      uppercamelcase: 3.0.0
+      yup: 1.7.1
 
   semver@7.7.4: {}
 
@@ -3093,6 +3803,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-case@1.0.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -3112,13 +3824,21 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toposort@2.0.2: {}
+
+  tr46@0.0.3: {}
+
   tree-kill@1.2.2: {}
+
+  treeify@1.1.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
 
   ts-interface-checker@0.1.13: {}
+
+  tslib@2.7.0: {}
 
   tsup@8.5.1(postcss@8.5.14)(typescript@5.9.3):
     dependencies:
@@ -3161,13 +3881,23 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@2.19.0: {}
+
   typescript@5.9.3: {}
 
   ufo@1.6.4: {}
 
+  undici-types@6.19.8: {}
+
   undici-types@6.21.0: {}
 
+  uniq@1.0.1: {}
+
   universalify@0.1.2: {}
+
+  uppercamelcase@3.0.0:
+    dependencies:
+      camelcase: 4.1.0
 
   uri-js@4.4.1:
     dependencies:
@@ -3208,6 +3938,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.9(@types/node@22.7.5):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.7.5)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.21(@types/node@20.19.40):
     dependencies:
       esbuild: 0.21.5
@@ -3215,6 +3963,15 @@ snapshots:
       rollup: 4.60.3
     optionalDependencies:
       '@types/node': 20.19.40
+      fsevents: 2.3.3
+
+  vite@5.4.21(@types/node@22.7.5):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.14
+      rollup: 4.60.3
+    optionalDependencies:
+      '@types/node': 22.7.5
       fsevents: 2.3.3
 
   vitest@2.1.9(@types/node@20.19.40):
@@ -3252,6 +4009,48 @@ snapshots:
       - supports-color
       - terser
 
+  vitest@2.1.9(@types/node@22.7.5):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.7.5))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.7.5)
+      vite-node: 2.1.9(@types/node@22.7.5)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.7.5
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -3263,8 +4062,17 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  ws@8.17.1: {}
+
   ws@8.18.3: {}
 
   yocto-queue@0.1.0: {}
+
+  yup@1.7.1:
+    dependencies:
+      property-expr: 2.0.6
+      tiny-case: 1.0.3
+      toposort: 2.0.2
+      type-fest: 2.19.0
 
   zod@3.25.76: {}

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -28,6 +28,11 @@
       "types": "./dist/cjs/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
+    },
+    "./eip712": {
+      "types": "./dist/cjs/eip712/index.d.ts",
+      "import": "./dist/esm/eip712/index.js",
+      "require": "./dist/cjs/eip712/index.js"
     }
   },
   "files": [
@@ -45,7 +50,10 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
+    "@bosonprotocol/common": "^1.32.2",
+    "@bosonprotocol/core-sdk": "1.46.1",
     "@x402/core": "^2.11.0",
+    "lodash": "^4.18.1",
     "viem": "^2.39.3",
     "zod": "^3.24.2"
   },

--- a/typescript/packages/core/src/eip712/full-offer.ts
+++ b/typescript/packages/core/src/eip712/full-offer.ts
@@ -1,0 +1,124 @@
+// EIP-712 typed-data builder for the BPIP-10 FullOffer signed by the seller.
+//
+// FullOffer's nested struct shape (Offer / OfferDates / OfferDurations /
+// DRParameters / Condition / RoyaltyInfo) is large and protocol-internal — it
+// can change as the contracts evolve. Rather than hand-mirroring it here,
+// this module wraps `@bosonprotocol/core-sdk@1.46.1`'s
+// `exchanges.handler.signFullOffer({..., returnTypedDataToSign: true})` and
+// re-exposes the typed-data through a viem-friendly hash + recover API.
+//
+// In `returnTypedDataToSign: true` mode, core-sdk's `prepareDataSignatureParameters`
+// returns the StructuredData immediately and never invokes any method on
+// `web3Lib`. We therefore pass a stub adapter whose methods all throw if
+// called — making any future use of web3Lib loud rather than silent.
+//
+// The result hashes against the same Boson EIP-712 domain that
+// `verifyOffer` uses on-chain (salt-based, "Boson Protocol" name) — the
+// shape comes straight from core-sdk so we don't redefine it here.
+
+import { exchanges } from "@bosonprotocol/core-sdk";
+import type { FullOfferArgs, Web3LibAdapter } from "@bosonprotocol/common";
+import { hashTypedData, recoverTypedDataAddress, type Address, type Hex } from "viem";
+
+/** Unsigned FullOffer payload — same shape core-sdk accepts. */
+export type UnsignedFullOffer = Omit<FullOfferArgs, "signature">;
+
+/** A single EIP-712 type field — a `{ name, type }` pair. */
+export type TypedDataField = { name: string; type: string };
+
+/**
+ * EIP-712 typed-data ready for any viem signer. Uses a deliberately-loose
+ * `types` shape (not viem's `TypedData`) because Boson's `EIP712Domain`
+ * field set is non-standard and viem's strict union rejects it; consumers
+ * pass this shape directly to `hashTypedData` / `signTypedData` /
+ * `recoverTypedDataAddress`, which accept it structurally.
+ */
+export interface FullOfferTypedData {
+  domain: Record<string, unknown>;
+  types: Record<string, readonly TypedDataField[]>;
+  primaryType: "FullOffer";
+  message: Record<string, unknown>;
+}
+
+export interface FullOfferArgsForBuilder {
+  fullOffer: UnsignedFullOffer;
+  /** Address of the Boson escrow contract — the EIP-712 verifyingContract. */
+  verifyingContract: Address;
+  chainId: number;
+}
+
+/**
+ * Stub `Web3LibAdapter`. core-sdk's `signFullOffer` requires this argument
+ * even when `returnTypedDataToSign: true`, but never calls any method in
+ * that branch. If any method does end up invoked, throw loudly rather than
+ * fall through with a default.
+ */
+const STUB_WEB3LIB: Web3LibAdapter = {
+  uuid: "x402-core:stub",
+  getSignerAddress: () => Promise.reject(unreachable("getSignerAddress")),
+  isSignerContract: () => Promise.reject(unreachable("isSignerContract")),
+  getChainId: () => Promise.reject(unreachable("getChainId")),
+  getBalance: () => Promise.reject(unreachable("getBalance")),
+  estimateGas: () => Promise.reject(unreachable("estimateGas")),
+  sendTransaction: () => Promise.reject(unreachable("sendTransaction")),
+  call: () => Promise.reject(unreachable("call")),
+  send: () => Promise.reject(unreachable("send")),
+  getTransactionReceipt: () => Promise.reject(unreachable("getTransactionReceipt")),
+  getCurrentTimeMs: () => Promise.reject(unreachable("getCurrentTimeMs")),
+};
+
+function unreachable(method: string): Error {
+  return new Error(
+    `@bosonprotocol/x402-core: stub Web3LibAdapter.${method}() should never be called when ` +
+      `returnTypedDataToSign is true. If you see this, either core-sdk changed its ` +
+      `behaviour or the stub leaked into a non-signing-only path — file a bug.`,
+  );
+}
+
+/**
+ * Build EIP-712 typed-data for a FullOffer that the seller will sign.
+ * Delegates the struct definition to `@bosonprotocol/core-sdk` so we stay in
+ * lock-step with whatever shape the deployed protocol's `verifyOffer`
+ * accepts.
+ */
+export async function fullOfferTypedData({
+  fullOffer,
+  verifyingContract,
+  chainId,
+}: FullOfferArgsForBuilder): Promise<FullOfferTypedData> {
+  const sd = await exchanges.handler.signFullOffer({
+    fullOfferArgsUnsigned: fullOffer,
+    contractAddress: verifyingContract,
+    chainId,
+    web3Lib: STUB_WEB3LIB,
+    returnTypedDataToSign: true,
+  });
+
+  return {
+    domain: sd.domain as unknown as Record<string, unknown>,
+    types: sd.types as unknown as Record<string, readonly TypedDataField[]>,
+    primaryType: "FullOffer",
+    message: sd.message,
+  };
+}
+
+/** EIP-712 digest for a FullOffer — what the seller signs. */
+export async function hashFullOffer(args: FullOfferArgsForBuilder): Promise<Hex> {
+  const td = await fullOfferTypedData(args);
+  return hashTypedData(td as Parameters<typeof hashTypedData>[0]);
+}
+
+/** Recover the seller address from a FullOffer signature. */
+export async function recoverFullOfferSigner(
+  args: FullOfferArgsForBuilder & { signature: Hex },
+): Promise<Address> {
+  const { signature, ...rest } = args;
+  const td = await fullOfferTypedData(rest);
+  return recoverTypedDataAddress({
+    domain: td.domain,
+    types: td.types,
+    primaryType: td.primaryType,
+    message: td.message,
+    signature,
+  } as unknown as Parameters<typeof recoverTypedDataAddress>[0]);
+}

--- a/typescript/packages/core/src/eip712/full-offer.ts
+++ b/typescript/packages/core/src/eip712/full-offer.ts
@@ -3,7 +3,7 @@
 // FullOffer's nested struct shape (Offer / OfferDates / OfferDurations /
 // DRParameters / Condition / RoyaltyInfo) is large and protocol-internal — it
 // can change as the contracts evolve. Rather than hand-mirroring it here,
-// this module wraps `@bosonprotocol/core-sdk@1.46.1`'s
+// this module wraps `@bosonprotocol/core-sdk`'s
 // `exchanges.handler.signFullOffer({..., returnTypedDataToSign: true})` and
 // re-exposes the typed-data through a viem-friendly hash + recover API.
 //

--- a/typescript/packages/core/src/eip712/index.ts
+++ b/typescript/packages/core/src/eip712/index.ts
@@ -1,0 +1,14 @@
+// Public surface for the Boson EIP-712 typed-data builders.
+//
+//   - `MetaTransaction(...)` typed-data builder + hash + signer recovery.
+//     Same typed-data is consumed by both the existing
+//     `executeMetaTransaction` Boson entrypoint and the BPIP-12
+//     `executeMetaTransactionWithTokenTransferAuthorization` entrypoint.
+//   - `FullOffer` (BPIP-10) typed-data builder + hash + signer recovery.
+//
+// Both builders delegate the EIP-712 type definitions and the (non-standard,
+// salt-based) Boson domain construction to `@bosonprotocol/core-sdk` so we
+// stay in lock-step with what the deployed protocol actually verifies on-chain.
+
+export * from "./meta-transaction.js";
+export * from "./full-offer.js";

--- a/typescript/packages/core/src/eip712/meta-transaction.ts
+++ b/typescript/packages/core/src/eip712/meta-transaction.ts
@@ -1,0 +1,155 @@
+// EIP-712 typed-data builder for the Boson Protocol meta-transaction envelope.
+//
+// The MetaTransaction struct shape and the salt-flavor EIP-712 domain are
+// fully owned by `@bosonprotocol/core-sdk@1.46.1`'s
+// `metaTx.handler.signMetaTx`. Rather than re-declaring them here (and risking
+// drift), we route the signing call through a stub `Web3LibAdapter` that
+// intercepts `eth_signTypedData_v4` to capture the structured data, then
+// returns a dummy 65-byte signature so signMetaTx can finish without errors.
+// The captured object is exactly what the deployed protocol's
+// `MetaTransactionsHandlerFacet` recovers signatures against.
+//
+// The same typed-data is consumed by both:
+//
+//   1. `MetaTransactionsHandlerFacet.executeMetaTransaction(...)` — the
+//      existing Boson entrypoint, already supported by `@bosonprotocol/core-sdk`.
+//      Used when no token-transfer authorization payloads need to be queued
+//      (e.g. `tokenAuthStrategy: "none"` flows where the buyer has
+//      pre-approved the escrow contract).
+//
+//   2. `MetaTransactionsHandlerFacet.executeMetaTransactionWithTokenTransferAuthorization(...)`
+//      — the BPIP-12 entrypoint. Used when ERC-3009 / EIP-2612 / Permit2
+//      payloads are queued alongside the meta-tx.
+//
+// The buyer signs once. Choice of on-chain entrypoint is the relayer's, and
+// happens at calldata-build time downstream (in `@bosonprotocol/x402-evm`).
+
+import { metaTx } from "@bosonprotocol/core-sdk";
+import type { Web3LibAdapter } from "@bosonprotocol/common";
+import { hashTypedData, recoverTypedDataAddress, type Address, type Hex } from "viem";
+
+import type { TypedDataField } from "./full-offer.js";
+
+export const META_TRANSACTION_PRIMARY_TYPE = "MetaTransaction" as const;
+
+/** Strongly-typed message body — what the buyer signs. */
+export interface MetaTransactionMessage {
+  /** `MetaTransactionsHandlerFacet.usedNonce[from][nonce]` replay-protection slot. */
+  nonce: bigint;
+  /** Buyer EOA. Must match the signature recovery on-chain. */
+  from: Address;
+  /** Address of the Boson escrow contract the call targets. */
+  contractAddress: Address;
+  /**
+   * Solidity function-name+selector string, e.g.
+   * `"createOfferCommitAndRedeem(BosonTypes.FullOffer,address,bytes,uint256)"`.
+   */
+  functionName: string;
+  /** ABI-encoded function-call data. */
+  functionSignature: Hex;
+}
+
+export interface MetaTransactionTypedData {
+  domain: Record<string, unknown>;
+  types: Record<string, readonly TypedDataField[]>;
+  primaryType: typeof META_TRANSACTION_PRIMARY_TYPE;
+  message: Record<string, unknown>;
+}
+
+export interface MetaTransactionArgs {
+  chainId: number;
+  /** Address of the Boson escrow contract — the EIP-712 verifyingContract. */
+  verifyingContract: Address;
+  message: MetaTransactionMessage;
+}
+
+// Any 65-byte hex; the value is irrelevant — core-sdk's
+// `getSignatureParameters` only slices it without validation.
+const DUMMY_SIGNATURE_65: Hex = `0x${"11".repeat(32)}${"22".repeat(32)}1b`;
+
+/**
+ * Build the EIP-712 typed-data for a Boson meta-transaction.
+ *
+ * Pass the result to:
+ *   - `account.signTypedData(typedData)` (a viem `LocalAccount` / HD account);
+ *   - `walletClient.signTypedData({ account, ...typedData })` (a viem
+ *     `WalletClient` for browser-wallet / RPC signers).
+ *
+ * Use {@link recoverMetaTransactionSigner} to verify a signature.
+ */
+export async function metaTransactionTypedData({
+  message,
+  chainId,
+  verifyingContract,
+}: MetaTransactionArgs): Promise<MetaTransactionTypedData> {
+  let captured: MetaTransactionTypedData | undefined;
+
+  const intercept: Web3LibAdapter = {
+    uuid: "x402-core:meta-tx-typed-data-intercept",
+    // signMetaTx puts the signer's address into the `from` field of the
+    // typed-data message — we want it to match the caller-supplied `from`.
+    getSignerAddress: () => Promise.resolve(message.from),
+    isSignerContract: () => Promise.resolve(false),
+    getChainId: () => Promise.resolve(chainId),
+    send: async (method, params) => {
+      if (method !== "eth_signTypedData_v4") {
+        throw new Error(`x402-core: unexpected RPC method during typed-data capture: ${method}`);
+      }
+      const json = (params as unknown[])[1];
+      if (typeof json !== "string") {
+        throw new Error("x402-core: signMetaTx send payload is not a JSON string");
+      }
+      captured = JSON.parse(json) as MetaTransactionTypedData;
+      return DUMMY_SIGNATURE_65;
+    },
+    getBalance: () => Promise.reject(unreachable("getBalance")),
+    estimateGas: () => Promise.reject(unreachable("estimateGas")),
+    sendTransaction: () => Promise.reject(unreachable("sendTransaction")),
+    call: () => Promise.reject(unreachable("call")),
+    getTransactionReceipt: () => Promise.reject(unreachable("getTransactionReceipt")),
+    getCurrentTimeMs: () => Promise.reject(unreachable("getCurrentTimeMs")),
+  };
+
+  await metaTx.handler.signMetaTx({
+    web3Lib: intercept,
+    nonce: message.nonce.toString(),
+    metaTxHandlerAddress: verifyingContract,
+    chainId,
+    functionName: message.functionName,
+    functionSignature: message.functionSignature,
+  });
+
+  if (!captured) {
+    throw new Error(
+      "x402-core: signMetaTx did not invoke eth_signTypedData_v4 — core-sdk internals may have changed",
+    );
+  }
+  return captured;
+}
+
+function unreachable(method: string): Error {
+  return new Error(
+    `x402-core: stub Web3LibAdapter.${method}() should never be called during typed-data capture`,
+  );
+}
+
+/** EIP-712 digest for the meta-tx — what gets signed. */
+export async function hashMetaTransaction(args: MetaTransactionArgs): Promise<Hex> {
+  const td = await metaTransactionTypedData(args);
+  return hashTypedData(td as Parameters<typeof hashTypedData>[0]);
+}
+
+/** Recover the signer address from a meta-tx signature. */
+export async function recoverMetaTransactionSigner(
+  args: MetaTransactionArgs & { signature: Hex },
+): Promise<Address> {
+  const { signature, ...rest } = args;
+  const td = await metaTransactionTypedData(rest);
+  return recoverTypedDataAddress({
+    domain: td.domain,
+    types: td.types,
+    primaryType: td.primaryType,
+    message: td.message,
+    signature,
+  } as unknown as Parameters<typeof recoverTypedDataAddress>[0]);
+}

--- a/typescript/packages/core/src/eip712/meta-transaction.ts
+++ b/typescript/packages/core/src/eip712/meta-transaction.ts
@@ -1,7 +1,7 @@
 // EIP-712 typed-data builder for the Boson Protocol meta-transaction envelope.
 //
 // The MetaTransaction struct shape and the salt-flavor EIP-712 domain are
-// fully owned by `@bosonprotocol/core-sdk@1.46.1`'s
+// fully owned by `@bosonprotocol/core-sdk`'s
 // `metaTx.handler.signMetaTx`. Rather than re-declaring them here (and risking
 // drift), we route the signing call through a stub `Web3LibAdapter` that
 // intercepts `eth_signTypedData_v4` to capture the structured data, then

--- a/typescript/packages/core/test/eip712/full-offer.test.ts
+++ b/typescript/packages/core/test/eip712/full-offer.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { numberToHex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import {
+  fullOfferTypedData,
+  hashFullOffer,
+  recoverFullOfferSigner,
+  type UnsignedFullOffer,
+} from "../../src/eip712/index.js";
+
+const ESCROW = "0xdddddddddddddddddddddddddddddddddddddddd" as const;
+const TOKEN = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" as const;
+const SELLER = "0x1111111111111111111111111111111111111111" as const;
+const BUYER_PLACEHOLDER = "0x0000000000000000000000000000000000000000" as const;
+
+const TEST_PRIVATE_KEY = `0x${"22".repeat(32)}` as const;
+
+const baseOffer: UnsignedFullOffer = {
+  // CreateOfferArgs
+  price: "1000000",
+  sellerDeposit: "0",
+  agentId: "0",
+  buyerCancelPenalty: "0",
+  quantityAvailable: "1",
+  validFromDateInMS: "1900000000000",
+  validUntilDateInMS: "1900003600000",
+  voucherRedeemableFromDateInMS: "1900000000000",
+  voucherRedeemableUntilDateInMS: "1900003600000",
+  disputePeriodDurationInMS: "86400000",
+  voucherValidDurationInMS: "0",
+  resolutionPeriodDurationInMS: "604800000",
+  exchangeToken: TOKEN,
+  disputeResolverId: "1",
+  metadataUri: "ipfs://QmDeadBeef",
+  metadataHash: "QmDeadBeef",
+  collectionIndex: "0",
+  feeLimit: "0",
+  // FullOffer-only
+  offerCreator: SELLER,
+  committer: BUYER_PLACEHOLDER,
+  condition: {
+    method: 0,
+    tokenType: 0,
+    tokenAddress: "0x0000000000000000000000000000000000000000",
+    gatingType: 0,
+    minTokenId: "0",
+    threshold: "0",
+    maxCommits: "0",
+    maxTokenId: "0",
+  },
+  useDepositedFunds: false,
+  sellerId: "12345",
+  buyerId: "0",
+  sellerOfferParams: {
+    collectionIndex: "0",
+    royaltyInfo: { recipients: [], bps: [] },
+    mutualizerAddress: "0x0000000000000000000000000000000000000000",
+  },
+};
+
+describe("fullOfferTypedData (wraps core-sdk's signFullOffer)", () => {
+  it("returns FullOffer-typed EIP-712 data with the salt-based domain", async () => {
+    const td = await fullOfferTypedData({
+      fullOffer: baseOffer,
+      verifyingContract: ESCROW,
+      chainId: 8453,
+    });
+    expect(td.primaryType).toBe("FullOffer");
+    expect(td.domain).toMatchObject({
+      name: "Boson Protocol",
+      version: "V2",
+      verifyingContract: ESCROW,
+      salt: numberToHex(8453, { size: 32 }),
+    });
+    expect(td.domain).not.toHaveProperty("chainId");
+  });
+
+  it("types include the FullOffer struct and its nested types", async () => {
+    const td = await fullOfferTypedData({
+      fullOffer: baseOffer,
+      verifyingContract: ESCROW,
+      chainId: 8453,
+    });
+    expect(td.types).toHaveProperty("FullOffer");
+    expect(td.types).toHaveProperty("Offer");
+    expect(td.types).toHaveProperty("OfferDates");
+    expect(td.types).toHaveProperty("OfferDurations");
+    expect(td.types).toHaveProperty("DRParameters");
+    expect(td.types).toHaveProperty("Condition");
+    expect(td.types).toHaveProperty("RoyaltyInfo");
+    expect(td.types).toHaveProperty("EIP712Domain");
+  });
+});
+
+describe("hashFullOffer + recoverFullOfferSigner round-trip", () => {
+  it("recovers the signing seller", async () => {
+    const seller = privateKeyToAccount(TEST_PRIVATE_KEY);
+    const td = await fullOfferTypedData({
+      fullOffer: { ...baseOffer, offerCreator: seller.address },
+      verifyingContract: ESCROW,
+      chainId: 8453,
+    });
+    const signature = await seller.signTypedData(td);
+    const recovered = await recoverFullOfferSigner({
+      fullOffer: { ...baseOffer, offerCreator: seller.address },
+      verifyingContract: ESCROW,
+      chainId: 8453,
+      signature,
+    });
+    expect(recovered.toLowerCase()).toBe(seller.address.toLowerCase());
+  });
+
+  it("hash is deterministic and 32 bytes", async () => {
+    const args = { fullOffer: baseOffer, verifyingContract: ESCROW, chainId: 8453 };
+    const h1 = await hashFullOffer(args);
+    const h2 = await hashFullOffer(args);
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it("hash differs across chains", async () => {
+    const onBase = await hashFullOffer({
+      fullOffer: baseOffer,
+      verifyingContract: ESCROW,
+      chainId: 8453,
+    });
+    const onPolygon = await hashFullOffer({
+      fullOffer: baseOffer,
+      verifyingContract: ESCROW,
+      chainId: 137,
+    });
+    expect(onBase).not.toBe(onPolygon);
+  });
+});

--- a/typescript/packages/core/test/eip712/meta-transaction.test.ts
+++ b/typescript/packages/core/test/eip712/meta-transaction.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { numberToHex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import {
+  hashMetaTransaction,
+  META_TRANSACTION_PRIMARY_TYPE,
+  metaTransactionTypedData,
+  recoverMetaTransactionSigner,
+  type MetaTransactionMessage,
+} from "../../src/eip712/index.js";
+
+const ESCROW = "0xdddddddddddddddddddddddddddddddddddddddd" as const;
+
+// Deterministic test key — never use anywhere else.
+const TEST_PRIVATE_KEY = `0x${"11".repeat(32)}` as const;
+
+const baseMessage: MetaTransactionMessage = {
+  nonce: 0n,
+  from: privateKeyToAccount(TEST_PRIVATE_KEY).address,
+  contractAddress: ESCROW,
+  functionName: "createOfferCommitAndRedeem(BosonTypes.FullOffer,address,bytes,uint256)",
+  functionSignature: "0xabcdef",
+};
+
+const baseDomainArgs = { chainId: 8453, verifyingContract: ESCROW } as const;
+
+describe("metaTransactionTypedData (delegates to core-sdk's signMetaTx)", () => {
+  it("returns the salt-based Boson domain (no chainId field)", async () => {
+    const td = await metaTransactionTypedData({ ...baseDomainArgs, message: baseMessage });
+    expect(td.primaryType).toBe(META_TRANSACTION_PRIMARY_TYPE);
+    expect(td.domain).toMatchObject({
+      name: "Boson Protocol",
+      version: "V2",
+      verifyingContract: ESCROW,
+      salt: numberToHex(8453, { size: 32 }),
+    });
+    expect(td.domain).not.toHaveProperty("chainId");
+  });
+
+  it("declares MetaTransaction with the protocol's five fields in production order", async () => {
+    const td = await metaTransactionTypedData({ ...baseDomainArgs, message: baseMessage });
+    const fields = td.types.MetaTransaction;
+    expect(fields.map((f) => f.name)).toEqual([
+      "nonce",
+      "from",
+      "contractAddress",
+      "functionName",
+      "functionSignature",
+    ]);
+    expect(fields.map((f) => f.type)).toEqual(["uint256", "address", "address", "string", "bytes"]);
+  });
+
+  it("includes the salt-flavor EIP712Domain so viem doesn't auto-derive the standard one", async () => {
+    const td = await metaTransactionTypedData({ ...baseDomainArgs, message: baseMessage });
+    expect(td.types.EIP712Domain.map((f) => f.name)).toEqual([
+      "name",
+      "version",
+      "verifyingContract",
+      "salt",
+    ]);
+  });
+
+  it("threads message fields through to the captured typed-data", async () => {
+    const td = await metaTransactionTypedData({ ...baseDomainArgs, message: baseMessage });
+    expect(td.message).toMatchObject({
+      nonce: "0",
+      from: baseMessage.from,
+      contractAddress: ESCROW,
+      functionName: baseMessage.functionName,
+      functionSignature: baseMessage.functionSignature,
+    });
+  });
+});
+
+describe("hashMetaTransaction", () => {
+  it("is deterministic for fixed inputs", async () => {
+    const h1 = await hashMetaTransaction({ ...baseDomainArgs, message: baseMessage });
+    const h2 = await hashMetaTransaction({ ...baseDomainArgs, message: baseMessage });
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it("differs across chains for the same message (salt diverges)", async () => {
+    const onBase = await hashMetaTransaction({ ...baseDomainArgs, message: baseMessage });
+    const onPolygon = await hashMetaTransaction({
+      chainId: 137,
+      verifyingContract: ESCROW,
+      message: baseMessage,
+    });
+    expect(onBase).not.toBe(onPolygon);
+  });
+
+  it("differs when any message field changes", async () => {
+    const original = await hashMetaTransaction({ ...baseDomainArgs, message: baseMessage });
+    const bumpedNonce = await hashMetaTransaction({
+      ...baseDomainArgs,
+      message: { ...baseMessage, nonce: 1n },
+    });
+    const renamedFn = await hashMetaTransaction({
+      ...baseDomainArgs,
+      message: { ...baseMessage, functionName: "createOfferAndCommit(...)" },
+    });
+    const swappedSig = await hashMetaTransaction({
+      ...baseDomainArgs,
+      message: { ...baseMessage, functionSignature: "0x123456" },
+    });
+    expect(bumpedNonce).not.toBe(original);
+    expect(renamedFn).not.toBe(original);
+    expect(swappedSig).not.toBe(original);
+  });
+});
+
+describe("signMetaTransaction round-trip via viem account", () => {
+  it("the recovered signer matches `from`", async () => {
+    const account = privateKeyToAccount(TEST_PRIVATE_KEY);
+    const td = await metaTransactionTypedData({ ...baseDomainArgs, message: baseMessage });
+    const signature = await account.signTypedData(
+      td as unknown as Parameters<typeof account.signTypedData>[0],
+    );
+    const recovered = await recoverMetaTransactionSigner({
+      ...baseDomainArgs,
+      message: baseMessage,
+      signature,
+    });
+    expect(recovered.toLowerCase()).toBe(account.address.toLowerCase());
+    expect(recovered.toLowerCase()).toBe(baseMessage.from.toLowerCase());
+  });
+
+  it("a signature for one message does not recover for a different message", async () => {
+    const account = privateKeyToAccount(TEST_PRIVATE_KEY);
+    const td = await metaTransactionTypedData({ ...baseDomainArgs, message: baseMessage });
+    const signature = await account.signTypedData(
+      td as unknown as Parameters<typeof account.signTypedData>[0],
+    );
+    const recovered = await recoverMetaTransactionSigner({
+      ...baseDomainArgs,
+      message: { ...baseMessage, nonce: 999n },
+      signature,
+    });
+    expect(recovered.toLowerCase()).not.toBe(account.address.toLowerCase());
+  });
+});

--- a/typescript/packages/core/tsup.config.ts
+++ b/typescript/packages/core/tsup.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from "tsup";
 
-// Dual CJS + ESM build with type declarations.
-// JSON schemas under src/**/schemas/*.json are copied to dist/schemas/ so
-// consumers can resolve them via `@bosonprotocol/x402-core/schemas/<name>.json`
-// once schemas are added (PR 3).
+// Dual CJS + ESM build with type declarations. Each public subpath of the
+// package gets its own entry so consumers resolving e.g.
+// `@bosonprotocol/x402-core/eip712` get a separate file per format.
+const entry = ["src/index.ts", "src/eip712/index.ts"];
+
 export default defineConfig([
   {
-    entry: ["src/index.ts"],
+    entry,
     format: "esm",
     outDir: "dist/esm",
     outExtension: () => ({ js: ".js" }),
@@ -17,7 +18,7 @@ export default defineConfig([
     treeshake: true,
   },
   {
-    entry: ["src/index.ts"],
+    entry,
     format: "cjs",
     outDir: "dist/cjs",
     outExtension: () => ({ js: ".js" }),


### PR DESCRIPTION
## Summary

Adds the `./eip712` subpath of `@bosonprotocol/x402-core` with FullOffer and MetaTransaction typed-data builders, hash helpers, and signer-recovery helpers.

Both wrappers **delegate the EIP-712 type definitions and the salt-based Boson domain construction to `@bosonprotocol/core-sdk@1.46.1`** so this package stays in lock-step with what the deployed protocol actually verifies on-chain — no parallel hand-mirrored type definitions to keep in sync. Verified against `core-sdk`'s `dist/cjs/utils/signature.js` and `dist/cjs/meta-tx/handler.js`.

### Public surface (new `./eip712`)

- `fullOfferTypedData` / `hashFullOffer` / `recoverFullOfferSigner` — wrap [`exchanges.handler.signFullOffer({..., returnTypedDataToSign: true})`](https://github.com/bosonprotocol/core-components/blob/main/packages/core-sdk/src/exchanges/handler.ts). In that mode core-sdk returns the `StructuredData` immediately and never invokes `web3Lib`; we pass a stub adapter whose methods throw loudly if called, so any future change in core-sdk's behaviour surfaces rather than silently breaks.
- `metaTransactionTypedData` / `hashMetaTransaction` / `recoverMetaTransactionSigner` — wrap [`metaTx.handler.signMetaTx`](https://github.com/bosonprotocol/core-components/blob/main/packages/core-sdk/src/meta-tx/handler.ts). `signMetaTx` hardcodes `returnTypedDataToSign: false`, so we route through it with a stub `Web3LibAdapter` that intercepts the `eth_signTypedData_v4` RPC, captures the typed-data the SDK builds, and returns a dummy 65-byte signature (any 65 bytes; core-sdk's `getSignatureParameters` slices without validating). Same typed-data is consumed by both `executeMetaTransaction` (existing) and `executeMetaTransactionWithTokenTransferAuthorization` (BPIP-12).

### Why salt-based and "Boson Protocol" with a space

The published `@bosonprotocol/core-sdk@1.46.1` uses a non-standard EIP-712 domain — `{name: "Boson Protocol", version: "V2", verifyingContract, salt: bytes32(chainId)}`, no standard `chainId` field. The spec doc at [docs/boson-impl-01-escrow-scheme.md:206](./docs/boson-impl-01-escrow-scheme.md) currently describes the standard form; reconciling the doc is a follow-up. Using the standard form here would produce digests the on-chain `verifyOffer` / `MetaTransactionsHandlerFacet` rejects.

### New runtime deps

- `@bosonprotocol/core-sdk@1.46.1` — for `signFullOffer` and `signMetaTx`
- `@bosonprotocol/common` — for `FullOfferArgs` and `Web3LibAdapter` types
- `lodash` — core-sdk imports `lodash/groupBy` at runtime but doesn't list it in its own `dependencies`; we have to surface it ourselves so pnpm's strict resolution finds it. Worth filing upstream against core-sdk.

The transitive footprint is sizeable (`@ethersproject/*`, `opensea-js`, `graphql-request`, `mustache`, `schema-to-yup`, etc.). Trade-off accepted: lock-step with the protocol vs. a leaner dep tree with hand-mirrored types we'd have to maintain.

### Test plan

- [x] 14 vitest cases pass (5 full-offer + 9 meta-tx)
- [x] Domain shape: salt-based, no `chainId` field, name is "Boson Protocol" (with space)
- [x] MetaTransaction struct: 5 fields in production order (`nonce`, `from`, `contractAddress`, `functionName`, `functionSignature`)
- [x] Round-trip: sign with viem `LocalAccount`, recover same address back; signature for one message doesn't recover for another
- [x] Hash is deterministic and 32 bytes; differs across chains; differs when any message field changes
- [x] `pnpm build` clean — emits `dist/{cjs,esm}/eip712/index.{js,d.ts}` (4 kB `.d.ts`)
- [x] `pnpm lint`, `pnpm format:check` clean
- [x] `pnpm publish --dry-run --filter @bosonprotocol/x402-core` packs 13 files at 11.8 kB
- [x] CI green on Node 22 + 24

### Open item (not blocking this PR)

No on-chain hash fixture cross-check. Tests verify internal consistency and that our typed-data matches what core-sdk produces, but don't independently verify against a known protocol-computed digest. Worth landing before 1.0 — likely as a separate test that signs a fixed FullOffer with a known private key and asserts the digest equals a value pinned from a contract test fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)