### PR TITLE
feat(fulfillment): add email channel

### DIFF
--- a/.changeset/add-email-channel.md
+++ b/.changeset/add-email-channel.md
@@ -1,0 +1,10 @@
+---
+"@bosonprotocol/x402-fulfillment": minor
+---
+
+Add the `email` fulfillment channel: buyer attaches `{ email: string }`
+at commit; the server stores it against the exchange id and dispatches
+through the configured `send(exchangeId, data)` hook at redeem time
+(returning a `mailto:` pointer). zod is the runtime source of truth;
+the JSON Schema surfaced on `describe()` is derived via
+`zod-to-json-schema`. Exposed via the `./channels/email` subpath.

--- a/typescript/packages/fulfillment/src/channels/email/index.ts
+++ b/typescript/packages/fulfillment/src/channels/email/index.ts
@@ -1,0 +1,74 @@
+// `email` fulfillment channel.
+//
+// Buyer attaches `{ email: string }` at commit; the server stores it
+// against the exchange id and dispatches a (license key, mailing list
+// confirmation, etc.) through the configured `send` hook at redeem
+// time.
+//
+// `send` is intentionally an injection point — this package does not
+// own SMTP / SES / SendGrid wiring; the server SDK provides a real
+// transport.
+//
+// See docs/boson-impl-03-fulfillment-channels.md for the registry entry.
+
+import type { JSONSchema7 } from "json-schema";
+
+import type { FulfillmentChannel } from "../../types.js";
+import { emailBuyerDataJsonSchema, emailBuyerDataSchema, type EmailBuyerData } from "./schema.js";
+
+export const EMAIL_CHANNEL_ID = "email";
+
+export interface EmailServerCfg {
+  /** Persist `exchangeId → buyerData`. Defaults to an in-memory `Map`. */
+  store?: Map<string, EmailBuyerData>;
+  /** Server-side hook invoked from `onRedeem`. */
+  send: (exchangeId: string, data: EmailBuyerData) => Promise<void>;
+  /** Optional descriptor metadata (e.g. sender display name) surfaced on the 402. */
+  metadata?: unknown;
+}
+
+export type EmailChannel = FulfillmentChannel<EmailServerCfg, EmailBuyerData>;
+
+export type { EmailBuyerData } from "./schema.js";
+export { emailBuyerDataJsonSchema, emailBuyerDataSchema } from "./schema.js";
+
+export function createEmailChannel(initialCfg?: EmailServerCfg): EmailChannel {
+  let cfg: EmailServerCfg | undefined = initialCfg;
+  let store: Map<string, EmailBuyerData> = initialCfg?.store ?? new Map();
+
+  return {
+    id: EMAIL_CHANNEL_ID,
+    buyerDataSchema: emailBuyerDataJsonSchema as JSONSchema7,
+    configure(next) {
+      cfg = next;
+      store = next.store ?? new Map();
+    },
+    describe() {
+      return {
+        id: EMAIL_CHANNEL_ID,
+        schema: emailBuyerDataJsonSchema,
+        ...(cfg?.metadata !== undefined ? { metadata: cfg.metadata } : {}),
+      };
+    },
+    validate(data) {
+      const result = emailBuyerDataSchema.safeParse(data);
+      return result.success
+        ? { ok: true }
+        : { ok: false, reason: result.error.issues[0]?.message ?? "invalid email data" };
+    },
+    async onCommit(exchangeId, data) {
+      store.set(exchangeId, data);
+    },
+    async onRedeem(exchangeId) {
+      if (!cfg) {
+        throw new Error("email channel: configure({ send }) before invoking onRedeem");
+      }
+      const data = store.get(exchangeId);
+      if (!data) {
+        throw new Error(`email channel: no buyer data stored for exchange ${exchangeId}`);
+      }
+      await cfg.send(exchangeId, data);
+      return { kind: "async", pointer: `mailto:${data.email}` };
+    },
+  };
+}

--- a/typescript/packages/fulfillment/src/channels/email/schema.ts
+++ b/typescript/packages/fulfillment/src/channels/email/schema.ts
@@ -1,0 +1,21 @@
+// Buyer-data schema for the `email` fulfillment channel.
+//
+// zod is the source of truth (used at runtime for `validate`); the
+// JSON-Schema artifact is derived once via `zod-to-json-schema` and
+// surfaced on `describe()` so it travels in the 402 response.
+
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const emailBuyerDataSchema = z
+  .object({
+    email: z.string().email(),
+  })
+  .strict();
+
+export type EmailBuyerData = z.infer<typeof emailBuyerDataSchema>;
+
+export const emailBuyerDataJsonSchema = zodToJsonSchema(emailBuyerDataSchema, {
+  $refStrategy: "none",
+  target: "jsonSchema7",
+}) as Record<string, unknown>;

--- a/typescript/packages/fulfillment/test/channels/email.test.ts
+++ b/typescript/packages/fulfillment/test/channels/email.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createEmailChannel, type EmailBuyerData } from "../../src/channels/email/index.js";
+
+describe("email channel", () => {
+  it("describes itself with a JSON-Schema-shaped buyer data schema", () => {
+    const channel = createEmailChannel();
+    const descriptor = channel.describe();
+    expect(descriptor.id).toBe("email");
+    expect(descriptor.schema).toMatchObject({
+      type: "object",
+      properties: { email: { type: "string", format: "email" } },
+      required: ["email"],
+      additionalProperties: false,
+    });
+  });
+
+  it("surfaces optional descriptor metadata when configured", () => {
+    const channel = createEmailChannel({
+      send: async () => {},
+      metadata: { from: "shop@example.com" },
+    });
+    expect(channel.describe().metadata).toEqual({ from: "shop@example.com" });
+  });
+
+  it("validates well-formed emails and rejects garbage", () => {
+    const channel = createEmailChannel();
+    expect(channel.validate({ email: "buyer@example.com" })).toEqual({ ok: true });
+    const bad = channel.validate({ email: "not-an-email" } as EmailBuyerData);
+    expect(bad).toMatchObject({ ok: false });
+    expect(channel.validate({} as EmailBuyerData)).toMatchObject({ ok: false });
+    expect(channel.validate({ email: "x@y.z", extra: 1 } as never)).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("onCommit stores by exchange id; onRedeem invokes send and returns a mailto pointer", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const channel = createEmailChannel({ send });
+
+    await channel.onCommit("exch-1", { email: "buyer@example.com" });
+    const result = await channel.onRedeem("exch-1");
+
+    expect(send).toHaveBeenCalledWith("exch-1", { email: "buyer@example.com" });
+    expect(result).toEqual({ kind: "async", pointer: "mailto:buyer@example.com" });
+  });
+
+  it("supports a caller-supplied store", async () => {
+    const store = new Map<string, EmailBuyerData>();
+    const channel = createEmailChannel({ send: async () => {}, store });
+
+    await channel.onCommit("exch-2", { email: "x@y.z" });
+    expect(store.get("exch-2")).toEqual({ email: "x@y.z" });
+  });
+
+  it("onRedeem rejects when not configured", async () => {
+    const channel = createEmailChannel();
+    await expect(channel.onRedeem("exch-1")).rejects.toThrow(/configure/);
+  });
+
+  it("onRedeem rejects when no commit data exists for the exchange", async () => {
+    const channel = createEmailChannel({ send: async () => {} });
+    await expect(channel.onRedeem("nonexistent")).rejects.toThrow(/no buyer data/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the `email` fulfillment channel to `@bosonprotocol/x402-fulfillment` under the new `./channels/email` subpath.
- Buyer attaches `{ email: string }` at commit; the server stores it against the exchange id (caller-supplied or default in-memory `Map`) and dispatches through the configured `send(exchangeId, data)` hook at redeem time, returning a `mailto:<email>` async pointer.
- zod is the runtime source of truth for validation; the JSON Schema surfaced on `describe()` is derived once via `zod-to-json-schema`. `strict()` rejects unknown keys.
- Transport (`send`) is an injection point — this package does not own SMTP/SES/SendGrid wiring; the server SDK provides the real transport.

## Test plan

- [x] `pnpm build` — `dist/cjs/channels/email/index.d.ts` emitted.
- [x] `pnpm test` — 7 channel tests cover descriptor JSON-Schema shape, optional metadata, validate happy/sad/missing/strict-extra paths, store + send round-trip, custom store, unconfigured/missing-data error paths.
- [x] `pnpm lint` — clean.
- [x] `pnpm format:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)