### PR TITLE
feat(fulfillment): add atomic-http channel

### DIFF
--- a/.changeset/add-atomic-http-channel.md
+++ b/.changeset/add-atomic-http-channel.md
@@ -1,0 +1,8 @@
+---
+"@bosonprotocol/x402-fulfillment": minor
+---
+
+Add the `atomic-http` fulfillment channel: schemaless (the buyer
+attaches no data), with `onRedeem` returning the resource body
+resolved by a server-supplied `resolve(exchangeId)` callback. Exposed
+via the `./channels/atomic-http` subpath.

--- a/typescript/packages/fulfillment/src/channels/atomic-http/index.ts
+++ b/typescript/packages/fulfillment/src/channels/atomic-http/index.ts
@@ -1,0 +1,54 @@
+// Atomic HTTP fulfillment channel.
+//
+// The resource is returned in the same HTTP response that completes
+// the redeem. The buyer attaches no data (`buyerDataSchema: null`);
+// the server resolves the body at redeem time via the configured
+// `resolve(exchangeId)` callback.
+//
+// See docs/boson-impl-03-fulfillment-channels.md for the registry entry.
+
+import type { FulfillmentChannel, FulfillmentOptionDescriptor } from "../../types.js";
+
+export const ATOMIC_HTTP_CHANNEL_ID = "atomic-http";
+
+export interface AtomicHttpServerCfg {
+  /** Server-side resolver invoked from `onRedeem`. */
+  resolve: (exchangeId: string) => Promise<{ body: Uint8Array; contentType: string }>;
+}
+
+export type AtomicHttpChannel = FulfillmentChannel<AtomicHttpServerCfg, null>;
+
+export function createAtomicHttpChannel(initialCfg?: AtomicHttpServerCfg): AtomicHttpChannel {
+  let cfg: AtomicHttpServerCfg | undefined = initialCfg;
+
+  const descriptor: FulfillmentOptionDescriptor = {
+    id: ATOMIC_HTTP_CHANNEL_ID,
+    schema: null,
+  };
+
+  return {
+    id: ATOMIC_HTTP_CHANNEL_ID,
+    buyerDataSchema: null,
+    configure(next) {
+      cfg = next;
+    },
+    describe() {
+      return descriptor;
+    },
+    validate(data) {
+      return data === null
+        ? { ok: true }
+        : { ok: false, reason: "atomic-http accepts no buyer data" };
+    },
+    async onCommit() {
+      // Nothing to persist — the buyer attaches no data.
+    },
+    async onRedeem(exchangeId) {
+      if (!cfg) {
+        throw new Error("atomic-http channel: configure({ resolve }) before invoking onRedeem");
+      }
+      const { body, contentType } = await cfg.resolve(exchangeId);
+      return { kind: "atomic", body, contentType };
+    },
+  };
+}

--- a/typescript/packages/fulfillment/test/channels/atomic-http.test.ts
+++ b/typescript/packages/fulfillment/test/channels/atomic-http.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAtomicHttpChannel } from "../../src/channels/atomic-http/index.js";
+
+const encoder = new TextEncoder();
+
+describe("atomic-http channel", () => {
+  it("describes itself with a null schema", () => {
+    const channel = createAtomicHttpChannel();
+    expect(channel.describe()).toEqual({ id: "atomic-http", schema: null });
+    expect(channel.buyerDataSchema).toBeNull();
+  });
+
+  it("validates only null buyer data", () => {
+    const channel = createAtomicHttpChannel();
+    expect(channel.validate(null)).toEqual({ ok: true });
+    expect(channel.validate({} as never)).toMatchObject({ ok: false });
+    expect(channel.validate("anything" as never)).toMatchObject({ ok: false });
+  });
+
+  it("onRedeem returns the body resolved by the configured resolver", async () => {
+    const body = encoder.encode("hello");
+    const resolve = vi.fn().mockResolvedValue({ body, contentType: "text/plain" });
+    const channel = createAtomicHttpChannel({ resolve });
+
+    await expect(channel.onRedeem("exch-1")).resolves.toEqual({
+      kind: "atomic",
+      body,
+      contentType: "text/plain",
+    });
+    expect(resolve).toHaveBeenCalledWith("exch-1");
+  });
+
+  it("supports late configuration via configure()", async () => {
+    const channel = createAtomicHttpChannel();
+    const body = encoder.encode("late");
+    channel.configure({
+      resolve: async () => ({ body, contentType: "application/octet-stream" }),
+    });
+    const result = await channel.onRedeem("exch-2");
+    expect(result).toEqual({
+      kind: "atomic",
+      body,
+      contentType: "application/octet-stream",
+    });
+  });
+
+  it("onRedeem rejects when not configured", async () => {
+    const channel = createAtomicHttpChannel();
+    await expect(channel.onRedeem("exch-3")).rejects.toThrow(/configure/);
+  });
+
+  it("onCommit is a no-op", async () => {
+    const channel = createAtomicHttpChannel();
+    await expect(channel.onCommit("exch-1", null)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the `atomic-http` fulfillment channel to `@bosonprotocol/x402-fulfillment` under the new `./channels/atomic-http` subpath.
- Schemaless — the buyer attaches no data; `validate` accepts only `null`.
- `onRedeem` invokes the server-supplied `resolve(exchangeId)` callback and returns the body in-band as a `{ kind: "atomic" }` result.
- Throws if `onRedeem` runs before the channel is configured.

## Test plan

- [x] `pnpm build` — `dist/cjs/channels/atomic-http/index.d.ts` emitted.
- [x] `pnpm test` — 6 channel tests cover descriptor shape, validation, `onRedeem` round-trip, late configuration, unconfigured rejection, no-op `onCommit`.
- [x] `pnpm lint` — clean.
- [x] `pnpm format:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)