### PR TITLE
feat(actions): derive next-actions envelope from state-machine

### DIFF
--- a/.changeset/derive-next-actions.md
+++ b/.changeset/derive-next-actions.md
@@ -1,0 +1,22 @@
+---
+"@bosonprotocol/x402-actions": minor
+"@bosonprotocol/x402-core": minor
+---
+
+Add `deriveNextActions` and `deriveInitialNextActions` to
+`@bosonprotocol/x402-actions` — pure envelope builders that read the
+client-invokable transitions from `x402-core`'s state-machine tables
+and stamp them with the seller's configured channels, endpoints, and
+optional deadlines.
+
+In `@bosonprotocol/x402-core`:
+
+- Add the post-commit `EscrowNextActions` type, its zod validator
+  (`escrowNextActionsSchema` / `parseEscrowNextActions`), and the JSON
+  Schema `next_actions.schema.json` (re-exported under
+  `./schemas/next_actions.schema.json`). The type and schema encode the
+  spec invariant that `state === DISPUTED` ↔ `disputeState` is present.
+- Extend the `NextAction` wire-format type and the
+  `payment_requirements.schema.json` `actions.next[]` items with an
+  optional ISO 8601 `deadline` field (relevant for
+  dispute-window-bounded actions).

--- a/.changeset/derive-next-actions.md
+++ b/.changeset/derive-next-actions.md
@@ -15,7 +15,8 @@ In `@bosonprotocol/x402-core`:
   (`escrowNextActionsSchema` / `parseEscrowNextActions`), and the JSON
   Schema `next_actions.schema.json` (re-exported under
   `./schemas/next_actions.schema.json`). The type and schema encode the
-  spec invariant that `state === DISPUTED` ↔ `disputeState` is present.
+  spec invariant that `exchangeState === DISPUTED` ↔ `disputeState` is
+  present.
 - Extend the `NextAction` wire-format type and the
   `payment_requirements.schema.json` `actions.next[]` items with an
   optional ISO 8601 `deadline` field (relevant for

--- a/docs/boson-impl-01-escrow-scheme.md
+++ b/docs/boson-impl-01-escrow-scheme.md
@@ -69,7 +69,12 @@ Trade-off: the `escrow` scheme is not registered with the x402 Foundation (yet).
           "onchainHints": {
             "escrow":           "0xDiamond...",
             "metaTxFacet":      "MetaTransactionsHandlerFacet",
-            "metaTxEntrypoint": "executeMetaTransactionWithTokenTransferAuthorization",
+            "metaTxEntrypoints": {
+              "none":    "executeMetaTransaction",
+              "erc3009": "executeMetaTransactionWithTokenTransferAuthorization",
+              "permit":  "executeMetaTransactionWithTokenTransferAuthorization",
+              "permit2": "executeMetaTransactionWithTokenTransferAuthorization"
+            },
             "actionFacets": {
               "boson-createOfferAndCommit":         "ExchangeCommitFacet",
               "boson-createOfferCommitAndRedeem":   "OrchestrationHandlerFacet2"
@@ -240,7 +245,12 @@ type:    MetaTransaction(
 
 `functionSignature` is the ABI encoding of the function parameters — including the `FullOffer` and the seller's signature, which echoes `requirements.offer.fullOffer` and `requirements.offer.sellerSig`.
 
-The protocol's existing meta-tx replay protection (`MetaTransactionsHandlerFacet.usedNonce[from][nonce]`) applies. The relayer (facilitator) submits via `executeMetaTransactionWithTokenTransferAuthorization`, which reuses this nonce scheme and additionally accepts a queue of token-transfer authorizations.
+The protocol's existing meta-tx replay protection (`MetaTransactionsHandlerFacet.usedNonce[from][nonce]`) applies. The relayer (facilitator) picks the entry point on `MetaTransactionsHandlerFacet` that matches the buyer's chosen `tokenAuthStrategy`:
+
+- `tokenAuthStrategy = "none"` — submit via the legacy `executeMetaTransaction` (BPIP-9). No token-transfer authorization queue is needed because the buyer has pre-approved the Diamond.
+- `tokenAuthStrategy = "erc3009"` / `"permit"` / `"permit2"` — submit via `executeMetaTransactionWithTokenTransferAuthorization` (BPIP-12), which reuses the same nonce scheme and additionally accepts a queue of token-transfer authorizations.
+
+Both entry points are advertised on the wire via `onchainHints.metaTxEntrypoints`, keyed by strategy.
 
 ### 4.3 Buyer — token-transfer authorization (BPIP-12)
 

--- a/docs/boson-impl-04-state-machine-and-next-actions.md
+++ b/docs/boson-impl-04-state-machine-and-next-actions.md
@@ -67,8 +67,8 @@ Example for an exchange that is `DISPUTED` with a dispute in `RESOLVING` — the
 ```jsonc
 "nextActions": {
   "exchangeId": "12345",                  // omitted on the initial 402
-  "state": "DISPUTED",                    // ExchangeState; omitted on the initial 402
-  "disputeState": "RESOLVING",            // DisputeState; present iff state === "DISPUTED"
+  "exchangeState": "DISPUTED",            // ExchangeState; omitted on the initial 402
+  "disputeState": "RESOLVING",            // DisputeState; present iff exchangeState === "DISPUTED"
   "next": [
     {
       "id": "boson-resolveDispute",
@@ -90,12 +90,21 @@ Example for an exchange that is `DISPUTED` with a dispute in `RESOLVING` — the
   ],
   "fallback": {
     "xmtp": "0xSellerXMTP...",
-    "mcp":  "boson://seller/12345",
+    "mcp":  "boson://exchange/12345",          // identifier within the Boson MCP (e.g. `bosonprotocol/agentic-commerce`)
     "onchainHints": {
-      "escrow":           "0xEscrow...",
-      "facet":            "DisputeHandlerFacet",  // varies per action
-      "metaTxFacet":      "MetaTransactionsHandlerFacet",
-      "metaTxEntrypoint": "executeMetaTransactionWithTokenTransferAuthorization"
+      "escrow":      "0xEscrow...",
+      "metaTxFacet": "MetaTransactionsHandlerFacet",
+      "metaTxEntrypoints": {                    // keyed by buyer's `tokenAuthStrategy`
+        "none":    "executeMetaTransaction",
+        "erc3009": "executeMetaTransactionWithTokenTransferAuthorization",
+        "permit":  "executeMetaTransactionWithTokenTransferAuthorization",
+        "permit2": "executeMetaTransactionWithTokenTransferAuthorization"
+      },
+      "actionFacets": {                          // facet hosting each emitted action
+        "boson-resolveDispute":  "DisputeHandlerFacet",
+        "boson-escalateDispute": "DisputeHandlerFacet",
+        "boson-retractDispute":  "DisputeHandlerFacet"
+      }
     }
   }
 }
@@ -146,7 +155,7 @@ A **channel** is a transport for invoking an action. The standard registry:
 | `server` | The seller's HTTP server exposes a convenience endpoint that wraps the on-chain call (and may notify the seller for context). | `POST <endpoints.server>` with action-specific body. |
 | `facilitator` | A third-party facilitator that submits on-chain on the buyer's behalf (gas-paying meta-tx). | `POST <facilitator>/x402B/<action>` per the facilitator's API (see [boson-impl-07-facilitator.md](./boson-impl-07-facilitator.md)). |
 | `onchain` | Direct on-chain submission. The buyer signs and submits the raw tx themselves. | `<facet>.<method>(...)` per `onchainHints`. |
-| `mcp` | The buyer's agent calls a Boson MCP tool (e.g. `bosonprotocol/agentic-commerce`). | MCP tool invocation; identifier in `fallback.mcp`. |
+| `mcp` | The buyer's agent dispatches against the **escrow's** MCP server (the Boson Protocol MCP, currently [`bosonprotocol/agentic-commerce`](https://github.com/bosonprotocol/agentic-commerce)) — one shared server across every Boson seller, not a per-seller endpoint. The seller-specific routing lives in `fallback.mcp` as a Boson-namespaced identifier the BosonMCP resolves. | MCP tool invocation against BosonMCP; identifier from `fallback.mcp`. |
 | `xmtp` | Out-of-band: the buyer messages the seller's XMTP inbox; the seller can act on behalf of the buyer for some actions, or simply acknowledge. | XMTP message to `fallback.xmtp` with structured payload. |
 
 `channels[]` ordering on the server response is the seller's *preferred* order, but the client SDK is free to override based on its own policy (e.g. AI-agent clients may always prefer `onchain` or `mcp`).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
@@ -94,10 +97,6 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
-
-  typescript/packages/core/dist/cjs: {}
-
-  typescript/packages/core/dist/esm: {}
 
   typescript/packages/fulfillment:
     dependencies:
@@ -129,10 +128,6 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
-
-  typescript/packages/fulfillment/dist/cjs: {}
-
-  typescript/packages/fulfillment/dist/esm: {}
 
 packages:
 
@@ -984,6 +979,14 @@ packages:
 
   aes-js@4.0.0-beta.5:
     resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -3006,6 +3009,10 @@ snapshots:
   acorn@8.16.0: {}
 
   aes-js@4.0.0-beta.5: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@6.15.0:
     dependencies:

--- a/typescript/packages/actions/src/derive.ts
+++ b/typescript/packages/actions/src/derive.ts
@@ -11,6 +11,7 @@
 
 import type {
   ActionsEnvelope,
+  ActionChannel,
   EscrowNextActions,
   NextAction,
 } from "@bosonprotocol/x402-core/schemes/escrow";
@@ -68,11 +69,15 @@ function buildEnvelope(
   decorations?: DeriveDecorations,
 ): ActionsEnvelope {
   const next: NextAction[] = actionIds.map((id) => {
-    const entry: NextAction = {
-      id,
-      channels: [...registry.channels],
-    };
     const serverEndpoint = registry.endpoints?.[id];
+    const channels = registry.channels.filter((channel) =>
+      isUsableChannel(channel, id, registry, serverEndpoint),
+    );
+    if (channels.length === 0) {
+      throw new Error(`No usable channel configured for action ${id}`);
+    }
+
+    const entry: NextAction = { id, channels };
     if (serverEndpoint !== undefined) {
       entry.endpoints = { server: serverEndpoint };
     }
@@ -83,17 +88,27 @@ function buildEnvelope(
     return entry;
   });
 
-  const envelope: ActionsEnvelope = { next };
-  // Re-emit the fallback block only when at least one sub-field is set so
-  // an empty `{}` doesn't leak onto the wire.
-  if (
-    registry.fallback.xmtp !== undefined ||
-    registry.fallback.mcp !== undefined ||
-    registry.fallback.onchainHints !== undefined
-  ) {
-    envelope.fallback = registry.fallback;
+  return { next, fallback: registry.fallback };
+}
+
+function isUsableChannel(
+  channel: ActionChannel,
+  actionId: ActionId,
+  registry: ChannelRegistry,
+  serverEndpoint: string | undefined,
+): boolean {
+  switch (channel) {
+    case "server":
+      return serverEndpoint !== undefined;
+    case "mcp":
+      return registry.fallback.mcp !== undefined;
+    case "xmtp":
+      return registry.fallback.xmtp !== undefined;
+    case "onchain":
+      return registry.fallback.onchainHints.actionFacets[actionId] !== undefined;
+    case "facilitator":
+      return true;
   }
-  return envelope;
 }
 
 function toClientState(input: DeriveNextActionsInput): ClientState {

--- a/typescript/packages/actions/src/derive.ts
+++ b/typescript/packages/actions/src/derive.ts
@@ -1,0 +1,152 @@
+// `deriveNextActions` — pure envelope builder.
+//
+// Reads the legal client-invokable transitions from
+// `@bosonprotocol/x402-core/state-machine`'s transition tables and
+// stamps them with the seller's configured channels, endpoints, and
+// deadlines. No I/O, no protocol calls — input is the client's
+// `(exchangeState, disputeState?)` tuple plus a `ChannelRegistry`.
+//
+// Source of truth: docs/boson-impl-04-state-machine-and-next-actions.md
+// §"Server-side derivation".
+
+import type {
+  ActionsEnvelope,
+  EscrowNextActions,
+  NextAction,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+import {
+  clientLegalActions,
+  ExchangeState,
+  PRE_COMMIT,
+  type ActionId,
+  type ClientState,
+  type DisputeState,
+} from "@bosonprotocol/x402-core/state-machine";
+
+import type { ChannelRegistry } from "./registry/index.js";
+
+/**
+ * Per-action input the caller may attach to override or augment what the
+ * envelope builder produces. Keys are stable action ids.
+ *
+ * - `deadlines` — ISO 8601 absolute timestamps. Useful when the caller
+ *   has the on-chain dispute / redemption-window timestamps from the
+ *   subgraph and wants the deadline math handled upstream rather than
+ *   re-derived inside the builder. Future revisions of this function
+ *   may compute deadlines from a richer `Exchange` argument directly,
+ *   at which point this field becomes redundant.
+ */
+export interface DeriveDecorations {
+  deadlines?: Partial<Record<ActionId, string>>;
+}
+
+/**
+ * The current client-state input to `deriveNextActions`. Mirrors the
+ * three top-level fields of `EscrowNextActions` (the post-commit
+ * envelope) so callers can pass an exchange snapshot directly. The
+ * field is named `exchangeState` (not `state`) for symmetry with
+ * `disputeState` and to remove ambiguity with the `state` field the
+ * subgraph entity itself carries.
+ */
+export type DeriveNextActionsInput = {
+  exchangeId: string;
+} & (
+  | {
+      exchangeState: Exclude<ExchangeState, typeof ExchangeState.DISPUTED>;
+      disputeState?: never;
+    }
+  | { exchangeState: typeof ExchangeState.DISPUTED; disputeState: DisputeState }
+);
+
+/**
+ * Build the inner `ActionsEnvelope` (the `next[]` + `fallback` block)
+ * shared by both pre-commit and post-commit envelopes.
+ */
+function buildEnvelope(
+  actionIds: readonly ActionId[],
+  registry: ChannelRegistry,
+  decorations?: DeriveDecorations,
+): ActionsEnvelope {
+  const next: NextAction[] = actionIds.map((id) => {
+    const entry: NextAction = {
+      id,
+      channels: [...registry.channels],
+    };
+    const serverEndpoint = registry.endpoints?.[id];
+    if (serverEndpoint !== undefined) {
+      entry.endpoints = { server: serverEndpoint };
+    }
+    const deadline = decorations?.deadlines?.[id];
+    if (deadline !== undefined) {
+      entry.deadline = deadline;
+    }
+    return entry;
+  });
+
+  const envelope: ActionsEnvelope = { next };
+  // Re-emit the fallback block only when at least one sub-field is set so
+  // an empty `{}` doesn't leak onto the wire.
+  if (
+    registry.fallback.xmtp !== undefined ||
+    registry.fallback.mcp !== undefined ||
+    registry.fallback.onchainHints !== undefined
+  ) {
+    envelope.fallback = registry.fallback;
+  }
+  return envelope;
+}
+
+function toClientState(input: DeriveNextActionsInput): ClientState {
+  if (input.exchangeState === ExchangeState.DISPUTED) {
+    return { exchange: ExchangeState.DISPUTED, dispute: input.disputeState };
+  }
+  return { exchange: input.exchangeState };
+}
+
+/**
+ * Build the initial 402 envelope — the `actions` block embedded in
+ * `accepts[i]`. The legal transitions out of `PRE_COMMIT` are the two
+ * commit-time actions (`boson-createOfferAndCommit`,
+ * `boson-createOfferCommitAndRedeem`); both are populated here.
+ *
+ * Returns the bare `ActionsEnvelope` (no `exchangeId` / `exchangeState`)
+ * since no exchange exists yet.
+ */
+export function deriveInitialNextActions(
+  registry: ChannelRegistry,
+  decorations?: DeriveDecorations,
+): ActionsEnvelope {
+  const actions = clientLegalActions(PRE_COMMIT);
+  return buildEnvelope(actions, registry, decorations);
+}
+
+/**
+ * Build the post-commit `nextActions` envelope for a given client state.
+ * The returned shape carries `exchangeId`, `exchangeState`, and (iff
+ * `exchangeState === DISPUTED`) `disputeState` so the buyer-side SDK
+ * can reason about legal transitions without re-fetching the subgraph.
+ */
+export function deriveNextActions(
+  input: DeriveNextActionsInput,
+  registry: ChannelRegistry,
+  decorations?: DeriveDecorations,
+): EscrowNextActions {
+  const actions = clientLegalActions(toClientState(input));
+  const inner = buildEnvelope(actions, registry, decorations);
+
+  if (input.exchangeState === ExchangeState.DISPUTED) {
+    return {
+      exchangeId: input.exchangeId,
+      exchangeState: input.exchangeState,
+      disputeState: input.disputeState,
+      next: inner.next,
+      ...(inner.fallback !== undefined ? { fallback: inner.fallback } : {}),
+    };
+  }
+  return {
+    exchangeId: input.exchangeId,
+    exchangeState: input.exchangeState,
+    next: inner.next,
+    ...(inner.fallback !== undefined ? { fallback: inner.fallback } : {}),
+  };
+}

--- a/typescript/packages/actions/src/derive.ts
+++ b/typescript/packages/actions/src/derive.ts
@@ -70,9 +70,17 @@ function buildEnvelope(
 ): ActionsEnvelope {
   const next: NextAction[] = actionIds.map((id) => {
     const serverEndpoint = registry.endpoints?.[id];
-    const channels = registry.channels.filter((channel) =>
-      isUsableChannel(channel, id, registry, serverEndpoint),
-    );
+    // Dedupe defensively while preserving order: the `uniqueItems`
+    // constraint on `next[].channels` in the JSON Schema would otherwise
+    // reject envelopes built from a `ChannelRegistry` whose `channels`
+    // list contains duplicates (a caller bypassing `buildChannelRegistry`).
+    const seen = new Set<ActionChannel>();
+    const channels = registry.channels.filter((channel) => {
+      if (seen.has(channel)) return false;
+      if (!isUsableChannel(channel, id, registry, serverEndpoint)) return false;
+      seen.add(channel);
+      return true;
+    });
     if (channels.length === 0) {
       throw new Error(`No usable channel configured for action ${id}`);
     }
@@ -155,13 +163,13 @@ export function deriveNextActions(
       exchangeState: input.exchangeState,
       disputeState: input.disputeState,
       next: inner.next,
-      ...(inner.fallback !== undefined ? { fallback: inner.fallback } : {}),
+      fallback: inner.fallback,
     };
   }
   return {
     exchangeId: input.exchangeId,
     exchangeState: input.exchangeState,
     next: inner.next,
-    ...(inner.fallback !== undefined ? { fallback: inner.fallback } : {}),
+    fallback: inner.fallback,
   };
 }

--- a/typescript/packages/actions/src/index.ts
+++ b/typescript/packages/actions/src/index.ts
@@ -1,10 +1,10 @@
 // Public API for @bosonprotocol/x402-actions.
 //
-// The root entry exposes the framework-level types and the channel
-// registry constants. The thin `ChannelAdapter` contract is reached via
-// `./channels`; the per-seller `ChannelRegistry` config type via
-// `./registry`. The `deriveNextActions` envelope builder lands in a
-// follow-up PR.
+// The root entry exposes the framework-level types, the channel
+// registry constants, and the pure `deriveNextActions` /
+// `deriveInitialNextActions` envelope builders. The thin
+// `ChannelAdapter` contract is reached via `./channels`; the
+// per-seller `ChannelRegistry` config type via `./registry`.
 
 export type {
   ActionChannel,
@@ -12,6 +12,7 @@ export type {
   ActionsEnvelope,
   ActionsFallback,
   DisputeState,
+  EscrowNextActions,
   ExchangeState,
   NextAction,
   NextActionsEnvelope,
@@ -22,3 +23,6 @@ export type { Channel, ChannelAdapter } from "./channels/index.js";
 export { CHANNEL_IDS } from "./channels/index.js";
 
 export type { ChannelRegistry } from "./registry/index.js";
+
+export type { DeriveDecorations, DeriveNextActionsInput } from "./derive.js";
+export { deriveInitialNextActions, deriveNextActions } from "./derive.js";

--- a/typescript/packages/actions/src/registry/index.ts
+++ b/typescript/packages/actions/src/registry/index.ts
@@ -37,10 +37,16 @@ export interface ChannelRegistry {
    */
   endpoints?: Partial<Record<ActionId, string>>;
 
-  /** Fallback hints embedded in the envelope's `fallback` field. */
+  /**
+   * Fallback hints embedded in the envelope's `fallback` field. The
+   * `actionFacets` map is `Partial` because a seller is not obliged to
+   * advertise every `ActionId` — actions absent from the map are
+   * effectively excluded from the `onchain` channel for that exchange
+   * (see `isUsableChannel` in `derive.ts`).
+   */
   fallback: Omit<ActionsFallback, "onchainHints"> & {
     onchainHints: Omit<OnchainHints, "actionFacets"> & {
-      actionFacets: Record<ActionId, string>;
+      actionFacets: Partial<Record<ActionId, string>>;
     };
   };
 }

--- a/typescript/packages/actions/src/registry/index.ts
+++ b/typescript/packages/actions/src/registry/index.ts
@@ -7,7 +7,7 @@
 // lands in a follow-up PR; this module ships only the configuration
 // type so the server SDK can begin to type against it.
 
-import type { ActionsFallback } from "@bosonprotocol/x402-core/schemes/escrow";
+import type { ActionsFallback, OnchainHints } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { ActionId } from "@bosonprotocol/x402-core/state-machine";
 
 import type { Channel } from "../channels/index.js";
@@ -22,9 +22,9 @@ import type { Channel } from "../channels/index.js";
  *   *hint*, not a constraint.
  * - `endpoints` — per-action HTTP endpoint overrides for the `server`
  *   channel. Actions absent from this map have no `server` endpoint.
- * - `fallback` — the `xmtp` / `mcp` / `onchainHints` block that ends
- *   up at `nextActions.fallback`. Always present even when only some
- *   sub-fields are populated, so clients can rely on its shape.
+ * - `fallback` — the `xmtp` / `mcp` / required `onchainHints` block
+ *   that ends up at `nextActions.fallback`. On-chain fallback is always
+ *   present so every advertised action has a censorship-resistant path.
  */
 export interface ChannelRegistry {
   /** The seller's preferred channel order. */
@@ -38,5 +38,9 @@ export interface ChannelRegistry {
   endpoints?: Partial<Record<ActionId, string>>;
 
   /** Fallback hints embedded in the envelope's `fallback` field. */
-  fallback: ActionsFallback;
+  fallback: Omit<ActionsFallback, "onchainHints"> & {
+    onchainHints: Omit<OnchainHints, "actionFacets"> & {
+      actionFacets: Record<ActionId, string>;
+    };
+  };
 }

--- a/typescript/packages/actions/src/types.ts
+++ b/typescript/packages/actions/src/types.ts
@@ -1,76 +1,50 @@
-// `nextActions` envelope types — the wire-format shape returned at the
-// top level of every server response (and nested in `accepts[i].actions`
-// on the initial 402 where there is no exchange yet).
+// `nextActions` envelope types for the actions package.
 //
 // Source of truth: docs/boson-impl-04-state-machine-and-next-actions.md
 // §"`nextActions` envelope".
 //
-// The base wire-format types (`NextAction`, `OnchainHints`,
-// `ActionsFallback`, `ActionsEnvelope`, `ActionChannel`) live in
-// `@bosonprotocol/x402-core/schemes/escrow` so the JSON-Schema validators
-// in core can reference them. This package adds the **execution-layer**
-// pieces those base types omit: an absolute `deadline` on each action
-// entry, and the post-commit envelope variant that carries the current
-// `(exchangeId, state, disputeState)` tuple.
+// All wire-format types live in `@bosonprotocol/x402-core/schemes/escrow`
+// next to the JSON Schema and zod validators that ship with them. This
+// module is a thin alias layer: `ActionEntry` is `NextAction` (the
+// id+channels+endpoints+deadline tuple) renamed for ergonomic short
+// usage, and `NextActionsEnvelope` is the union of the pre-commit
+// (initial 402) and post-commit (`EscrowNextActions`) shapes — useful
+// when a function may return either, e.g. a server-SDK helper that
+// dispatches the same builder for the 402 and post-redeem responses.
 
-import type { ActionsFallback, NextAction } from "@bosonprotocol/x402-core/schemes/escrow";
-import type { DisputeState, ExchangeState } from "@bosonprotocol/x402-core/state-machine";
+import type {
+  ActionsEnvelope,
+  EscrowNextActions,
+  NextAction,
+} from "@bosonprotocol/x402-core/schemes/escrow";
 
 export type {
   ActionChannel,
   ActionsEnvelope,
   ActionsFallback,
+  EscrowNextActions,
   NextAction,
   OnchainHints,
 } from "@bosonprotocol/x402-core/schemes/escrow";
 export type { DisputeState, ExchangeState } from "@bosonprotocol/x402-core/state-machine";
 
 /**
- * Single entry in the `next[]` array of a `nextActions` envelope.
- *
- * Extends the base `NextAction` (id, channels, endpoints) with an
- * optional absolute `deadline` the buyer must act by — relevant for
- * dispute-window-bounded actions like `boson-resolveDispute`,
- * `boson-escalateDispute`, and `boson-retractDispute`.
- *
- * Note: as of v0.1 the JSON Schema in
- * `@bosonprotocol/x402-core/schemas/payment_requirements.schema.json`
- * does not yet enumerate `deadline` on `actions.next[]` items — that
- * schema only covers the initial-402 envelope, where deadlines don't
- * apply. Adding `deadline` to the schema (and a separate post-commit
- * envelope schema) is tracked for a follow-up PR alongside the
- * `deriveNextActions` implementation.
+ * Single entry in the `next[]` array of a `nextActions` envelope. Alias
+ * of `NextAction` from `@bosonprotocol/x402-core/schemes/escrow` —
+ * carries `id`, `channels`, optional `endpoints`, and optional ISO 8601
+ * `deadline`.
  */
-export interface ActionEntry extends NextAction {
-  /** ISO 8601 absolute timestamp by which the action must be invoked. */
-  deadline?: string;
-}
-
-/**
- * Discriminator for the post-commit shape of a `NextActionsEnvelope`.
- * Encodes the spec invariant that `state === "DISPUTED"` ↔
- * `disputeState` is present, without any runtime check.
- */
-type ExchangeStatePair =
-  | { state: Exclude<ExchangeState, typeof ExchangeState.DISPUTED>; disputeState?: never }
-  | { state: typeof ExchangeState.DISPUTED; disputeState: DisputeState };
+export type ActionEntry = NextAction;
 
 /**
  * Top-level `nextActions` envelope returned in every server response.
  *
- * Two shapes:
- *
- * - **Pre-commit** (initial 402): no `exchangeId` / `state` /
- *   `disputeState` — the exchange doesn't exist yet. This is the shape
- *   nested inside `accepts[i].actions` on the 402 response.
- * - **Post-commit** (every subsequent response): carries the current
- *   `(exchangeId, state[, disputeState])` so clients can reason about
- *   the legal transitions without re-fetching the subgraph.
+ * - **Pre-commit** (initial 402): the base `ActionsEnvelope` (no
+ *   `exchangeId` / `state` / `disputeState`). Nested inside
+ *   `accepts[i].actions` on the 402 response.
+ * - **Post-commit**: the richer `EscrowNextActions` (with
+ *   `exchangeId`, `state`, and — when `state === DISPUTED` —
+ *   `disputeState`). Returned at the top level of every subsequent
+ *   response.
  */
-export type NextActionsEnvelope = {
-  next: ActionEntry[];
-  fallback?: ActionsFallback;
-} & (
-  | { exchangeId?: never; state?: never; disputeState?: never }
-  | ({ exchangeId: string } & ExchangeStatePair)
-);
+export type NextActionsEnvelope = ActionsEnvelope | EscrowNextActions;

--- a/typescript/packages/actions/test/derive.test.ts
+++ b/typescript/packages/actions/test/derive.test.ts
@@ -1,0 +1,176 @@
+// Table-driven tests for `deriveNextActions` / `deriveInitialNextActions`.
+//
+// Coverage matrix follows docs/boson-impl-04-state-machine-and-next-actions.md
+// — every (ExchangeState, DisputeState?) tuple the spec lists, plus the
+// synthetic PRE_COMMIT.
+
+import { DisputeState, ExchangeState } from "@bosonprotocol/x402-core/state-machine";
+import { describe, expect, it } from "vitest";
+
+import { deriveInitialNextActions, deriveNextActions, type ChannelRegistry } from "../src/index.js";
+
+const REGISTRY: ChannelRegistry = {
+  channels: ["server", "facilitator", "onchain", "mcp", "xmtp"],
+  endpoints: {
+    "boson-redeem": "https://seller.example/x402B/redeem",
+    "boson-cancelVoucher": "https://seller.example/x402B/cancel",
+  },
+  fallback: {
+    xmtp: "0xSellerXMTP",
+    mcp: "boson://seller/12345",
+    onchainHints: {
+      escrow: "0x0000000000000000000000000000000000000001",
+      metaTxFacet: "MetaTransactionsHandlerFacet",
+      metaTxEntrypoints: {
+        none: "executeMetaTransaction",
+        erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
+        permit: "executeMetaTransactionWithTokenTransferAuthorization",
+        permit2: "executeMetaTransactionWithTokenTransferAuthorization",
+      },
+      actionFacets: {
+        "boson-redeem": "ExchangeHandlerFacet",
+      },
+    },
+  },
+};
+
+describe("deriveInitialNextActions (PRE_COMMIT)", () => {
+  it("emits the two commit-time actions in spec order", () => {
+    const envelope = deriveInitialNextActions(REGISTRY);
+    expect(envelope.next.map((entry) => entry.id)).toEqual([
+      "boson-createOfferAndCommit",
+      "boson-createOfferCommitAndRedeem",
+    ]);
+  });
+
+  it("each entry inherits the registry's channel order verbatim", () => {
+    const envelope = deriveInitialNextActions(REGISTRY);
+    for (const entry of envelope.next) {
+      expect(entry.channels).toEqual(REGISTRY.channels);
+    }
+  });
+
+  it("does not stamp endpoints when the registry has none for the action", () => {
+    const envelope = deriveInitialNextActions(REGISTRY);
+    for (const entry of envelope.next) {
+      expect(entry.endpoints).toBeUndefined();
+    }
+  });
+
+  it("plumbs through optional deadlines", () => {
+    const envelope = deriveInitialNextActions(REGISTRY, {
+      deadlines: { "boson-createOfferAndCommit": "2026-05-15T00:00:00Z" },
+    });
+    expect(envelope.next.find((e) => e.id === "boson-createOfferAndCommit")?.deadline).toBe(
+      "2026-05-15T00:00:00Z",
+    );
+    expect(
+      envelope.next.find((e) => e.id === "boson-createOfferCommitAndRedeem")?.deadline,
+    ).toBeUndefined();
+  });
+
+  it("emits the fallback block when populated", () => {
+    const envelope = deriveInitialNextActions(REGISTRY);
+    expect(envelope.fallback).toEqual(REGISTRY.fallback);
+  });
+
+  it("omits an empty fallback block", () => {
+    const envelope = deriveInitialNextActions({
+      channels: ["onchain"],
+      fallback: {},
+    });
+    expect(envelope.fallback).toBeUndefined();
+  });
+});
+
+describe("deriveNextActions — non-DISPUTED states", () => {
+  it.each([
+    [ExchangeState.COMMITTED, ["boson-redeem", "boson-cancelVoucher"]],
+    [ExchangeState.REDEEMED, ["boson-completeExchange", "boson-raiseDispute"]],
+    [ExchangeState.COMPLETED, []],
+    [ExchangeState.CANCELLED, []],
+    [ExchangeState.REVOKED, []],
+  ] as const)("exchangeState=%s -> %j", (exchangeState, expectedIds) => {
+    const envelope = deriveNextActions({ exchangeId: "12345", exchangeState }, REGISTRY);
+    expect(envelope.exchangeId).toBe("12345");
+    expect(envelope.exchangeState).toBe(exchangeState);
+    expect("disputeState" in envelope ? envelope.disputeState : undefined).toBeUndefined();
+    expect(envelope.next.map((entry) => entry.id)).toEqual(expectedIds);
+  });
+
+  it("stamps the per-action server endpoint when registry has one", () => {
+    const envelope = deriveNextActions(
+      { exchangeId: "12345", exchangeState: ExchangeState.COMMITTED },
+      REGISTRY,
+    );
+    const redeem = envelope.next.find((e) => e.id === "boson-redeem");
+    expect(redeem?.endpoints).toEqual({
+      server: "https://seller.example/x402B/redeem",
+    });
+  });
+
+  it("returns next: [] for terminal exchange states", () => {
+    for (const exchangeState of [
+      ExchangeState.COMPLETED,
+      ExchangeState.CANCELLED,
+      ExchangeState.REVOKED,
+    ] as const) {
+      const envelope = deriveNextActions({ exchangeId: "x", exchangeState }, REGISTRY);
+      expect(envelope.next).toEqual([]);
+    }
+  });
+});
+
+describe("deriveNextActions — DISPUTED state by dispute sub-state", () => {
+  it.each([
+    [
+      DisputeState.RESOLVING,
+      ["boson-resolveDispute", "boson-escalateDispute", "boson-retractDispute"],
+    ],
+    [DisputeState.ESCALATED, []],
+    [DisputeState.RESOLVED, []],
+    [DisputeState.RETRACTED, []],
+    [DisputeState.DECIDED, []],
+    [DisputeState.REFUSED, []],
+  ] as const)("dispute=%s -> %j", (disputeState, expectedIds) => {
+    const envelope = deriveNextActions(
+      {
+        exchangeId: "42",
+        exchangeState: ExchangeState.DISPUTED,
+        disputeState,
+      },
+      REGISTRY,
+    );
+    expect(envelope.exchangeId).toBe("42");
+    expect(envelope.exchangeState).toBe(ExchangeState.DISPUTED);
+    if (envelope.exchangeState === ExchangeState.DISPUTED) {
+      expect(envelope.disputeState).toBe(disputeState);
+    }
+    expect(envelope.next.map((entry) => entry.id)).toEqual(expectedIds);
+  });
+});
+
+describe("deriveNextActions — output validates against the post-commit JSON Schema (zod)", () => {
+  it("non-DISPUTED envelope round-trips through the parser", async () => {
+    const { parseEscrowNextActions } = await import("@bosonprotocol/x402-core/schemes/escrow");
+    const envelope = deriveNextActions(
+      { exchangeId: "12345", exchangeState: ExchangeState.REDEEMED },
+      REGISTRY,
+      { deadlines: { "boson-completeExchange": "2026-05-20T12:00:00Z" } },
+    );
+    expect(() => parseEscrowNextActions(envelope)).not.toThrow();
+  });
+
+  it("DISPUTED envelope with disputeState round-trips", async () => {
+    const { parseEscrowNextActions } = await import("@bosonprotocol/x402-core/schemes/escrow");
+    const envelope = deriveNextActions(
+      {
+        exchangeId: "12345",
+        exchangeState: ExchangeState.DISPUTED,
+        disputeState: DisputeState.RESOLVING,
+      },
+      REGISTRY,
+    );
+    expect(() => parseEscrowNextActions(envelope)).not.toThrow();
+  });
+});

--- a/typescript/packages/actions/test/derive.test.ts
+++ b/typescript/packages/actions/test/derive.test.ts
@@ -28,7 +28,16 @@ const REGISTRY: ChannelRegistry = {
         permit2: "executeMetaTransactionWithTokenTransferAuthorization",
       },
       actionFacets: {
+        "boson-createOfferAndCommit": "ExchangeCommitFacet",
+        "boson-createOfferCommitAndRedeem": "OrchestrationHandlerFacet2",
         "boson-redeem": "ExchangeHandlerFacet",
+        "boson-cancelVoucher": "ExchangeHandlerFacet",
+        "boson-revokeVoucher": "ExchangeHandlerFacet",
+        "boson-completeExchange": "ExchangeHandlerFacet",
+        "boson-raiseDispute": "DisputeHandlerFacet",
+        "boson-resolveDispute": "DisputeHandlerFacet",
+        "boson-escalateDispute": "DisputeHandlerFacet",
+        "boson-retractDispute": "DisputeHandlerFacet",
       },
     },
   },
@@ -43,10 +52,10 @@ describe("deriveInitialNextActions (PRE_COMMIT)", () => {
     ]);
   });
 
-  it("each entry inherits the registry's channel order verbatim", () => {
+  it("each entry keeps only usable channels in registry order", () => {
     const envelope = deriveInitialNextActions(REGISTRY);
     for (const entry of envelope.next) {
-      expect(entry.channels).toEqual(REGISTRY.channels);
+      expect(entry.channels).toEqual(["facilitator", "onchain", "mcp", "xmtp"]);
     }
   });
 
@@ -54,6 +63,7 @@ describe("deriveInitialNextActions (PRE_COMMIT)", () => {
     const envelope = deriveInitialNextActions(REGISTRY);
     for (const entry of envelope.next) {
       expect(entry.endpoints).toBeUndefined();
+      expect(entry.channels).not.toContain("server");
     }
   });
 
@@ -74,12 +84,9 @@ describe("deriveInitialNextActions (PRE_COMMIT)", () => {
     expect(envelope.fallback).toEqual(REGISTRY.fallback);
   });
 
-  it("omits an empty fallback block", () => {
-    const envelope = deriveInitialNextActions({
-      channels: ["onchain"],
-      fallback: {},
-    });
-    expect(envelope.fallback).toBeUndefined();
+  it("always emits the on-chain fallback block", () => {
+    const envelope = deriveInitialNextActions(REGISTRY);
+    expect(envelope.fallback?.onchainHints).toEqual(REGISTRY.fallback.onchainHints);
   });
 });
 
@@ -107,6 +114,51 @@ describe("deriveNextActions — non-DISPUTED states", () => {
     expect(redeem?.endpoints).toEqual({
       server: "https://seller.example/x402B/redeem",
     });
+    expect(redeem?.channels).toEqual(["server", "facilitator", "onchain", "mcp", "xmtp"]);
+  });
+
+  it("omits channels whose required hints are absent", () => {
+    const envelope = deriveNextActions(
+      { exchangeId: "12345", exchangeState: ExchangeState.REDEEMED },
+      {
+        channels: ["server", "facilitator", "onchain", "mcp", "xmtp"],
+        fallback: {
+          onchainHints: {
+            escrow: "0x0000000000000000000000000000000000000001",
+            metaTxFacet: "MetaTransactionsHandlerFacet",
+            metaTxEntrypoints: {
+              none: "executeMetaTransaction",
+              erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
+              permit: "executeMetaTransactionWithTokenTransferAuthorization",
+              permit2: "executeMetaTransactionWithTokenTransferAuthorization",
+            },
+            actionFacets: {
+              "boson-createOfferAndCommit": "ExchangeCommitFacet",
+              "boson-createOfferCommitAndRedeem": "OrchestrationHandlerFacet2",
+              "boson-redeem": "ExchangeHandlerFacet",
+              "boson-cancelVoucher": "ExchangeHandlerFacet",
+              "boson-revokeVoucher": "ExchangeHandlerFacet",
+              "boson-completeExchange": "ExchangeHandlerFacet",
+              "boson-raiseDispute": "DisputeHandlerFacet",
+              "boson-resolveDispute": "DisputeHandlerFacet",
+              "boson-escalateDispute": "DisputeHandlerFacet",
+              "boson-retractDispute": "DisputeHandlerFacet",
+            },
+          },
+        },
+      },
+    );
+
+    expect(envelope.next).toEqual([
+      {
+        id: "boson-completeExchange",
+        channels: ["facilitator", "onchain"],
+      },
+      {
+        id: "boson-raiseDispute",
+        channels: ["facilitator", "onchain"],
+      },
+    ]);
   });
 
   it("returns next: [] for terminal exchange states", () => {
@@ -118,6 +170,22 @@ describe("deriveNextActions — non-DISPUTED states", () => {
       const envelope = deriveNextActions({ exchangeId: "x", exchangeState }, REGISTRY);
       expect(envelope.next).toEqual([]);
     }
+  });
+});
+
+describe("deriveNextActions — unusable actions", () => {
+  it("throws when no configured channel can be used for a legal action", () => {
+    expect(() =>
+      deriveNextActions(
+        { exchangeId: "12345", exchangeState: ExchangeState.REDEEMED },
+        {
+          channels: ["server", "mcp", "xmtp"],
+          fallback: {
+            onchainHints: REGISTRY.fallback.onchainHints,
+          },
+        },
+      ),
+    ).toThrow("No usable channel configured for action boson-completeExchange");
   });
 });
 

--- a/typescript/packages/actions/test/derive.test.ts
+++ b/typescript/packages/actions/test/derive.test.ts
@@ -7,41 +7,8 @@
 import { DisputeState, ExchangeState } from "@bosonprotocol/x402-core/state-machine";
 import { describe, expect, it } from "vitest";
 
-import { deriveInitialNextActions, deriveNextActions, type ChannelRegistry } from "../src/index.js";
-
-const REGISTRY: ChannelRegistry = {
-  channels: ["server", "facilitator", "onchain", "mcp", "xmtp"],
-  endpoints: {
-    "boson-redeem": "https://seller.example/x402B/redeem",
-    "boson-cancelVoucher": "https://seller.example/x402B/cancel",
-  },
-  fallback: {
-    xmtp: "0xSellerXMTP",
-    mcp: "boson://seller/12345",
-    onchainHints: {
-      escrow: "0x0000000000000000000000000000000000000001",
-      metaTxFacet: "MetaTransactionsHandlerFacet",
-      metaTxEntrypoints: {
-        none: "executeMetaTransaction",
-        erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
-        permit: "executeMetaTransactionWithTokenTransferAuthorization",
-        permit2: "executeMetaTransactionWithTokenTransferAuthorization",
-      },
-      actionFacets: {
-        "boson-createOfferAndCommit": "ExchangeCommitFacet",
-        "boson-createOfferCommitAndRedeem": "OrchestrationHandlerFacet2",
-        "boson-redeem": "ExchangeHandlerFacet",
-        "boson-cancelVoucher": "ExchangeHandlerFacet",
-        "boson-revokeVoucher": "ExchangeHandlerFacet",
-        "boson-completeExchange": "ExchangeHandlerFacet",
-        "boson-raiseDispute": "DisputeHandlerFacet",
-        "boson-resolveDispute": "DisputeHandlerFacet",
-        "boson-escalateDispute": "DisputeHandlerFacet",
-        "boson-retractDispute": "DisputeHandlerFacet",
-      },
-    },
-  },
-};
+import { deriveInitialNextActions, deriveNextActions } from "../src/index.js";
+import { REGISTRY } from "./fixtures/registry.js";
 
 describe("deriveInitialNextActions (PRE_COMMIT)", () => {
   it("emits the two commit-time actions in spec order", () => {

--- a/typescript/packages/actions/test/fixtures/registry.ts
+++ b/typescript/packages/actions/test/fixtures/registry.ts
@@ -1,0 +1,39 @@
+// Shared `ChannelRegistry` test fixture used across the actions
+// package's test files. Centralised here so `derive.test.ts` and
+// `types.test.ts` reference the same canonical seller configuration.
+
+import type { ChannelRegistry } from "../../src/index.js";
+
+export const REGISTRY: ChannelRegistry = {
+  channels: ["server", "facilitator", "onchain", "mcp", "xmtp"],
+  endpoints: {
+    "boson-redeem": "https://seller.example/x402B/redeem",
+    "boson-cancelVoucher": "https://seller.example/x402B/cancel",
+  },
+  fallback: {
+    xmtp: "0xSellerXMTP",
+    mcp: "boson://seller/12345",
+    onchainHints: {
+      escrow: "0x0000000000000000000000000000000000000001",
+      metaTxFacet: "MetaTransactionsHandlerFacet",
+      metaTxEntrypoints: {
+        none: "executeMetaTransaction",
+        erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
+        permit: "executeMetaTransactionWithTokenTransferAuthorization",
+        permit2: "executeMetaTransactionWithTokenTransferAuthorization",
+      },
+      actionFacets: {
+        "boson-createOfferAndCommit": "ExchangeCommitFacet",
+        "boson-createOfferCommitAndRedeem": "OrchestrationHandlerFacet2",
+        "boson-redeem": "ExchangeHandlerFacet",
+        "boson-cancelVoucher": "ExchangeHandlerFacet",
+        "boson-revokeVoucher": "ExchangeHandlerFacet",
+        "boson-completeExchange": "ExchangeHandlerFacet",
+        "boson-raiseDispute": "DisputeHandlerFacet",
+        "boson-resolveDispute": "DisputeHandlerFacet",
+        "boson-escalateDispute": "DisputeHandlerFacet",
+        "boson-retractDispute": "DisputeHandlerFacet",
+      },
+    },
+  },
+};

--- a/typescript/packages/actions/test/types.test.ts
+++ b/typescript/packages/actions/test/types.test.ts
@@ -10,6 +10,7 @@ import {
   type ChannelRegistry,
   type NextActionsEnvelope,
 } from "../src/index.js";
+import { REGISTRY } from "./fixtures/registry.js";
 
 describe("@bosonprotocol/x402-actions public types", () => {
   it("CHANNEL_IDS includes the five standard channels in stable order", () => {
@@ -85,38 +86,7 @@ describe("@bosonprotocol/x402-actions public types", () => {
   });
 
   it("ChannelRegistry types channel order and per-action server endpoints", () => {
-    const registry: ChannelRegistry = {
-      channels: ["server", "facilitator", "onchain", "mcp"],
-      endpoints: {
-        "boson-redeem": "https://seller.example/x402B/redeem",
-      },
-      fallback: {
-        xmtp: "0xSellerXMTP",
-        mcp: "boson://seller/12345",
-        onchainHints: {
-          escrow: "0x0000000000000000000000000000000000000001",
-          metaTxFacet: "MetaTransactionsHandlerFacet",
-          metaTxEntrypoints: {
-            none: "executeMetaTransaction",
-            erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
-            permit: "executeMetaTransactionWithTokenTransferAuthorization",
-            permit2: "executeMetaTransactionWithTokenTransferAuthorization",
-          },
-          actionFacets: {
-            "boson-createOfferAndCommit": "ExchangeCommitFacet",
-            "boson-createOfferCommitAndRedeem": "OrchestrationHandlerFacet2",
-            "boson-redeem": "ExchangeHandlerFacet",
-            "boson-cancelVoucher": "ExchangeHandlerFacet",
-            "boson-revokeVoucher": "ExchangeHandlerFacet",
-            "boson-completeExchange": "ExchangeHandlerFacet",
-            "boson-raiseDispute": "DisputeHandlerFacet",
-            "boson-resolveDispute": "DisputeHandlerFacet",
-            "boson-escalateDispute": "DisputeHandlerFacet",
-            "boson-retractDispute": "DisputeHandlerFacet",
-          },
-        },
-      },
-    };
-    expectTypeOf(registry.channels).toMatchTypeOf<readonly Channel[]>();
+    expectTypeOf(REGISTRY).toMatchTypeOf<ChannelRegistry>();
+    expectTypeOf(REGISTRY.channels).toMatchTypeOf<readonly Channel[]>();
   });
 });

--- a/typescript/packages/actions/test/types.test.ts
+++ b/typescript/packages/actions/test/types.test.ts
@@ -93,6 +93,28 @@ describe("@bosonprotocol/x402-actions public types", () => {
       fallback: {
         xmtp: "0xSellerXMTP",
         mcp: "boson://seller/12345",
+        onchainHints: {
+          escrow: "0x0000000000000000000000000000000000000001",
+          metaTxFacet: "MetaTransactionsHandlerFacet",
+          metaTxEntrypoints: {
+            none: "executeMetaTransaction",
+            erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
+            permit: "executeMetaTransactionWithTokenTransferAuthorization",
+            permit2: "executeMetaTransactionWithTokenTransferAuthorization",
+          },
+          actionFacets: {
+            "boson-createOfferAndCommit": "ExchangeCommitFacet",
+            "boson-createOfferCommitAndRedeem": "OrchestrationHandlerFacet2",
+            "boson-redeem": "ExchangeHandlerFacet",
+            "boson-cancelVoucher": "ExchangeHandlerFacet",
+            "boson-revokeVoucher": "ExchangeHandlerFacet",
+            "boson-completeExchange": "ExchangeHandlerFacet",
+            "boson-raiseDispute": "DisputeHandlerFacet",
+            "boson-resolveDispute": "DisputeHandlerFacet",
+            "boson-escalateDispute": "DisputeHandlerFacet",
+            "boson-retractDispute": "DisputeHandlerFacet",
+          },
+        },
       },
     };
     expectTypeOf(registry.channels).toMatchTypeOf<readonly Channel[]>();

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -77,6 +77,7 @@
   "devDependencies": {
     "@types/node": "^20.17.10",
     "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "tsup": "^8.3.5",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"

--- a/typescript/packages/core/src/schemes/escrow/index.ts
+++ b/typescript/packages/core/src/schemes/escrow/index.ts
@@ -4,6 +4,7 @@
 export * from "./types.js";
 export * from "./payment-requirements.js";
 export * from "./payment-payload.js";
+export * from "./next-actions.js";
 
 /** Stable identifier for the scheme. Use this in place of the raw string `"escrow"` to avoid typos. */
 export const ESCROW_SCHEME = "escrow" as const;

--- a/typescript/packages/core/src/schemes/escrow/next-actions.ts
+++ b/typescript/packages/core/src/schemes/escrow/next-actions.ts
@@ -8,13 +8,8 @@
 import { z } from "zod";
 
 import { DisputeState, ExchangeState } from "../../state-machine/states.js";
-import {
-  ACTION_CHANNELS,
-  type ActionChannel,
-  type ActionsFallback,
-  type NextAction,
-} from "./types.js";
-import { addressSchema } from "./validators.js";
+import { actionEntrySchema, actionsFallbackSchema } from "./shared-schemas.js";
+import { type ActionsFallback, type NextAction } from "./types.js";
 
 /**
  * Wire-format type for the post-commit `nextActions` envelope.
@@ -43,52 +38,14 @@ export type EscrowNextActions = {
 const exchangeStateSchema = z.nativeEnum(ExchangeState);
 const disputeStateSchema = z.nativeEnum(DisputeState);
 
-const nextActionSchema = z
-  .object({
-    id: z.string().min(1),
-    channels: z
-      .array(z.enum(ACTION_CHANNELS as readonly [ActionChannel, ...ActionChannel[]]))
-      .min(1)
-      .refine((channels) => new Set(channels).size === channels.length, {
-        message: "channels must contain unique items",
-      }),
-    endpoints: z.record(z.string()).optional(),
-    deadline: z.string().datetime({ offset: true }).optional(),
-  })
-  .strict();
-
-const fallbackSchema = z
-  .object({
-    xmtp: z.string().optional(),
-    mcp: z.string().optional(),
-    onchainHints: z
-      .object({
-        escrow: addressSchema,
-        metaTxFacet: z.string().min(1),
-        metaTxEntrypoints: z
-          .object({
-            none: z.string().min(1),
-            erc3009: z.string().min(1),
-            permit: z.string().min(1),
-            permit2: z.string().min(1),
-          })
-          .strict(),
-        actionFacets: z.record(z.string()),
-      })
-      .strict()
-      .optional(),
-  })
-  .strict()
-  .optional();
-
 /** Zod validator paired with `next_actions.schema.json`. */
 export const escrowNextActionsSchema = z
   .object({
     exchangeId: z.string().min(1),
     exchangeState: exchangeStateSchema,
     disputeState: disputeStateSchema.optional(),
-    next: z.array(nextActionSchema),
-    fallback: fallbackSchema,
+    next: z.array(actionEntrySchema),
+    fallback: actionsFallbackSchema.optional(),
   })
   .strict()
   .refine(

--- a/typescript/packages/core/src/schemes/escrow/next-actions.ts
+++ b/typescript/packages/core/src/schemes/escrow/next-actions.ts
@@ -1,0 +1,108 @@
+// Post-commit `nextActions` envelope (top level of every response after
+// the initial 402). The pre-commit variant lives nested inside
+// `EscrowPaymentRequirements.actions` — see `payment-requirements.ts`.
+//
+// Source of truth: docs/boson-impl-04-state-machine-and-next-actions.md
+// §"`nextActions` envelope" and `schemas/next_actions.schema.json`.
+
+import { z } from "zod";
+
+import { DisputeState, ExchangeState } from "../../state-machine/states.js";
+import {
+  ACTION_CHANNELS,
+  type ActionChannel,
+  type ActionsFallback,
+  type NextAction,
+} from "./types.js";
+import { addressSchema } from "./validators.js";
+
+/**
+ * Wire-format type for the post-commit `nextActions` envelope.
+ *
+ * The `exchangeState === DISPUTED ↔ disputeState present` invariant is
+ * encoded structurally: `exchangeState: DISPUTED` requires
+ * `disputeState`, and any other `exchangeState` forbids it. The zod
+ * validator below enforces the same invariant at runtime.
+ *
+ * The wire field is named `exchangeState` (not `state`) for symmetry
+ * with `disputeState` and to remove ambiguity with the `state` field
+ * the subgraph entity itself carries.
+ */
+export type EscrowNextActions = {
+  exchangeId: string;
+  next: NextAction[];
+  fallback?: ActionsFallback;
+} & (
+  | {
+      exchangeState: Exclude<ExchangeState, typeof ExchangeState.DISPUTED>;
+      disputeState?: never;
+    }
+  | { exchangeState: typeof ExchangeState.DISPUTED; disputeState: DisputeState }
+);
+
+const exchangeStateSchema = z.nativeEnum(ExchangeState);
+const disputeStateSchema = z.nativeEnum(DisputeState);
+
+const nextActionSchema = z
+  .object({
+    id: z.string().min(1),
+    channels: z
+      .array(z.enum(ACTION_CHANNELS as readonly [ActionChannel, ...ActionChannel[]]))
+      .min(1)
+      .refine((channels) => new Set(channels).size === channels.length, {
+        message: "channels must contain unique items",
+      }),
+    endpoints: z.record(z.string()).optional(),
+    deadline: z.string().datetime({ offset: true }).optional(),
+  })
+  .strict();
+
+const fallbackSchema = z
+  .object({
+    xmtp: z.string().optional(),
+    mcp: z.string().optional(),
+    onchainHints: z
+      .object({
+        escrow: addressSchema,
+        metaTxFacet: z.string().min(1),
+        metaTxEntrypoints: z
+          .object({
+            none: z.string().min(1),
+            erc3009: z.string().min(1),
+            permit: z.string().min(1),
+            permit2: z.string().min(1),
+          })
+          .strict(),
+        actionFacets: z.record(z.string()),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .optional();
+
+/** Zod validator paired with `next_actions.schema.json`. */
+export const escrowNextActionsSchema = z
+  .object({
+    exchangeId: z.string().min(1),
+    exchangeState: exchangeStateSchema,
+    disputeState: disputeStateSchema.optional(),
+    next: z.array(nextActionSchema),
+    fallback: fallbackSchema,
+  })
+  .strict()
+  .refine(
+    (envelope) =>
+      envelope.exchangeState === ExchangeState.DISPUTED
+        ? envelope.disputeState !== undefined
+        : envelope.disputeState === undefined,
+    {
+      message: "disputeState is required iff exchangeState === DISPUTED",
+      path: ["disputeState"],
+    },
+  );
+
+/** Type-guard form. Returns the parsed value on success, throws on failure. */
+export function parseEscrowNextActions(value: unknown): EscrowNextActions {
+  return escrowNextActionsSchema.parse(value) as EscrowNextActions;
+}

--- a/typescript/packages/core/src/schemes/escrow/payment-requirements.ts
+++ b/typescript/packages/core/src/schemes/escrow/payment-requirements.ts
@@ -56,6 +56,7 @@ const actionsSchema = z
                 message: "channels must contain unique items",
               }),
             endpoints: z.record(z.string()).optional(),
+            deadline: z.string().datetime({ offset: true }).optional(),
           })
           .strict(),
       )
@@ -68,7 +69,14 @@ const actionsSchema = z
           .object({
             escrow: addressSchema,
             metaTxFacet: z.string().min(1),
-            metaTxEntrypoint: z.string().min(1),
+            metaTxEntrypoints: z
+              .object({
+                none: z.string().min(1),
+                erc3009: z.string().min(1),
+                permit: z.string().min(1),
+                permit2: z.string().min(1),
+              })
+              .strict(),
             actionFacets: z.record(z.string()),
           })
           .strict()

--- a/typescript/packages/core/src/schemes/escrow/payment-requirements.ts
+++ b/typescript/packages/core/src/schemes/escrow/payment-requirements.ts
@@ -3,10 +3,9 @@
 
 import { z } from "zod";
 
+import { actionEntrySchema, actionsFallbackSchema } from "./shared-schemas.js";
 import {
-  ACTION_CHANNELS,
   TOKEN_AUTH_STRATEGIES,
-  type ActionChannel,
   type ActionsEnvelope,
   type Address,
   type BosonOfferRef,
@@ -42,48 +41,13 @@ const fulfillmentSchema = z
   })
   .strict();
 
+// Pre-commit (initial 402) `actions` envelope: `next[]` must be
+// non-empty (the buyer needs at least one path to commit) and the
+// `fallback` block is optional.
 const actionsSchema = z
   .object({
-    next: z
-      .array(
-        z
-          .object({
-            id: z.string().min(1),
-            channels: z
-              .array(z.enum(ACTION_CHANNELS as readonly [ActionChannel, ...ActionChannel[]]))
-              .min(1)
-              .refine((channels) => new Set(channels).size === channels.length, {
-                message: "channels must contain unique items",
-              }),
-            endpoints: z.record(z.string()).optional(),
-            deadline: z.string().datetime({ offset: true }).optional(),
-          })
-          .strict(),
-      )
-      .min(1),
-    fallback: z
-      .object({
-        xmtp: z.string().optional(),
-        mcp: z.string().optional(),
-        onchainHints: z
-          .object({
-            escrow: addressSchema,
-            metaTxFacet: z.string().min(1),
-            metaTxEntrypoints: z
-              .object({
-                none: z.string().min(1),
-                erc3009: z.string().min(1),
-                permit: z.string().min(1),
-                permit2: z.string().min(1),
-              })
-              .strict(),
-            actionFacets: z.record(z.string()),
-          })
-          .strict()
-          .optional(),
-      })
-      .strict()
-      .optional(),
+    next: z.array(actionEntrySchema).min(1),
+    fallback: actionsFallbackSchema.optional(),
   })
   .strict();
 

--- a/typescript/packages/core/src/schemes/escrow/schemas/next_actions.schema.json
+++ b/typescript/packages/core/src/schemes/escrow/schemas/next_actions.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bosonprotocol.io/schemas/x402-core/next_actions.schema.json",
+  "title": "x402B escrow nextActions envelope (post-commit)",
+  "description": "Wire-format `nextActions` envelope returned at the top level of every post-commit response. The pre-commit (initial 402) variant is the inner `actions` field of payment_requirements.schema.json. Enum value orderings mirror the on-chain `BosonTypes.sol` declarations (ExchangeState, DisputeState) so the wire format stays in lock-step with the protocol. Source: docs/boson-impl-04-state-machine-and-next-actions.md §`nextActions` envelope.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["exchangeId", "exchangeState", "next"],
+  "properties": {
+    "exchangeId": { "type": "string", "minLength": 1 },
+    "exchangeState": {
+      "enum": ["COMMITTED", "REVOKED", "CANCELLED", "REDEEMED", "COMPLETED", "DISPUTED"]
+    },
+    "disputeState": {
+      "enum": ["RESOLVING", "RETRACTED", "RESOLVED", "ESCALATED", "DECIDED", "REFUSED"]
+    },
+    "next": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "channels"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "channels": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "enum": ["server", "facilitator", "onchain", "mcp", "xmtp"]
+            }
+          },
+          "endpoints": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          },
+          "deadline": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "fallback": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "xmtp": { "type": "string" },
+        "mcp": { "type": "string" },
+        "onchainHints": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["escrow", "metaTxFacet", "metaTxEntrypoints", "actionFacets"],
+          "properties": {
+            "escrow": { "type": "string", "pattern": "^0x[a-fA-F0-9]{40}$" },
+            "metaTxFacet": { "type": "string", "minLength": 1 },
+            "metaTxEntrypoints": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["none", "erc3009", "permit", "permit2"],
+              "properties": {
+                "none": { "type": "string", "minLength": 1 },
+                "erc3009": { "type": "string", "minLength": 1 },
+                "permit": { "type": "string", "minLength": 1 },
+                "permit2": { "type": "string", "minLength": 1 }
+              }
+            },
+            "actionFacets": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "exchangeState": { "const": "DISPUTED" } },
+        "required": ["exchangeState"]
+      },
+      "then": { "required": ["disputeState"] },
+      "else": { "not": { "required": ["disputeState"] } }
+    }
+  ]
+}

--- a/typescript/packages/core/src/schemes/escrow/schemas/payment_requirements.schema.json
+++ b/typescript/packages/core/src/schemes/escrow/schemas/payment_requirements.schema.json
@@ -88,6 +88,10 @@
               "endpoints": {
                 "type": "object",
                 "additionalProperties": { "type": "string" }
+              },
+              "deadline": {
+                "type": "string",
+                "format": "date-time"
               }
             }
           }
@@ -101,11 +105,21 @@
             "onchainHints": {
               "type": "object",
               "additionalProperties": false,
-              "required": ["escrow", "metaTxFacet", "metaTxEntrypoint", "actionFacets"],
+              "required": ["escrow", "metaTxFacet", "metaTxEntrypoints", "actionFacets"],
               "properties": {
                 "escrow": { "type": "string", "pattern": "^0x[a-fA-F0-9]{40}$" },
                 "metaTxFacet": { "type": "string", "minLength": 1 },
-                "metaTxEntrypoint": { "type": "string", "minLength": 1 },
+                "metaTxEntrypoints": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["none", "erc3009", "permit", "permit2"],
+                  "properties": {
+                    "none": { "type": "string", "minLength": 1 },
+                    "erc3009": { "type": "string", "minLength": 1 },
+                    "permit": { "type": "string", "minLength": 1 },
+                    "permit2": { "type": "string", "minLength": 1 }
+                  }
+                },
                 "actionFacets": {
                   "type": "object",
                   "additionalProperties": { "type": "string" }

--- a/typescript/packages/core/src/schemes/escrow/shared-schemas.ts
+++ b/typescript/packages/core/src/schemes/escrow/shared-schemas.ts
@@ -1,0 +1,64 @@
+// Shared zod fragments used by both `payment-requirements.ts` (the
+// pre-commit / 402 envelope) and `next-actions.ts` (the post-commit
+// envelope). Centralised here so the two wire-format validators can't
+// drift on shared sub-shapes like an action entry, the `fallback` block,
+// or the `onchainHints` block.
+
+import { z } from "zod";
+
+import { ACTION_CHANNELS, type ActionChannel } from "./types.js";
+import { addressSchema } from "./validators.js";
+
+/** ISO 8601 absolute timestamp with timezone offset. */
+export const actionDeadlineSchema = z.string().datetime({ offset: true });
+
+/** Non-empty unique `ActionChannel[]` for `next[i].channels`. */
+export const actionChannelsSchema = z
+  .array(z.enum(ACTION_CHANNELS as readonly [ActionChannel, ...ActionChannel[]]))
+  .min(1)
+  .refine((channels) => new Set(channels).size === channels.length, {
+    message: "channels must contain unique items",
+  });
+
+/** Single entry in the `next[]` array of any `nextActions` envelope. */
+export const actionEntrySchema = z
+  .object({
+    id: z.string().min(1),
+    channels: actionChannelsSchema,
+    endpoints: z.record(z.string()).optional(),
+    deadline: actionDeadlineSchema.optional(),
+  })
+  .strict();
+
+/**
+ * Per-`tokenAuthStrategy` meta-tx entry points on
+ * `onchainHints.metaTxFacet`. All four strategies are required so
+ * clients can resolve any strategy they happen to advertise.
+ */
+export const metaTxEntrypointsSchema = z
+  .object({
+    none: z.string().min(1),
+    erc3009: z.string().min(1),
+    permit: z.string().min(1),
+    permit2: z.string().min(1),
+  })
+  .strict();
+
+/** `fallback.onchainHints` block. */
+export const onchainHintsSchema = z
+  .object({
+    escrow: addressSchema,
+    metaTxFacet: z.string().min(1),
+    metaTxEntrypoints: metaTxEntrypointsSchema,
+    actionFacets: z.record(z.string()),
+  })
+  .strict();
+
+/** `fallback` block embedded in any `nextActions` envelope. */
+export const actionsFallbackSchema = z
+  .object({
+    xmtp: z.string().optional(),
+    mcp: z.string().optional(),
+    onchainHints: onchainHintsSchema.optional(),
+  })
+  .strict();

--- a/typescript/packages/core/src/schemes/escrow/types.ts
+++ b/typescript/packages/core/src/schemes/escrow/types.ts
@@ -71,18 +71,50 @@ export interface NextAction {
   id: string;
   channels: ActionChannel[];
   endpoints?: Record<string, string>;
+  /**
+   * ISO 8601 absolute timestamp by which the action must be invoked.
+   * Relevant for dispute-window-bounded actions like
+   * `boson-resolveDispute`, `boson-escalateDispute`,
+   * `boson-retractDispute`, and (post-commit) `boson-completeExchange`.
+   */
+  deadline?: string;
 }
 
 export interface OnchainHints {
   /** Address of the Boson escrow contract. */
   escrow: Address;
   metaTxFacet: string;
-  metaTxEntrypoint: string;
+  /**
+   * Per-`tokenAuthStrategy` meta-tx entry points on `metaTxFacet`. The
+   * Boson Diamond exposes two functions on `MetaTransactionsHandlerFacet`:
+   *
+   * - `executeMetaTransaction` — legacy BPIP-9 entry point. Used when
+   *   the buyer's `tokenAuthStrategy` is `none` (the buyer has
+   *   pre-approved the Diamond, so no token-transfer authorization
+   *   queue is needed). Also the right entry point for any
+   *   post-commit action that doesn't move tokens (`redeem`,
+   *   `complete`, dispute transitions).
+   * - `executeMetaTransactionWithTokenTransferAuthorization` — BPIP-12
+   *   entry point. Carries the buyer's signed `MetaTransaction` *and*
+   *   a queue of token-transfer authorizations. Used when
+   *   `tokenAuthStrategy` is `erc3009`, `permit`, or `permit2`.
+   *
+   * Clients select the entry point by their chosen strategy at
+   * dispatch time.
+   */
+  metaTxEntrypoints: Record<TokenAuthStrategy, string>;
   actionFacets: Record<string, string>;
 }
 
 export interface ActionsFallback {
   xmtp?: string;
+  /**
+   * Identifier within the Boson MCP server (e.g. the
+   * `bosonprotocol/agentic-commerce` server) that the buyer's
+   * MCP-aware agent dispatches against. The MCP *server* is escrow-
+   * level (one BosonMCP serving every Boson seller); this value is the
+   * URI/identifier the BosonMCP routes to the right exchange / seller.
+   */
   mcp?: string;
   onchainHints?: OnchainHints;
 }

--- a/typescript/packages/core/test/schemes/escrow/fixtures.ts
+++ b/typescript/packages/core/test/schemes/escrow/fixtures.ts
@@ -58,7 +58,12 @@ export const validRequirements: EscrowPaymentRequirements = {
       onchainHints: {
         escrow: ESCROW,
         metaTxFacet: "MetaTransactionsHandlerFacet",
-        metaTxEntrypoint: "executeMetaTransactionWithTokenTransferAuthorization",
+        metaTxEntrypoints: {
+          none: "executeMetaTransaction",
+          erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
+          permit: "executeMetaTransactionWithTokenTransferAuthorization",
+          permit2: "executeMetaTransactionWithTokenTransferAuthorization",
+        },
         actionFacets: {
           "boson-createOfferAndCommit": "ExchangeCommitFacet",
           "boson-createOfferCommitAndRedeem": "OrchestrationHandlerFacet2",

--- a/typescript/packages/core/test/schemes/escrow/next-actions.test.ts
+++ b/typescript/packages/core/test/schemes/escrow/next-actions.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import Ajv, { type ValidateFunction } from "ajv";
+import addFormats from "ajv-formats";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -26,7 +27,9 @@ const schemaPath = join(
   "next_actions.schema.json",
 );
 const jsonSchema = JSON.parse(readFileSync(schemaPath, "utf8"));
-const ajv = new Ajv({ allErrors: true, strict: false });
+// Register the standard JSON Schema string formats (notably `date-time`)
+// so Ajv actually enforces them — Ajv v8 ignores formats by default.
+const ajv = addFormats(new Ajv({ allErrors: true, strict: false }));
 const ajvValidate: ValidateFunction = ajv.compile(jsonSchema);
 
 const fallback = {
@@ -133,5 +136,6 @@ describe("EscrowNextActions — invariants", () => {
     const bad = JSON.parse(JSON.stringify(validNonDisputed)) as Record<string, unknown>;
     (bad.next as Array<Record<string, unknown>>)[0].deadline = "not-a-date";
     expect(escrowNextActionsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
   });
 });

--- a/typescript/packages/core/test/schemes/escrow/next-actions.test.ts
+++ b/typescript/packages/core/test/schemes/escrow/next-actions.test.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+import Ajv, { type ValidateFunction } from "ajv";
+import { describe, expect, it } from "vitest";
+
+import {
+  escrowNextActionsSchema,
+  parseEscrowNextActions,
+  type EscrowNextActions,
+} from "../../../src/schemes/escrow/index.js";
+import { DisputeState, ExchangeState } from "../../../src/state-machine/index.js";
+import { ESCROW } from "./fixtures.js";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const schemaPath = join(
+  here,
+  "..",
+  "..",
+  "..",
+  "src",
+  "schemes",
+  "escrow",
+  "schemas",
+  "next_actions.schema.json",
+);
+const jsonSchema = JSON.parse(readFileSync(schemaPath, "utf8"));
+const ajv = new Ajv({ allErrors: true, strict: false });
+const ajvValidate: ValidateFunction = ajv.compile(jsonSchema);
+
+const fallback = {
+  xmtp: "0xSellerXMTP",
+  mcp: "boson://seller/12345",
+  onchainHints: {
+    escrow: ESCROW,
+    metaTxFacet: "MetaTransactionsHandlerFacet",
+    metaTxEntrypoints: {
+      none: "executeMetaTransaction",
+      erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
+      permit: "executeMetaTransactionWithTokenTransferAuthorization",
+      permit2: "executeMetaTransactionWithTokenTransferAuthorization",
+    },
+    actionFacets: { "boson-redeem": "ExchangeHandlerFacet" },
+  },
+} as const;
+
+const validNonDisputed: EscrowNextActions = {
+  exchangeId: "12345",
+  exchangeState: ExchangeState.REDEEMED,
+  next: [
+    {
+      id: "boson-completeExchange",
+      channels: ["server", "facilitator", "onchain"],
+      deadline: "2026-05-15T00:00:00Z",
+    },
+  ],
+  fallback,
+};
+
+const validDisputed: EscrowNextActions = {
+  exchangeId: "42",
+  exchangeState: ExchangeState.DISPUTED,
+  disputeState: DisputeState.RESOLVING,
+  next: [
+    { id: "boson-resolveDispute", channels: ["server", "onchain"] },
+    { id: "boson-escalateDispute", channels: ["onchain"] },
+    { id: "boson-retractDispute", channels: ["server", "onchain"] },
+  ],
+  fallback,
+};
+
+describe("EscrowNextActions — happy path", () => {
+  it("zod accepts a non-DISPUTED envelope with deadline", () => {
+    expect(() => parseEscrowNextActions(validNonDisputed)).not.toThrow();
+  });
+
+  it("ajv accepts a non-DISPUTED envelope with deadline", () => {
+    const ok = ajvValidate(validNonDisputed);
+    expect(ajvValidate.errors ?? null).toBeNull();
+    expect(ok).toBe(true);
+  });
+
+  it("zod accepts a DISPUTED envelope with disputeState", () => {
+    expect(() => parseEscrowNextActions(validDisputed)).not.toThrow();
+  });
+
+  it("ajv accepts a DISPUTED envelope with disputeState", () => {
+    const ok = ajvValidate(validDisputed);
+    expect(ajvValidate.errors ?? null).toBeNull();
+    expect(ok).toBe(true);
+  });
+});
+
+describe("EscrowNextActions — invariants", () => {
+  it("rejects DISPUTED without disputeState", () => {
+    const bad = { ...validDisputed } as Record<string, unknown>;
+    delete bad.disputeState;
+    expect(escrowNextActionsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects non-DISPUTED with disputeState", () => {
+    const bad = { ...validNonDisputed, disputeState: DisputeState.RESOLVING } as Record<
+      string,
+      unknown
+    >;
+    expect(escrowNextActionsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects unknown top-level field", () => {
+    const bad = { ...validNonDisputed, surprise: "extra" } as Record<string, unknown>;
+    expect(escrowNextActionsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects unknown action-entry field", () => {
+    const bad = JSON.parse(JSON.stringify(validNonDisputed)) as Record<string, unknown>;
+    (bad.next as Array<Record<string, unknown>>)[0].surprise = "extra";
+    expect(escrowNextActionsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects missing exchangeId", () => {
+    const bad = { ...validNonDisputed } as Record<string, unknown>;
+    delete bad.exchangeId;
+    expect(escrowNextActionsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
+  });
+
+  it("rejects malformed deadline (not ISO 8601)", () => {
+    const bad = JSON.parse(JSON.stringify(validNonDisputed)) as Record<string, unknown>;
+    (bad.next as Array<Record<string, unknown>>)[0].deadline = "not-a-date";
+    expect(escrowNextActionsSchema.safeParse(bad).success).toBe(false);
+  });
+});

--- a/typescript/packages/core/test/schemes/escrow/payment-requirements.test.ts
+++ b/typescript/packages/core/test/schemes/escrow/payment-requirements.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import Ajv, { type ValidateFunction } from "ajv";
+import addFormats from "ajv-formats";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -24,7 +25,9 @@ const schemaPath = join(
   "payment_requirements.schema.json",
 );
 const jsonSchema = JSON.parse(readFileSync(schemaPath, "utf8"));
-const ajv = new Ajv({ allErrors: true, strict: false });
+// Register the standard JSON Schema string formats (notably `date-time`)
+// so Ajv actually enforces them — Ajv v8 ignores formats by default.
+const ajv = addFormats(new Ajv({ allErrors: true, strict: false }));
 const ajvValidate: ValidateFunction = ajv.compile(jsonSchema);
 
 const cloneFixture = (): typeof validRequirements => JSON.parse(JSON.stringify(validRequirements));
@@ -121,5 +124,6 @@ describe("EscrowPaymentRequirements — actions.next[].deadline", () => {
     const bad = cloneFixture();
     bad.actions.next[0].deadline = "not-a-date";
     expect(escrowPaymentRequirementsSchema.safeParse(bad).success).toBe(false);
+    expect(ajvValidate(bad)).toBe(false);
   });
 });

--- a/typescript/packages/core/test/schemes/escrow/payment-requirements.test.ts
+++ b/typescript/packages/core/test/schemes/escrow/payment-requirements.test.ts
@@ -108,3 +108,18 @@ describe("EscrowPaymentRequirements — rejection cases", () => {
     expect(ajvValidate(bad)).toBe(false);
   });
 });
+
+describe("EscrowPaymentRequirements — actions.next[].deadline", () => {
+  it("accepts an ISO 8601 deadline on an action entry", () => {
+    const ok = cloneFixture();
+    ok.actions.next[0].deadline = "2026-05-15T00:00:00Z";
+    expect(escrowPaymentRequirementsSchema.safeParse(ok).success).toBe(true);
+    expect(ajvValidate(ok)).toBe(true);
+  });
+
+  it("rejects a malformed deadline", () => {
+    const bad = cloneFixture();
+    bad.actions.next[0].deadline = "not-a-date";
+    expect(escrowPaymentRequirementsSchema.safeParse(bad).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Add the pure envelope builders to [`@bosonprotocol/x402-actions`](typescript/packages/actions/):

- **`deriveInitialNextActions(registry, decorations?)`** — builds the initial 402 envelope (PRE_COMMIT), emitting the two commit-time actions in spec order.
- **`deriveNextActions({ exchangeId, exchangeState, disputeState? }, registry, decorations?)`** — builds the post-commit `EscrowNextActions` for any exchange state, with the `exchangeState === DISPUTED ↔ disputeState present` invariant encoded structurally on the input.

Both are pure: no I/O, no protocol calls. They drive entirely off the `clientLegalActions(...)` table in [`@bosonprotocol/x402-core/state-machine`](typescript/packages/core/src/state-machine/) and the seller's `ChannelRegistry`. Optional `decorations.deadlines` plumbs through caller-computed deadlines per action.

### Wire-format additions in `@bosonprotocol/x402-core`

- New `EscrowNextActions` type + zod validator (`escrowNextActionsSchema` / `parseEscrowNextActions`) and JSON Schema [`schemas/next_actions.schema.json`](typescript/packages/core/src/schemes/escrow/schemas/next_actions.schema.json) for the post-commit envelope. Encodes the DISPUTED↔disputeState invariant in both layers.
- Optional ISO 8601 `deadline` on `NextAction` and on `payment_requirements.schema.json`'s `actions.next[]` items, with paired zod + ajv tests.

### Naming + ordering choices

- The post-commit envelope's exchange-state field is named **`exchangeState`** (not `state`) for symmetry with `disputeState` and to remove ambiguity with the subgraph entity's own `state` field. Spec doc 04 example updated.
- `next_actions.schema.json` enum value orders mirror the on-chain Solidity declarations in [`BosonTypes.sol`](https://github.com/bosonprotocol/boson-protocol-contracts/blob/main/contracts/domain/BosonTypes.sol):
  - `exchangeState: [COMMITTED, REVOKED, CANCELLED, REDEEMED, COMPLETED, DISPUTED]`
  - `disputeState: [RESOLVING, RETRACTED, RESOLVED, ESCALATED, DECIDED, REFUSED]`
  
  String values keep core-sdk's uppercase form (`"CANCELLED"` etc.) so consumers passing `subgraph.ExchangeState.X` produce valid envelopes without conversion. The on-chain Solidity enum spells the third value `Canceled` (single-L) while core-sdk uppercases it to `"CANCELLED"` (double-L) — that's a pre-existing upstream divergence we inherit, not introduced here.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm build` (DTS clean across all packages)
- [x] `pnpm test` — 99 core + 2 fulfillment + 28 actions = **129 tests, all green**

Coverage:
- 21 table-driven tests in `actions` covering every `(exchangeState, disputeState?)` tuple including PRE_COMMIT, all six `ExchangeState` values, and all six `DisputeState` values, plus zod round-trip checks against the new core schema.
- 7 zod+ajv tests in `core` for the new envelope, including invariant rejection cases (DISPUTED without disputeState, non-DISPUTED with disputeState) and deadline rejection cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side envelope builders to produce pre- and post-commit next-actions.
  * Optional ISO 8601 deadlines for time‑bounded actions.
  * Strategy‑specific meta‑transaction entrypoints and clearer MCP/fallback routing.
  * Formal post‑commit "next actions" envelope with explicit exchange/dispute fields.

* **Documentation**
  * Specs updated for meta‑tx routing, exchange/dispute naming, MCP routing, and fallback/action facet behavior.

* **Tests**
  * Extensive validation and behavioral tests plus shared registry fixtures and cross‑schema checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/24)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->