### PR TITLE
feat(fulfillment): scaffold @bosonprotocol/x402-fulfillment package

### DIFF
--- a/.changeset/prepare-fulfillment-package.md
+++ b/.changeset/prepare-fulfillment-package.md
@@ -1,0 +1,10 @@
+---
+"@bosonprotocol/x402-fulfillment": minor
+---
+
+Initial skeleton for `@bosonprotocol/x402-fulfillment`: ships the
+pluggable `FulfillmentChannel` interface and `FulfillmentResult` type,
+the build/test/postbuild conventions matching `@bosonprotocol/x402-core`,
+and the export-map subpaths (`./registry`, `./client`, `./channels/*`,
+`./schemas/*`) consumers will reach for. No channel implementations,
+registry, or negotiation helper yet.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,9 +76,36 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
 
-  typescript/packages/core/dist/cjs: {}
-
-  typescript/packages/core/dist/esm: {}
+  typescript/packages/fulfillment:
+    dependencies:
+      '@bosonprotocol/x402-core':
+        specifier: workspace:^
+        version: link:../core
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.23.5
+        version: 3.25.2(zod@3.25.76)
+    devDependencies:
+      '@types/json-schema':
+        specifier: ^7.0.15
+        version: 7.0.15
+      '@types/node':
+        specifier: ^20.17.10
+        version: 20.19.40
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.40)
 
 packages:
 
@@ -2059,6 +2086,11 @@ packages:
 
   yup@1.7.1:
     resolution: {integrity: sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -4119,5 +4151,9 @@ snapshots:
       tiny-case: 1.0.3
       toposort: 2.0.2
       type-fest: 2.19.0
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}

--- a/typescript/packages/fulfillment/README.md
+++ b/typescript/packages/fulfillment/README.md
@@ -1,0 +1,42 @@
+# @bosonprotocol/x402-fulfillment
+
+Fulfillment channels for the Boson Protocol [`escrow`
+scheme](../core/) of [x402](https://github.com/x402-foundation/x402).
+Defines the pluggable `FulfillmentChannel` interface that lets a seller
+advertise — and a buyer attach — delivery data alongside an x402
+escrow payment.
+
+See [`docs/boson-impl-03-fulfillment-channels.md`](../../../docs/boson-impl-03-fulfillment-channels.md)
+for the design and wire-format spec.
+
+## Status
+
+Skeleton package. Ships the `FulfillmentChannel` interface and
+`FulfillmentResult` type so consumers can begin to type against the
+contract. Built-in channels (`atomic-http`, `email`, `xmtp`, `webhook`,
+`ipfs-pointer`), the registry, and the client-side `negotiateFulfillment`
+helper land separately.
+
+## Install
+
+```bash
+pnpm add @bosonprotocol/x402-fulfillment @bosonprotocol/x402-core
+```
+
+## API
+
+```ts
+import type {
+  FulfillmentChannel,
+  FulfillmentResult,
+} from "@bosonprotocol/x402-fulfillment";
+```
+
+`FulfillmentOption` and `FulfillmentRequirements` (the on-the-wire
+shapes that appear in the 402 `PaymentRequirements` and the
+`X-PAYMENT` payload) are re-exported from
+[`@bosonprotocol/x402-core/schemes/escrow`](../core/) — import them from there.
+
+## License
+
+Apache-2.0.

--- a/typescript/packages/fulfillment/package.json
+++ b/typescript/packages/fulfillment/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@bosonprotocol/x402-fulfillment",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "description": "Boson Protocol fulfillment channels for x402 — pluggable FulfillmentChannel interface, registry, client-side negotiation helper, and built-in channel implementations.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bosonprotocol/x402B.git",
+    "directory": "typescript/packages/fulfillment"
+  },
+  "homepage": "https://github.com/bosonprotocol/x402B/tree/main/typescript/packages/fulfillment",
+  "bugs": {
+    "url": "https://github.com/bosonprotocol/x402B/issues"
+  },
+  "keywords": [
+    "x402",
+    "boson-protocol",
+    "fulfillment",
+    "delivery",
+    "escrow"
+  ],
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/cjs/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./registry": {
+      "types": "./dist/cjs/registry/index.d.ts",
+      "import": "./dist/esm/registry/index.js",
+      "require": "./dist/cjs/registry/index.js"
+    },
+    "./client": {
+      "types": "./dist/cjs/client/index.d.ts",
+      "import": "./dist/esm/client/index.js",
+      "require": "./dist/cjs/client/index.js"
+    },
+    "./channels/*": {
+      "types": "./dist/cjs/channels/*/index.d.ts",
+      "import": "./dist/esm/channels/*/index.js",
+      "require": "./dist/cjs/channels/*/index.js"
+    },
+    "./schemas/*": "./dist/schemas/*"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup && node scripts/postbuild.mjs",
+    "test": "vitest run --passWithNoTests",
+    "lint": "eslint src --max-warnings 0",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@bosonprotocol/x402-core": "workspace:^",
+    "zod": "^3.24.2",
+    "zod-to-json-schema": "^3.23.5"
+  },
+  "devDependencies": {
+    "@types/json-schema": "^7.0.15",
+    "@types/node": "^20.17.10",
+    "ajv": "^8.17.1",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/typescript/packages/fulfillment/scripts/postbuild.mjs
+++ b/typescript/packages/fulfillment/scripts/postbuild.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Post-build housekeeping after `tsup`:
+//
+// 1. Copy `src/**/schemas/*.json` flat into `dist/schemas/` so the
+//    `./schemas/*` package export resolves at runtime.
+// 2. Write `dist/esm/package.json` ({"type":"module"}) and
+//    `dist/cjs/package.json` ({"type":"commonjs"}) so Node treats each
+//    subtree under the correct module dialect without a
+//    MODULE_TYPELESS_PACKAGE_JSON warning at consume time.
+
+import { readdir, mkdir, rm, copyFile, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const srcRoot = join(here, "..", "src");
+const distRoot = join(here, "..", "dist");
+const schemasRoot = join(distRoot, "schemas");
+
+async function* walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else yield p;
+  }
+}
+
+// Wipe `dist/schemas/` first so renamed or removed source schemas don't
+// leak into published tarballs.
+await rm(schemasRoot, { recursive: true, force: true });
+await mkdir(schemasRoot, { recursive: true });
+
+let schemaCount = 0;
+for await (const file of walk(srcRoot)) {
+  if (!file.endsWith(".json")) continue;
+  const rel = relative(srcRoot, file);
+  if (!rel.split(/[\\/]/).includes("schemas")) continue;
+  const name = file.split(/[\\/]/).pop();
+  await copyFile(file, join(schemasRoot, name));
+  schemaCount += 1;
+}
+
+await writeFile(
+  join(distRoot, "esm", "package.json"),
+  JSON.stringify({ type: "module" }, null, 2) + "\n",
+);
+await writeFile(
+  join(distRoot, "cjs", "package.json"),
+  JSON.stringify({ type: "commonjs" }, null, 2) + "\n",
+);
+
+console.log(
+  `postbuild: ${schemaCount} schema(s) -> ${relative(process.cwd(), schemasRoot)}, wrote module-type markers in dist/{esm,cjs}/package.json`,
+);

--- a/typescript/packages/fulfillment/src/index.ts
+++ b/typescript/packages/fulfillment/src/index.ts
@@ -1,0 +1,12 @@
+// Public API for @bosonprotocol/x402-fulfillment.
+//
+// The root entry exposes the framework-level types. Concrete channels,
+// the server-side registry, and the client-side `negotiateFulfillment`
+// helper are reached via subpath imports (`./channels/<id>`,
+// `./registry`, `./client`).
+
+export type {
+  FulfillmentChannel,
+  FulfillmentOptionDescriptor,
+  FulfillmentResult,
+} from "./types.js";

--- a/typescript/packages/fulfillment/src/types.ts
+++ b/typescript/packages/fulfillment/src/types.ts
@@ -1,0 +1,68 @@
+// Pluggable fulfillment-channel contract.
+// Source of truth: docs/boson-impl-03-fulfillment-channels.md §`FulfillmentChannel` interface.
+
+import type { FulfillmentOption } from "@bosonprotocol/x402-core/schemes/escrow";
+import type { JSONSchema7 } from "json-schema";
+
+/**
+ * Server-side description of an advertised fulfillment option as it
+ * appears on the wire, optionally augmented with channel-specific
+ * `metadata` (e.g. a webhook URL or a widget endpoint).
+ */
+export interface FulfillmentOptionDescriptor extends FulfillmentOption {
+  metadata?: unknown;
+}
+
+/**
+ * Result of a server-side `onRedeem` invocation.
+ *
+ * - `atomic` — the resource itself is returned in-band (used by the
+ *   `atomic-http` channel; the body is the HTTP response payload).
+ * - `async`  — the resource is delivered out-of-band; an optional
+ *   `pointer` may be returned (e.g. `ipfs://…`, `https://…`,
+ *   `mailto:…`) for callers that want to surface a tracking URL.
+ */
+export type FulfillmentResult =
+  | { kind: "atomic"; body: Uint8Array; contentType: string }
+  | { kind: "async"; pointer?: string };
+
+/**
+ * Pluggable fulfillment channel.
+ *
+ * Implementations describe one delivery mechanism the seller offers.
+ * The same instance is used both to advertise the channel (`describe`)
+ * and to drive the server-side lifecycle (`validate`, `onCommit`,
+ * `onRedeem`). On the client, an optional `collect` may interactively
+ * gather the buyer's data from a UI or agent.
+ *
+ * Type parameters:
+ * - `TServerCfg`  — channel-specific server configuration (keys, urls).
+ * - `TBuyerData`  — shape of the buyer-supplied data validated by
+ *   `buyerDataSchema`. `null` for schemaless channels (e.g.
+ *   `atomic-http`, `widget`).
+ */
+export interface FulfillmentChannel<TServerCfg = unknown, TBuyerData = unknown> {
+  /** Stable identifier used in the wire format (`fulfillment.option`). */
+  readonly id: string;
+
+  /** JSON Schema for the buyer's `fulfillment.data`, or `null` if the channel takes no data. */
+  readonly buyerDataSchema: JSONSchema7 | null;
+
+  /** Apply server-side configuration. Called once at boot, not per request. */
+  configure(cfg: TServerCfg): void;
+
+  /** Build the entry that goes into `PaymentRequirements.fulfillment.options[]`. */
+  describe(): FulfillmentOptionDescriptor;
+
+  /** Validate the buyer's attached data against `buyerDataSchema`. */
+  validate(data: TBuyerData): { ok: true } | { ok: false; reason: string };
+
+  /** Invoked at commit acceptance — store the buyer data against the exchange id. */
+  onCommit(exchangeId: string, buyerData: TBuyerData): Promise<void>;
+
+  /** Invoked when the redeem is observed — return the resource (atomic) or void (async). */
+  onRedeem(exchangeId: string): Promise<FulfillmentResult>;
+
+  /** Client-side: optionally collect buyer data interactively. */
+  collect?(metadata: unknown): Promise<TBuyerData>;
+}

--- a/typescript/packages/fulfillment/test/types.test.ts
+++ b/typescript/packages/fulfillment/test/types.test.ts
@@ -1,0 +1,29 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import type {
+  FulfillmentChannel,
+  FulfillmentOptionDescriptor,
+  FulfillmentResult,
+} from "../src/index.js";
+
+describe("@bosonprotocol/x402-fulfillment public types", () => {
+  it("FulfillmentResult is a discriminated union of atomic | async", () => {
+    const atomic: FulfillmentResult = {
+      kind: "atomic",
+      body: new Uint8Array([0x4f, 0x4b]),
+      contentType: "text/plain",
+    };
+    const async: FulfillmentResult = { kind: "async", pointer: "ipfs://bafy" };
+    expectTypeOf(atomic.kind).toEqualTypeOf<"atomic" | "async">();
+    expectTypeOf(async.kind).toEqualTypeOf<"atomic" | "async">();
+  });
+
+  it("FulfillmentChannel is generic over TServerCfg and TBuyerData", () => {
+    type Cfg = { apiKey: string };
+    type Data = { email: string };
+    type Channel = FulfillmentChannel<Cfg, Data>;
+    expectTypeOf<Parameters<Channel["configure"]>[0]>().toEqualTypeOf<Cfg>();
+    expectTypeOf<Parameters<Channel["onCommit"]>[1]>().toEqualTypeOf<Data>();
+    expectTypeOf<ReturnType<Channel["describe"]>>().toEqualTypeOf<FulfillmentOptionDescriptor>();
+  });
+});

--- a/typescript/packages/fulfillment/tsconfig.json
+++ b/typescript/packages/fulfillment/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/typescript/packages/fulfillment/tsup.config.ts
+++ b/typescript/packages/fulfillment/tsup.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from "tsup";
+
+// Dual CJS + ESM build with type declarations.
+//
+// `entry` globs every `index.ts` under `src/`, including the root
+// `src/index.ts`, so any subpath under `src/<subdir>/index.ts` builds as
+// `@bosonprotocol/x402-fulfillment/<subdir>` without further config
+// changes. JSON schemas under `src/**/schemas/*.json` are copied flat
+// into `dist/schemas/` by the `postbuild` step chained from
+// package.json's `build` script.
+const entry = ["src/**/index.ts"];
+
+export default defineConfig([
+  {
+    entry,
+    format: "esm",
+    outDir: "dist/esm",
+    outExtension: () => ({ js: ".js" }),
+    dts: false,
+    sourcemap: true,
+    clean: true,
+    target: "es2020",
+    treeshake: true,
+  },
+  {
+    entry,
+    format: "cjs",
+    outDir: "dist/cjs",
+    outExtension: () => ({ js: ".js" }),
+    dts: true,
+    sourcemap: true,
+    clean: false,
+    target: "es2020",
+    treeshake: true,
+  },
+]);

--- a/typescript/packages/fulfillment/vitest.config.ts
+++ b/typescript/packages/fulfillment/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

- Adds new workspace package `@bosonprotocol/x402-fulfillment@0.1.0` under [`typescript/packages/fulfillment/`](typescript/packages/fulfillment/).
- Ships the pluggable `FulfillmentChannel` interface and `FulfillmentResult` type from [`docs/boson-impl-03-fulfillment-channels.md`](docs/boson-impl-03-fulfillment-channels.md). No channel implementations, no registry, no negotiation helper — those follow separately.
- Mirrors `@bosonprotocol/x402-core`'s build conventions: dual CJS+ESM `tsup` build, `postbuild.mjs` copies `src/**/schemas/*.json` into `dist/schemas/` and writes module-type markers, vitest with `--passWithNoTests`.
- Pre-declares export-map subpaths (`./registry`, `./client`, `./channels/*`, `./schemas/*`) up front so concrete implementations land as purely-additive changes.
- Reuses `FulfillmentOption` from `@bosonprotocol/x402-core/schemes/escrow` rather than redefining it.

## Test plan

- [x] `pnpm install` resolves the new workspace package and its deps (`@bosonprotocol/x402-core` workspace link, `zod`, `zod-to-json-schema`).
- [x] `pnpm build` — both packages build, tsup emits CJS/ESM/d.ts, postbuild writes module-type markers.
- [x] `pnpm test` — type-shape smoke test passes (89 tests across the monorepo, +2 new).
- [x] `pnpm lint` — clean.
- [x] `pnpm format:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)