### PR TITLE
feat(fulfillment): add ipfs-pointer channel

### DIFF
--- a/.changeset/add-ipfs-pointer-channel.md
+++ b/.changeset/add-ipfs-pointer-channel.md
@@ -1,0 +1,11 @@
+---
+"@bosonprotocol/x402-fulfillment": minor
+---
+
+Add the `ipfs-pointer` fulfillment channel: buyer optionally attaches
+`{ recipientPubKey? }` at commit. The server stores the record
+against the exchange id and at redeem time hands it to the configured
+`upload(exchangeId, data)` hook (which is responsible for assembling
+the resource bytes, optionally encrypting to `recipientPubKey`, and
+returning the IPFS CID). The channel returns `ipfs://<cid>` as the
+async pointer. Exposed via the `./channels/ipfs-pointer` subpath.

--- a/typescript/packages/fulfillment/src/channels/ipfs-pointer/index.ts
+++ b/typescript/packages/fulfillment/src/channels/ipfs-pointer/index.ts
@@ -1,0 +1,81 @@
+// `ipfs-pointer` fulfillment channel.
+//
+// Buyer optionally attaches `{ recipientPubKey? }` at commit. The
+// server stores the record against the exchange id and, at redeem
+// time, hands it to the configured `upload` hook which is responsible
+// for assembling the resource bytes, optionally encrypting them to
+// `recipientPubKey`, and returning the resulting IPFS CID. The
+// channel returns `ipfs://<cid>` as the async pointer.
+//
+// `upload` is the injection point — this package does not own the
+// IPFS client, the resource source, or any cipher. The server SDK (or
+// a custom adapter) supplies a real implementation.
+
+import type { JSONSchema7 } from "json-schema";
+
+import type { FulfillmentChannel } from "../../types.js";
+import {
+  ipfsPointerBuyerDataJsonSchema,
+  ipfsPointerBuyerDataSchema,
+  type IpfsPointerBuyerData,
+} from "./schema.js";
+
+export const IPFS_POINTER_CHANNEL_ID = "ipfs-pointer";
+
+export interface IpfsPointerServerCfg {
+  /** Persist `exchangeId → buyerData`. Defaults to an in-memory `Map`. */
+  store?: Map<string, IpfsPointerBuyerData>;
+  /** Server-side hook invoked from `onRedeem`. Returns the IPFS CID (no `ipfs://` prefix). */
+  upload: (exchangeId: string, data: IpfsPointerBuyerData) => Promise<string>;
+  /** Optional descriptor metadata (e.g. gateway hint) surfaced on the 402. */
+  metadata?: unknown;
+}
+
+export type IpfsPointerChannel = FulfillmentChannel<IpfsPointerServerCfg, IpfsPointerBuyerData>;
+
+export type { IpfsPointerBuyerData } from "./schema.js";
+export { ipfsPointerBuyerDataJsonSchema, ipfsPointerBuyerDataSchema } from "./schema.js";
+
+export function createIpfsPointerChannel(initialCfg?: IpfsPointerServerCfg): IpfsPointerChannel {
+  let cfg: IpfsPointerServerCfg | undefined = initialCfg;
+  let store: Map<string, IpfsPointerBuyerData> = initialCfg?.store ?? new Map();
+
+  return {
+    id: IPFS_POINTER_CHANNEL_ID,
+    buyerDataSchema: ipfsPointerBuyerDataJsonSchema as JSONSchema7,
+    configure(next) {
+      cfg = next;
+      store = next.store ?? new Map();
+    },
+    describe() {
+      return {
+        id: IPFS_POINTER_CHANNEL_ID,
+        schema: ipfsPointerBuyerDataJsonSchema,
+        ...(cfg?.metadata !== undefined ? { metadata: cfg.metadata } : {}),
+      };
+    },
+    validate(data) {
+      const result = ipfsPointerBuyerDataSchema.safeParse(data);
+      return result.success
+        ? { ok: true }
+        : {
+            ok: false,
+            reason: result.error.issues[0]?.message ?? "invalid ipfs-pointer data",
+          };
+    },
+    async onCommit(exchangeId, data) {
+      store.set(exchangeId, data);
+    },
+    async onRedeem(exchangeId) {
+      if (!cfg) {
+        throw new Error("ipfs-pointer channel: configure({ upload }) before invoking onRedeem");
+      }
+      const data = store.get(exchangeId);
+      if (!data) {
+        throw new Error(`ipfs-pointer channel: no buyer data stored for exchange ${exchangeId}`);
+      }
+      const cid = await cfg.upload(exchangeId, data);
+      return { kind: "async", pointer: `ipfs://${cid}` };
+    },
+  };
+}

--- a/typescript/packages/fulfillment/src/channels/ipfs-pointer/schema.ts
+++ b/typescript/packages/fulfillment/src/channels/ipfs-pointer/schema.ts
@@ -1,0 +1,22 @@
+// Buyer-data schema for the `ipfs-pointer` fulfillment channel.
+//
+// The buyer optionally publishes a `recipientPubKey` the seller MAY
+// use to encrypt the uploaded body. The cipher is opaque to this
+// package — the value is just persisted alongside the exchange and
+// handed to the upload adapter at redeem time.
+
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const ipfsPointerBuyerDataSchema = z
+  .object({
+    recipientPubKey: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type IpfsPointerBuyerData = z.infer<typeof ipfsPointerBuyerDataSchema>;
+
+export const ipfsPointerBuyerDataJsonSchema = zodToJsonSchema(ipfsPointerBuyerDataSchema, {
+  $refStrategy: "none",
+  target: "jsonSchema7",
+}) as Record<string, unknown>;

--- a/typescript/packages/fulfillment/test/channels/ipfs-pointer.test.ts
+++ b/typescript/packages/fulfillment/test/channels/ipfs-pointer.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createIpfsPointerChannel,
+  type IpfsPointerBuyerData,
+} from "../../src/channels/ipfs-pointer/index.js";
+
+const CID = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+
+describe("ipfs-pointer channel", () => {
+  it("describes itself with a JSON-Schema-shaped buyer data schema", () => {
+    const channel = createIpfsPointerChannel();
+    const descriptor = channel.describe();
+    expect(descriptor.id).toBe("ipfs-pointer");
+    expect(descriptor.schema).toMatchObject({
+      type: "object",
+      properties: { recipientPubKey: { type: "string" } },
+      additionalProperties: false,
+    });
+    expect((descriptor.schema as { required?: string[] }).required).toBeUndefined();
+  });
+
+  it("surfaces optional descriptor metadata when configured", () => {
+    const channel = createIpfsPointerChannel({
+      upload: async () => CID,
+      metadata: { gateway: "https://w3s.link/ipfs/" },
+    });
+    expect(channel.describe().metadata).toEqual({ gateway: "https://w3s.link/ipfs/" });
+  });
+
+  it("validates with and without recipientPubKey", () => {
+    const channel = createIpfsPointerChannel();
+    expect(channel.validate({})).toEqual({ ok: true });
+    expect(channel.validate({ recipientPubKey: "0x04abcdef" })).toEqual({ ok: true });
+  });
+
+  it("rejects empty recipientPubKey when present", () => {
+    const channel = createIpfsPointerChannel();
+    expect(channel.validate({ recipientPubKey: "" })).toMatchObject({ ok: false });
+  });
+
+  it("rejects extra keys (strict mode)", () => {
+    const channel = createIpfsPointerChannel();
+    expect(channel.validate({ extra: 1 } as never)).toMatchObject({ ok: false });
+  });
+
+  it("onCommit stores by exchange id; onRedeem uploads and returns an ipfs:// pointer", async () => {
+    const upload = vi.fn().mockResolvedValue(CID);
+    const channel = createIpfsPointerChannel({ upload });
+    const data: IpfsPointerBuyerData = { recipientPubKey: "0x04abcdef" };
+
+    await channel.onCommit("exch-1", data);
+    const result = await channel.onRedeem("exch-1");
+
+    expect(upload).toHaveBeenCalledWith("exch-1", data);
+    expect(result).toEqual({ kind: "async", pointer: `ipfs://${CID}` });
+  });
+
+  it("onRedeem works with no recipientPubKey supplied", async () => {
+    const upload = vi.fn().mockResolvedValue(CID);
+    const channel = createIpfsPointerChannel({ upload });
+
+    await channel.onCommit("exch-2", {});
+    const result = await channel.onRedeem("exch-2");
+
+    expect(upload).toHaveBeenCalledWith("exch-2", {});
+    expect(result).toEqual({ kind: "async", pointer: `ipfs://${CID}` });
+  });
+
+  it("supports a caller-supplied store", async () => {
+    const store = new Map<string, IpfsPointerBuyerData>();
+    const channel = createIpfsPointerChannel({ upload: async () => CID, store });
+    await channel.onCommit("exch-3", { recipientPubKey: "0x04abcdef" });
+    expect(store.get("exch-3")).toEqual({ recipientPubKey: "0x04abcdef" });
+  });
+
+  it("onRedeem rejects when not configured", async () => {
+    const channel = createIpfsPointerChannel();
+    await expect(channel.onRedeem("exch-1")).rejects.toThrow(/configure/);
+  });
+
+  it("onRedeem rejects when no commit data exists for the exchange", async () => {
+    const channel = createIpfsPointerChannel({ upload: async () => CID });
+    await expect(channel.onRedeem("nonexistent")).rejects.toThrow(/no buyer data/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the `ipfs-pointer` fulfillment channel to `@bosonprotocol/x402-fulfillment` under the new `./channels/ipfs-pointer` subpath.
- Buyer optionally attaches `{ recipientPubKey? }` at commit. Server stores the record against the exchange id and at redeem time hands it to the configured `upload(exchangeId, data)` hook — which assembles the resource bytes, optionally encrypts to `recipientPubKey`, and returns the IPFS CID. The channel wraps the CID in `ipfs://<cid>` and returns it as the async pointer.
- The cipher and the IPFS client are intentionally injection points; the server SDK (or a custom adapter) supplies a real implementation.

## Test plan

- [x] `pnpm build` — `dist/cjs/channels/ipfs-pointer/index.d.ts` emitted.
- [x] `pnpm test` — 10 channel tests cover descriptor JSON-Schema shape (no `required`), optional metadata, with and without `recipientPubKey`, empty-pubkey rejection, strict-extra rejection, store + upload round-trip, custom store, unconfigured/missing-data error paths.
- [x] `pnpm lint` — clean.
- [x] `pnpm format:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)