### PR TITLE
feat(fulfillment): add xmtp channel; expose core validators

### DIFF
--- a/.changeset/add-xmtp-channel.md
+++ b/.changeset/add-xmtp-channel.md
@@ -1,0 +1,11 @@
+---
+"@bosonprotocol/x402-fulfillment": minor
+---
+
+Add the `xmtp` fulfillment channel: buyer attaches
+`{ xmtpAddress: <0x…> }` at commit; the server stores it against the
+exchange id and pushes the delivery to the buyer's XMTP inbox at
+redeem time via the configured `send(exchangeId, data)` hook
+(returning an `xmtp:<address>` pointer). Reuses `addressSchema` from
+`@bosonprotocol/x402-core/schemes/escrow` for the validation rule.
+Exposed via the `./channels/xmtp` subpath.

--- a/.changeset/expose-escrow-validators.md
+++ b/.changeset/expose-escrow-validators.md
@@ -1,0 +1,9 @@
+---
+"@bosonprotocol/x402-core": minor
+---
+
+Re-export the regex/zod scalar validators (`addressSchema`,
+`hexSchema`, `hexBytesSchema`, `hex32Schema`, `decimalUintSchema`,
+`evmNetworkSchema` and their underlying `RegExp` constants) from
+`@bosonprotocol/x402-core/schemes/escrow`. Downstream packages can
+reuse them instead of duplicating the regex.

--- a/typescript/packages/core/src/schemes/escrow/index.ts
+++ b/typescript/packages/core/src/schemes/escrow/index.ts
@@ -4,6 +4,7 @@
 export * from "./types.js";
 export * from "./payment-requirements.js";
 export * from "./payment-payload.js";
+export * from "./validators.js";
 
 /** Stable identifier for the scheme. Use this in place of the raw string `"escrow"` to avoid typos. */
 export const ESCROW_SCHEME = "escrow" as const;

--- a/typescript/packages/fulfillment/src/channels/xmtp/index.ts
+++ b/typescript/packages/fulfillment/src/channels/xmtp/index.ts
@@ -1,0 +1,71 @@
+// `xmtp` fulfillment channel.
+//
+// Buyer attaches `{ xmtpAddress: <0x…> }` at commit. The server stores
+// it against the exchange id and pushes the delivery payload to the
+// buyer's XMTP inbox at redeem time via the configured `send` hook.
+// Useful for AI-agent buyers that already use XMTP for commerce.
+//
+// `send` is an injection point — this package does not own the XMTP
+// client; the server SDK (or the agent runtime) provides one.
+
+import type { JSONSchema7 } from "json-schema";
+
+import type { FulfillmentChannel } from "../../types.js";
+import { xmtpBuyerDataJsonSchema, xmtpBuyerDataSchema, type XmtpBuyerData } from "./schema.js";
+
+export const XMTP_CHANNEL_ID = "xmtp";
+
+export interface XmtpServerCfg {
+  /** Persist `exchangeId → buyerData`. Defaults to an in-memory `Map`. */
+  store?: Map<string, XmtpBuyerData>;
+  /** Server-side hook invoked from `onRedeem`. */
+  send: (exchangeId: string, data: XmtpBuyerData) => Promise<void>;
+  /** Optional descriptor metadata (e.g. seller XMTP address) surfaced on the 402. */
+  metadata?: unknown;
+}
+
+export type XmtpChannel = FulfillmentChannel<XmtpServerCfg, XmtpBuyerData>;
+
+export type { XmtpBuyerData } from "./schema.js";
+export { xmtpBuyerDataJsonSchema, xmtpBuyerDataSchema } from "./schema.js";
+
+export function createXmtpChannel(initialCfg?: XmtpServerCfg): XmtpChannel {
+  let cfg: XmtpServerCfg | undefined = initialCfg;
+  let store: Map<string, XmtpBuyerData> = initialCfg?.store ?? new Map();
+
+  return {
+    id: XMTP_CHANNEL_ID,
+    buyerDataSchema: xmtpBuyerDataJsonSchema as JSONSchema7,
+    configure(next) {
+      cfg = next;
+      store = next.store ?? new Map();
+    },
+    describe() {
+      return {
+        id: XMTP_CHANNEL_ID,
+        schema: xmtpBuyerDataJsonSchema,
+        ...(cfg?.metadata !== undefined ? { metadata: cfg.metadata } : {}),
+      };
+    },
+    validate(data) {
+      const result = xmtpBuyerDataSchema.safeParse(data);
+      return result.success
+        ? { ok: true }
+        : { ok: false, reason: result.error.issues[0]?.message ?? "invalid xmtp data" };
+    },
+    async onCommit(exchangeId, data) {
+      store.set(exchangeId, data);
+    },
+    async onRedeem(exchangeId) {
+      if (!cfg) {
+        throw new Error("xmtp channel: configure({ send }) before invoking onRedeem");
+      }
+      const data = store.get(exchangeId);
+      if (!data) {
+        throw new Error(`xmtp channel: no buyer data stored for exchange ${exchangeId}`);
+      }
+      await cfg.send(exchangeId, data);
+      return { kind: "async", pointer: `xmtp:${data.xmtpAddress}` };
+    },
+  };
+}

--- a/typescript/packages/fulfillment/src/channels/xmtp/schema.ts
+++ b/typescript/packages/fulfillment/src/channels/xmtp/schema.ts
@@ -1,0 +1,21 @@
+// Buyer-data schema for the `xmtp` fulfillment channel.
+//
+// Reuses the EVM `addressSchema` from `@bosonprotocol/x402-core/schemes/escrow`
+// so the address validation rule stays in one place.
+
+import { addressSchema } from "@bosonprotocol/x402-core/schemes/escrow";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const xmtpBuyerDataSchema = z
+  .object({
+    xmtpAddress: addressSchema,
+  })
+  .strict();
+
+export type XmtpBuyerData = z.infer<typeof xmtpBuyerDataSchema>;
+
+export const xmtpBuyerDataJsonSchema = zodToJsonSchema(xmtpBuyerDataSchema, {
+  $refStrategy: "none",
+  target: "jsonSchema7",
+}) as Record<string, unknown>;

--- a/typescript/packages/fulfillment/test/channels/xmtp.test.ts
+++ b/typescript/packages/fulfillment/test/channels/xmtp.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createXmtpChannel, type XmtpBuyerData } from "../../src/channels/xmtp/index.js";
+
+const VALID_ADDRESS = "0x1234567890abcdefABCDEF1234567890abcdef12";
+
+describe("xmtp channel", () => {
+  it("describes itself with a JSON-Schema-shaped buyer data schema", () => {
+    const channel = createXmtpChannel();
+    const descriptor = channel.describe();
+    expect(descriptor.id).toBe("xmtp");
+    expect(descriptor.schema).toMatchObject({
+      type: "object",
+      properties: { xmtpAddress: { type: "string" } },
+      required: ["xmtpAddress"],
+      additionalProperties: false,
+    });
+  });
+
+  it("surfaces optional descriptor metadata when configured", () => {
+    const channel = createXmtpChannel({
+      send: async () => {},
+      metadata: { sellerXmtp: VALID_ADDRESS },
+    });
+    expect(channel.describe().metadata).toEqual({ sellerXmtp: VALID_ADDRESS });
+  });
+
+  it("validates 0x-prefixed 20-byte addresses and rejects malformed inputs", () => {
+    const channel = createXmtpChannel();
+    expect(channel.validate({ xmtpAddress: VALID_ADDRESS })).toEqual({ ok: true });
+    expect(channel.validate({ xmtpAddress: VALID_ADDRESS.toLowerCase() })).toEqual({ ok: true });
+
+    expect(channel.validate({ xmtpAddress: "0xnothex" } as XmtpBuyerData)).toMatchObject({
+      ok: false,
+    });
+    expect(channel.validate({ xmtpAddress: "0x1234" } as XmtpBuyerData)).toMatchObject({
+      ok: false,
+    });
+    expect(channel.validate({} as XmtpBuyerData)).toMatchObject({ ok: false });
+    expect(channel.validate({ xmtpAddress: VALID_ADDRESS, extra: 1 } as never)).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("onCommit stores by exchange id; onRedeem invokes send and returns an xmtp: pointer", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const channel = createXmtpChannel({ send });
+
+    await channel.onCommit("exch-1", { xmtpAddress: VALID_ADDRESS });
+    const result = await channel.onRedeem("exch-1");
+
+    expect(send).toHaveBeenCalledWith("exch-1", { xmtpAddress: VALID_ADDRESS });
+    expect(result).toEqual({ kind: "async", pointer: `xmtp:${VALID_ADDRESS}` });
+  });
+
+  it("supports a caller-supplied store", async () => {
+    const store = new Map<string, XmtpBuyerData>();
+    const channel = createXmtpChannel({ send: async () => {}, store });
+
+    await channel.onCommit("exch-2", { xmtpAddress: VALID_ADDRESS });
+    expect(store.get("exch-2")).toEqual({ xmtpAddress: VALID_ADDRESS });
+  });
+
+  it("onRedeem rejects when not configured", async () => {
+    const channel = createXmtpChannel();
+    await expect(channel.onRedeem("exch-1")).rejects.toThrow(/configure/);
+  });
+
+  it("onRedeem rejects when no commit data exists for the exchange", async () => {
+    const channel = createXmtpChannel({ send: async () => {} });
+    await expect(channel.onRedeem("nonexistent")).rejects.toThrow(/no buyer data/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the `xmtp` fulfillment channel to `@bosonprotocol/x402-fulfillment` under the new `./channels/xmtp` subpath. Buyer attaches `{ xmtpAddress: <0x…> }` at commit; server stores it against the exchange id and pushes delivery to the buyer's XMTP inbox at redeem time via the configured `send(exchangeId, data)` hook, returning an `xmtp:<address>` async pointer.
- Surfaces the existing regex / zod scalar validators (`addressSchema`, `hexSchema`, `hex32Schema`, `hexBytesSchema`, `decimalUintSchema`, `evmNetworkSchema`, and the underlying `RegExp` constants) on `@bosonprotocol/x402-core/schemes/escrow`'s public exports so downstream packages can reuse them instead of duplicating regex.

## Test plan

- [x] `pnpm build` — both packages build, `dist/cjs/channels/xmtp/index.d.ts` emitted.
- [x] `pnpm test` — 7 channel tests cover descriptor JSON-Schema shape, optional metadata, valid checksummed/lowercase addresses, malformed-address rejection, store + send round-trip, custom store, unconfigured/missing-data error paths.
- [x] `pnpm lint` — clean.
- [x] `pnpm format:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)