### PR TITLE
feat(fulfillment): add webhook channel with layered endpoint protection

### DIFF
--- a/.changeset/add-webhook-channel.md
+++ b/.changeset/add-webhook-channel.md
@@ -1,0 +1,18 @@
+---
+"@bosonprotocol/x402-fulfillment": minor
+---
+
+Add the `webhook` fulfillment channel: buyer attaches
+`{ url, authToken?, encryptionPubKey? }` at commit (https endpoints
+only). The server stores the record against the exchange id and
+dispatches via the configured `send(exchangeId, data)` hook at redeem
+time, returning the buyer's url as the async pointer.
+
+Buyer-side endpoint protection has three layers — server-signed
+envelopes (always on, via `metadata.serverPublicKey`), an optional
+bearer `authToken` the server sends as `Authorization: Bearer …`,
+and an optional `encryptionPubKey` for the future cipher specced
+under `03b-webhook-encryption.md`. See the new "Webhook security"
+section in `docs/boson-impl-03-fulfillment-channels.md`.
+
+Exposed via the `./channels/webhook` subpath.

--- a/docs/boson-impl-03-fulfillment-channels.md
+++ b/docs/boson-impl-03-fulfillment-channels.md
@@ -85,7 +85,7 @@ export type FulfillmentResult =
 | `atomic-http` | Resource returned in same HTTP response | `null` | Server `onRedeem` returns the body. Composes naturally with Flow B's atomic commit-and-redeem (the resource is ready), but Flow B does **not** require this channel — the redeem state transition can be atomic while delivery itself is async. |
 | `email` | Mailing list signup, license key dispatch | `{ email: string }` | RFC 5321 validation. Server stores against exchangeId; sends on redeem. |
 | `xmtp` | Push to buyer's XMTP inbox | `{ xmtpAddress: string }` (EOA) | Useful for AI-agent buyers that already use XMTP for commerce. |
-| `webhook` | Push to buyer-controlled HTTPS endpoint | `{ url: string, publicKey: string }` | Server signs the payload with a key under `metadata.serverPublicKey`; client verifies signature. |
+| `webhook` | Push to buyer-controlled HTTPS endpoint | `{ url: string, authToken?: string, encryptionPubKey?: string }` | See [Webhook security](#webhook-security) below. Server signs the envelope with the key under `metadata.serverPublicKey`; client verifies signature. |
 | `ipfs-pointer` | Server uploads to IPFS, returns CID | `{ recipientPubKey?: string }` | Optional encryption to recipientPubKey. Returned on redeem. |
 | `widget` | Human buyer + physical goods (existing Boson Redemption Widget) | `null` (collected by widget) | `metadata.widgetUrl` points the human to the existing redemption widget. The widget's existing backend hook is reused unchanged. |
 | `mcp` | AI-agent buyer drives a server-exposed MCP tool | `{ mcpEndpoint?: string }` | The seller's MCP exposes a `submit_fulfillment_data(exchangeId, ...)` tool. The buyer's agent calls it post-commit. |
@@ -105,8 +105,18 @@ Servers SHOULD advertise at least one "in-payload" fulfillment channel (email/xm
 ## Privacy considerations
 
 - `fulfillment.data` is stored server-side keyed by exchangeId. Servers MUST NOT include it in any unauthenticated channel.
-- For `webhook`, the buyer's `publicKey` MAY be used to encrypt the resource payload (out of scope for v1; specced in `03b-webhook-encryption.md` later).
+- For `webhook`, the buyer's `encryptionPubKey` MAY be used to encrypt the resource payload (out of scope for v1; specced in `03b-webhook-encryption.md` later).
 - Sellers should expose a deletion endpoint per their privacy policy; not in the protocol.
+
+## Webhook security
+
+The `webhook` channel hands the seller a buyer-controlled HTTPS URL — the buyer's endpoint can become a target as soon as the URL is known. The protocol layers three independent protections; the buyer SHOULD use all three:
+
+1. **Server signature (always on).** The seller signs every webhook envelope with the key advertised under `metadata.serverPublicKey`. The envelope MUST include the `exchangeId` and a millisecond `timestamp`. The buyer MUST verify the signature, MUST reject envelopes whose `timestamp` is older than a small freshness window (recommended: ≤ 300 s), and MUST treat repeated deliveries with the same `exchangeId` as idempotent (one logical delivery, dedupe on the buyer's side).
+2. **Bearer token (optional, buyer-published).** When the buyer sets `authToken`, the seller MUST send it as `Authorization: Bearer <authToken>` on every webhook request. This lets the buyer's edge layer reject unauthenticated traffic before any signature work — useful against random POSTers and leaked-URL scanning. The token travels in the X-PAYMENT, so it offers no protection against an attacker who can read the X-PAYMENT itself; pair it with (1) for end-to-end authenticity.
+3. **Encryption to buyer (optional, buyer-published).** When the buyer sets `encryptionPubKey`, the seller MAY encrypt the resource body to that key (cipher specced under `03b-webhook-encryption.md`; not yet implemented). Protects confidentiality against any actor with the URL but without the buyer's private key.
+
+Seller adapters MUST refuse plain `http://` URLs — TLS is mandatory for the transport. Buyers SHOULD also rotate `authToken` per offer / per session if the same endpoint is reused across many exchanges.
 
 ## Validation rules (server side, before /verify)
 

--- a/typescript/packages/fulfillment/src/channels/webhook/index.ts
+++ b/typescript/packages/fulfillment/src/channels/webhook/index.ts
@@ -1,0 +1,86 @@
+// `webhook` fulfillment channel.
+//
+// Buyer attaches `{ url, authToken?, encryptionPubKey? }` at commit.
+// The server stores the record against the exchange id and POSTs the
+// delivered resource (or a pointer) to `url` at redeem time via the
+// configured `send` hook. Returns the buyer's `url` as the async
+// pointer.
+//
+// Buyer-side endpoint protection is layered:
+// - The server always signs the delivery envelope with
+//   `metadata.serverPublicKey` (see the channel registry in
+//   `docs/boson-impl-03-fulfillment-channels.md`); the buyer is
+//   expected to verify the signature, timestamp freshness, and
+//   idempotency on `exchangeId`.
+// - `authToken` (optional) is included by the server as
+//   `Authorization: Bearer <token>` so the buyer's endpoint can
+//   cheaply reject unauthenticated traffic before parsing the
+//   envelope.
+// - `encryptionPubKey` (optional) is persisted for the future
+//   `03b-webhook-encryption.md` cipher.
+
+import type { JSONSchema7 } from "json-schema";
+
+import type { FulfillmentChannel } from "../../types.js";
+import {
+  webhookBuyerDataJsonSchema,
+  webhookBuyerDataSchema,
+  type WebhookBuyerData,
+} from "./schema.js";
+
+export const WEBHOOK_CHANNEL_ID = "webhook";
+
+export interface WebhookServerCfg {
+  /** Persist `exchangeId → buyerData`. Defaults to an in-memory `Map`. */
+  store?: Map<string, WebhookBuyerData>;
+  /** Server-side hook invoked from `onRedeem`. */
+  send: (exchangeId: string, data: WebhookBuyerData) => Promise<void>;
+  /** Optional descriptor metadata (e.g. server's signing key) surfaced on the 402. */
+  metadata?: unknown;
+}
+
+export type WebhookChannel = FulfillmentChannel<WebhookServerCfg, WebhookBuyerData>;
+
+export type { WebhookBuyerData } from "./schema.js";
+export { webhookBuyerDataJsonSchema, webhookBuyerDataSchema } from "./schema.js";
+
+export function createWebhookChannel(initialCfg?: WebhookServerCfg): WebhookChannel {
+  let cfg: WebhookServerCfg | undefined = initialCfg;
+  let store: Map<string, WebhookBuyerData> = initialCfg?.store ?? new Map();
+
+  return {
+    id: WEBHOOK_CHANNEL_ID,
+    buyerDataSchema: webhookBuyerDataJsonSchema as JSONSchema7,
+    configure(next) {
+      cfg = next;
+      store = next.store ?? new Map();
+    },
+    describe() {
+      return {
+        id: WEBHOOK_CHANNEL_ID,
+        schema: webhookBuyerDataJsonSchema,
+        ...(cfg?.metadata !== undefined ? { metadata: cfg.metadata } : {}),
+      };
+    },
+    validate(data) {
+      const result = webhookBuyerDataSchema.safeParse(data);
+      return result.success
+        ? { ok: true }
+        : { ok: false, reason: result.error.issues[0]?.message ?? "invalid webhook data" };
+    },
+    async onCommit(exchangeId, data) {
+      store.set(exchangeId, data);
+    },
+    async onRedeem(exchangeId) {
+      if (!cfg) {
+        throw new Error("webhook channel: configure({ send }) before invoking onRedeem");
+      }
+      const data = store.get(exchangeId);
+      if (!data) {
+        throw new Error(`webhook channel: no buyer data stored for exchange ${exchangeId}`);
+      }
+      await cfg.send(exchangeId, data);
+      return { kind: "async", pointer: data.url };
+    },
+  };
+}

--- a/typescript/packages/fulfillment/src/channels/webhook/schema.ts
+++ b/typescript/packages/fulfillment/src/channels/webhook/schema.ts
@@ -1,0 +1,47 @@
+// Buyer-data schema for the `webhook` fulfillment channel.
+//
+// Required:
+// - `url`: https endpoint the server POSTs the delivery to. Plaintext
+//   http is rejected — the channel transports the resource (or a
+//   pointer to it) so confidentiality at the transport layer is not
+//   negotiable.
+//
+// Optional buyer-side endpoint-protection fields:
+// - `authToken`: opaque bearer token. The server-side adapter includes
+//   it as `Authorization: Bearer <authToken>`. Lets the buyer's
+//   endpoint cheaply reject unauthenticated traffic without verifying
+//   the signed envelope. Industry-standard webhook auth (Stripe,
+//   GitHub, Slack, Twilio).
+// - `encryptionPubKey`: buyer-published encryption key. The server MAY
+//   encrypt the resource body to this key. The cipher itself is
+//   specced separately under `03b-webhook-encryption.md` and is not
+//   yet implemented; the field is persisted today so server-side
+//   adapters can consume it once the cipher lands.
+//
+// Independent of these fields, the server signs every webhook
+// envelope with the key advertised under `metadata.serverPublicKey`
+// (see the channel registry in
+// `docs/boson-impl-03-fulfillment-channels.md`). The buyer is expected
+// to verify the signature, the timestamp freshness, and the
+// idempotency on `exchangeId`.
+
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const webhookBuyerDataSchema = z
+  .object({
+    url: z
+      .string()
+      .url()
+      .refine((u) => u.startsWith("https://"), { message: "url must be https://" }),
+    authToken: z.string().min(1).optional(),
+    encryptionPubKey: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type WebhookBuyerData = z.infer<typeof webhookBuyerDataSchema>;
+
+export const webhookBuyerDataJsonSchema = zodToJsonSchema(webhookBuyerDataSchema, {
+  $refStrategy: "none",
+  target: "jsonSchema7",
+}) as Record<string, unknown>;

--- a/typescript/packages/fulfillment/test/channels/webhook.test.ts
+++ b/typescript/packages/fulfillment/test/channels/webhook.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createWebhookChannel, type WebhookBuyerData } from "../../src/channels/webhook/index.js";
+
+const URL_HTTPS = "https://buyer.example.com/x402b/deliver";
+
+describe("webhook channel", () => {
+  it("describes itself with a JSON-Schema-shaped buyer data schema", () => {
+    const channel = createWebhookChannel();
+    const descriptor = channel.describe();
+    expect(descriptor.id).toBe("webhook");
+    expect(descriptor.schema).toMatchObject({
+      type: "object",
+      properties: {
+        url: { type: "string" },
+        authToken: { type: "string" },
+        encryptionPubKey: { type: "string" },
+      },
+      required: ["url"],
+      additionalProperties: false,
+    });
+  });
+
+  it("validates the minimal record (url only)", () => {
+    const channel = createWebhookChannel();
+    expect(channel.validate({ url: URL_HTTPS })).toEqual({ ok: true });
+  });
+
+  it("validates the full record (url + authToken + encryptionPubKey)", () => {
+    const channel = createWebhookChannel();
+    expect(
+      channel.validate({
+        url: URL_HTTPS,
+        authToken: "tkn-abc123",
+        encryptionPubKey: "0x04abcdef",
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("rejects http (non-tls) endpoints", () => {
+    const channel = createWebhookChannel();
+    expect(
+      channel.validate({ url: "http://buyer.example.com/x402b/deliver" } as WebhookBuyerData),
+    ).toMatchObject({ ok: false });
+  });
+
+  it("rejects malformed urls", () => {
+    const channel = createWebhookChannel();
+    expect(channel.validate({ url: "not-a-url" } as WebhookBuyerData)).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("rejects empty optional fields if present", () => {
+    const channel = createWebhookChannel();
+    expect(channel.validate({ url: URL_HTTPS, authToken: "" })).toMatchObject({ ok: false });
+    expect(channel.validate({ url: URL_HTTPS, encryptionPubKey: "" })).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("rejects extra keys (strict mode)", () => {
+    const channel = createWebhookChannel();
+    expect(channel.validate({ url: URL_HTTPS, extra: 1 } as never)).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("onCommit stores by exchange id; onRedeem invokes send and returns the buyer url as pointer", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const channel = createWebhookChannel({ send });
+    const data: WebhookBuyerData = { url: URL_HTTPS, authToken: "tkn" };
+
+    await channel.onCommit("exch-1", data);
+    const result = await channel.onRedeem("exch-1");
+
+    expect(send).toHaveBeenCalledWith("exch-1", data);
+    expect(result).toEqual({ kind: "async", pointer: URL_HTTPS });
+  });
+
+  it("supports a caller-supplied store", async () => {
+    const store = new Map<string, WebhookBuyerData>();
+    const channel = createWebhookChannel({ send: async () => {}, store });
+    const data: WebhookBuyerData = { url: URL_HTTPS };
+    await channel.onCommit("exch-2", data);
+    expect(store.get("exch-2")).toEqual(data);
+  });
+
+  it("onRedeem rejects when not configured", async () => {
+    const channel = createWebhookChannel();
+    await expect(channel.onRedeem("exch-1")).rejects.toThrow(/configure/);
+  });
+
+  it("onRedeem rejects when no commit data exists for the exchange", async () => {
+    const channel = createWebhookChannel({ send: async () => {} });
+    await expect(channel.onRedeem("nonexistent")).rejects.toThrow(/no buyer data/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the `webhook` fulfillment channel to `@bosonprotocol/x402-fulfillment` under the new `./channels/webhook` subpath.
- Buyer attaches `{ url, authToken?, encryptionPubKey? }` at commit (https endpoints only). The server stores the record against the exchange id and dispatches via the configured `send(exchangeId, data)` hook at redeem time, returning the buyer's url as the async pointer.
- Layered endpoint protection: server signature (always on, keyed to `metadata.serverPublicKey`) with required `exchangeId` + `timestamp` and idempotency on the buyer side; optional buyer-published bearer `authToken` the server sets as `Authorization: Bearer <token>`; optional `encryptionPubKey` reserved for the future `03b-webhook-encryption.md` cipher.

## Spec changes

`docs/boson-impl-03-fulfillment-channels.md`:

- Registry table row for `webhook` updated to the new buyer-data schema.
- Privacy-considerations bullet renamed `publicKey` → `encryptionPubKey` (semantic — it's for buyer-side decryption, not signing).
- New **Webhook security** section documenting the three protection layers and the threat-model trade-offs of each (server signature with freshness + idempotency, bearer token, encryption pubkey).

## Test plan

- [x] `pnpm build` — both packages build, `dist/cjs/channels/webhook/index.d.ts` emitted.
- [x] `pnpm test` — 11 webhook tests cover descriptor JSON-Schema shape, minimal-record, full-record, http rejection, malformed-url rejection, empty-optional rejection, strict-extra rejection, store + send round-trip, custom store, unconfigured/missing-data error paths.
- [x] `pnpm lint` — clean.
- [x] `pnpm format:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)