### PR TITLE
ci: skip drafts, run on ready-for-review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
 
@@ -20,6 +21,7 @@ jobs:
   build-test-lint:
     name: build / test / lint (node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

The default `pull_request` trigger types are `[opened, synchronize, reopened]` — none of which fire when a draft PR transitions to ready-for-review. Two changes to [.github/workflows/ci.yml](./.github/workflows/ci.yml):

1. **Add `ready_for_review`** to `pull_request.types` so CI fires the moment a PR is marked ready.
2. **Job-level `if: ${{ !github.event.pull_request.draft }}`** — skips draft PRs (where `synchronize` would otherwise still fire on every push). Push events to `main` carry no `pull_request` payload (`draft` is `undefined`, `!undefined === true`) so they pass through.

### Effective behavior

| Event | Before | After |
|---|---|---|
| PR opened (draft) | CI runs | CI **skipped** |
| PR opened (ready) | CI runs | CI runs |
| Push to draft PR | CI runs | CI **skipped** |
| Push to ready PR | CI runs | CI runs |
| Draft → ready-for-review | **no CI** | CI runs |
| Push to `main` | CI runs | CI runs |

## Test plan

- [ ] After merge: open a draft PR, confirm CI is skipped; mark ready, confirm CI fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)