### PR TITLE
feat(actions): auto-stamp fallback.onchainHints from emitted actions

### DIFF
--- a/.changeset/onchain-hints-stamper.md
+++ b/.changeset/onchain-hints-stamper.md
@@ -14,13 +14,18 @@ over `ActionId` so adding a new action forces a paired facet entry.
 In `@bosonprotocol/x402-actions`:
 
 - Add `buildOnchainHints(escrow, actionIds)`, `actionFacetsFor(actionIds)`,
-  and the `META_TX_FACET` / `META_TX_ENTRYPOINT` constants — pure
+  and the `META_TX_FACET` / `META_TX_ENTRYPOINTS` constants — pure
   helpers that bundle `ACTION_FACETS` with the BPIP-12 meta-tx
-  entry-point names.
+  entry-point names. `META_TX_ENTRYPOINTS` is keyed by
+  `TokenAuthStrategy`: `none` → `executeMetaTransaction` (legacy
+  BPIP-9), the other three → BPIP-12's
+  `executeMetaTransactionWithTokenTransferAuthorization`.
 - Refactor `ChannelRegistry`: replace the nested
   `fallback: ActionsFallback` block with discrete top-level fields
-  (`xmtp?`, `mcp?`, `escrow?`). When `escrow` is set, the envelope's
-  `fallback.onchainHints` is populated automatically from the emitted
-  action ids — sellers no longer maintain that mapping by hand.
+  (`xmtp?`, `mcp?`, required `escrow`). The envelope's
+  `fallback.onchainHints` is populated automatically from
+  `registry.escrow` plus the emitted action ids — sellers no longer
+  maintain that mapping by hand, and the `onchain` channel is
+  guaranteed reachable for every emitted action.
 - Wire the stamper into `deriveNextActions` /
   `deriveInitialNextActions`. PR-2 tests updated.

--- a/.changeset/onchain-hints-stamper.md
+++ b/.changeset/onchain-hints-stamper.md
@@ -1,0 +1,26 @@
+---
+"@bosonprotocol/x402-actions": minor
+"@bosonprotocol/x402-core": minor
+---
+
+Auto-stamp `fallback.onchainHints` in the `nextActions` envelope.
+
+In `@bosonprotocol/x402-core`: add `ACTION_FACETS: Record<ActionId,
+string>` to `state-machine` — the canonical action-id → Boson Diamond
+facet mapping (e.g. `boson-redeem` → `ExchangeHandlerFacet`,
+`boson-raiseDispute` → `DisputeHandlerFacet`). The keys are exhaustive
+over `ActionId` so adding a new action forces a paired facet entry.
+
+In `@bosonprotocol/x402-actions`:
+
+- Add `buildOnchainHints(escrow, actionIds)`, `actionFacetsFor(actionIds)`,
+  and the `META_TX_FACET` / `META_TX_ENTRYPOINT` constants — pure
+  helpers that bundle `ACTION_FACETS` with the BPIP-12 meta-tx
+  entry-point names.
+- Refactor `ChannelRegistry`: replace the nested
+  `fallback: ActionsFallback` block with discrete top-level fields
+  (`xmtp?`, `mcp?`, `escrow?`). When `escrow` is set, the envelope's
+  `fallback.onchainHints` is populated automatically from the emitted
+  action ids — sellers no longer maintain that mapping by hand.
+- Wire the stamper into `deriveNextActions` /
+  `deriveInitialNextActions`. PR-2 tests updated.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,10 +54,6 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
-  
-  typescript/packages/actions/dist/cjs: {}
-
-  typescript/packages/actions/dist/esm: {}
 
   typescript/packages/core:
     dependencies:

--- a/typescript/packages/actions/src/derive.ts
+++ b/typescript/packages/actions/src/derive.ts
@@ -12,6 +12,7 @@
 import type {
   ActionsEnvelope,
   ActionChannel,
+  ActionsFallback,
   EscrowNextActions,
   NextAction,
 } from "@bosonprotocol/x402-core/schemes/escrow";
@@ -24,6 +25,7 @@ import {
   type DisputeState,
 } from "@bosonprotocol/x402-core/state-machine";
 
+import { ACTION_FACETS, buildOnchainHints } from "./onchain-hints.js";
 import type { ChannelRegistry } from "./registry/index.js";
 
 /**
@@ -60,6 +62,20 @@ export type DeriveNextActionsInput = {
 );
 
 /**
+ * Build the `fallback` block from the registry's discrete sub-fields.
+ * On-chain fallback is mandatory, and `actionFacets` is computed from
+ * emitted actions so the seller never maintains it by hand.
+ */
+function buildFallback(registry: ChannelRegistry, actionIds: readonly ActionId[]): ActionsFallback {
+  const fallback: ActionsFallback = {
+    onchainHints: buildOnchainHints(registry.escrow, actionIds),
+  };
+  if (registry.xmtp !== undefined) fallback.xmtp = registry.xmtp;
+  if (registry.mcp !== undefined) fallback.mcp = registry.mcp;
+  return fallback;
+}
+
+/**
  * Build the inner `ActionsEnvelope` (the `next[]` + `fallback` block)
  * shared by both pre-commit and post-commit envelopes.
  */
@@ -75,7 +91,7 @@ function buildEnvelope(
     // reject envelopes built from a `ChannelRegistry` whose `channels`
     // list contains duplicates (a caller bypassing `buildChannelRegistry`).
     const seen = new Set<ActionChannel>();
-    const channels = registry.channels.filter((channel) => {
+    const channels = effectiveChannels(registry).filter((channel) => {
       if (seen.has(channel)) return false;
       if (!isUsableChannel(channel, id, registry, serverEndpoint)) return false;
       seen.add(channel);
@@ -96,7 +112,19 @@ function buildEnvelope(
     return entry;
   });
 
-  return { next, fallback: registry.fallback };
+  return {
+    next,
+    fallback: buildFallback(
+      registry,
+      next.map((entry) => entry.id as ActionId),
+    ),
+  };
+}
+
+function effectiveChannels(registry: ChannelRegistry): readonly ActionChannel[] {
+  return registry.channels.includes("onchain")
+    ? registry.channels
+    : [...registry.channels, "onchain"];
 }
 
 function isUsableChannel(
@@ -109,11 +137,11 @@ function isUsableChannel(
     case "server":
       return serverEndpoint !== undefined;
     case "mcp":
-      return registry.fallback.mcp !== undefined;
+      return registry.mcp !== undefined;
     case "xmtp":
-      return registry.fallback.xmtp !== undefined;
+      return registry.xmtp !== undefined;
     case "onchain":
-      return registry.fallback.onchainHints.actionFacets[actionId] !== undefined;
+      return registry.escrow.length > 0 && ACTION_FACETS[actionId] !== undefined;
     case "facilitator":
       return true;
   }

--- a/typescript/packages/actions/src/index.ts
+++ b/typescript/packages/actions/src/index.ts
@@ -25,3 +25,11 @@ export type { ChannelRegistry } from "./registry/index.js";
 
 export type { DeriveDecorations, DeriveNextActionsInput } from "./derive.js";
 export { deriveInitialNextActions, deriveNextActions } from "./derive.js";
+
+export {
+  ACTION_FACETS,
+  META_TX_ENTRYPOINTS,
+  META_TX_FACET,
+  actionFacetsFor,
+  buildOnchainHints,
+} from "./onchain-hints.js";

--- a/typescript/packages/actions/src/onchain-hints.ts
+++ b/typescript/packages/actions/src/onchain-hints.ts
@@ -52,8 +52,8 @@ export const META_TX_ENTRYPOINTS: Readonly<Record<TokenAuthStrategy, string>> = 
  * `fallback.onchainHints.actionFacets` only for the actions the
  * envelope actually advertises, keeping the wire format compact.
  */
-export function actionFacetsFor(actionIds: readonly ActionId[]): Record<ActionId, string> {
-  const out = {} as Record<ActionId, string>;
+export function actionFacetsFor(actionIds: readonly ActionId[]): Record<string, string> {
+  const out: Record<string, string> = {};
   for (const id of actionIds) {
     out[id] = ACTION_FACETS[id];
   }

--- a/typescript/packages/actions/src/onchain-hints.ts
+++ b/typescript/packages/actions/src/onchain-hints.ts
@@ -1,0 +1,78 @@
+// `fallback.onchainHints` stamper — pure mapping from action ids to
+// their owning facet, paired with the meta-tx entry-point constants.
+//
+// Source of truth for the action → facet table is `ACTION_FACETS` in
+// `@bosonprotocol/x402-core/state-machine`. This module is the
+// consumer-facing helper that bundles those constants with the
+// per-`tokenAuthStrategy` meta-tx entry-point names so the server SDK
+// never has to hand-author a `fallback.onchainHints` block.
+
+import type { OnchainHints, TokenAuthStrategy } from "@bosonprotocol/x402-core/schemes/escrow";
+import { ACTION_FACETS, type ActionId } from "@bosonprotocol/x402-core/state-machine";
+
+export { ACTION_FACETS } from "@bosonprotocol/x402-core/state-machine";
+
+/**
+ * Boson Diamond facet that hosts the BPIP-9 / BPIP-12 meta-transaction
+ * entry-points used by the `facilitator` and `onchain` channels.
+ * Constant — every meta-tx we forward goes through this facet.
+ *
+ * Intentionally not pinned to a specific contract version: this is the
+ * facet *name*, which is stable across protocol upgrades; the exact
+ * deployed-contract address is resolved separately via the seller's
+ * escrow address and the Diamond's facet registry.
+ */
+export const META_TX_FACET = "MetaTransactionsHandlerFacet" as const;
+
+/**
+ * Per-`tokenAuthStrategy` meta-tx entry points on `META_TX_FACET`.
+ *
+ * - `none` — legacy BPIP-9 entry point (`executeMetaTransaction`).
+ *   Used when the buyer has pre-approved the Diamond, and for any
+ *   post-commit action that doesn't move tokens
+ *   (`redeem` / `complete` / dispute transitions).
+ * - `erc3009` / `permit` / `permit2` — BPIP-12 entry point
+ *   (`executeMetaTransactionWithTokenTransferAuthorization`), which
+ *   carries the buyer's signed `MetaTransaction` *and* a queue of
+ *   token-transfer authorizations.
+ *
+ * Constant — these are protocol-level invariants; the seller does not
+ * configure them.
+ */
+export const META_TX_ENTRYPOINTS: Readonly<Record<TokenAuthStrategy, string>> = {
+  none: "executeMetaTransaction",
+  erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
+  permit: "executeMetaTransactionWithTokenTransferAuthorization",
+  permit2: "executeMetaTransactionWithTokenTransferAuthorization",
+} as const;
+
+/**
+ * Build the subset of `ACTION_FACETS` for a given list of action ids.
+ * Used by `deriveNextActions` to populate
+ * `fallback.onchainHints.actionFacets` only for the actions the
+ * envelope actually advertises, keeping the wire format compact.
+ */
+export function actionFacetsFor(actionIds: readonly ActionId[]): Record<ActionId, string> {
+  const out = {} as Record<ActionId, string>;
+  for (const id of actionIds) {
+    out[id] = ACTION_FACETS[id];
+  }
+  return out;
+}
+
+/**
+ * Build the full `fallback.onchainHints` block for an envelope.
+ *
+ * Consumers pass the seller's escrow (Boson Diamond) address and the
+ * action ids that the envelope is going to advertise; the helper
+ * returns a fully-populated `OnchainHints` ready to drop into
+ * `nextActions.fallback.onchainHints`.
+ */
+export function buildOnchainHints(escrow: string, actionIds: readonly ActionId[]): OnchainHints {
+  return {
+    escrow,
+    metaTxFacet: META_TX_FACET,
+    metaTxEntrypoints: { ...META_TX_ENTRYPOINTS },
+    actionFacets: actionFacetsFor(actionIds),
+  };
+}

--- a/typescript/packages/actions/src/registry/index.ts
+++ b/typescript/packages/actions/src/registry/index.ts
@@ -1,30 +1,41 @@
 // Channel registry — the per-seller configuration consumed by
-// `deriveNextActions` (PR follow-up) to stamp each `ActionEntry` with
-// the right channels, endpoints, and fallback hints.
+// `deriveNextActions` to stamp each `ActionEntry` with the right
+// channels, endpoints, and envelope-level fallback hints.
 //
 // Source of truth: docs/boson-impl-04-state-machine-and-next-actions.md
-// §"Server-side derivation". The actual `deriveNextActions` function
-// lands in a follow-up PR; this module ships only the configuration
-// type so the server SDK can begin to type against it.
+// §"Server-side derivation".
 
-import type { ActionsFallback, OnchainHints } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { ActionId } from "@bosonprotocol/x402-core/state-machine";
 
 import type { Channel } from "../channels/index.js";
 
 /**
- * Per-seller channel configuration. Passed to `deriveNextActions` (PR
- * follow-up) which uses it to stamp each `ActionEntry`:
+ * Per-seller channel configuration.
  *
- * - `channels` — the seller's preferred channel order. Clients are
- *   free to override based on their own policy (e.g. agentic clients
- *   may always prefer `onchain` or `mcp`); ordering on the wire is a
- *   *hint*, not a constraint.
+ * The fallback block on the wire is composed of three independent
+ * sub-fields (`xmtp`, `mcp`, `onchainHints`). Each one is gated on a
+ * separate piece of seller config; lifting them to the registry
+ * top-level is more ergonomic than nesting a partial `ActionsFallback`
+ * here, and lets `deriveNextActions` populate
+ * `fallback.onchainHints.actionFacets` automatically from the action
+ * ids it ends up emitting (so the seller doesn't have to maintain that
+ * mapping by hand).
+ *
+ * - `channels` — the seller's preferred channel order. Clients are free
+ *   to override based on their own policy (e.g. agentic clients may
+ *   always prefer `onchain` or `mcp`); ordering on the wire is a hint,
+ *   not a constraint.
  * - `endpoints` — per-action HTTP endpoint overrides for the `server`
  *   channel. Actions absent from this map have no `server` endpoint.
- * - `fallback` — the `xmtp` / `mcp` / required `onchainHints` block
- *   that ends up at `nextActions.fallback`. On-chain fallback is always
- *   present so every advertised action has a censorship-resistant path.
+ * - `xmtp` — seller's XMTP address. Stamped into `fallback.xmtp`.
+ * - `mcp` — identifier within the **escrow's** Boson MCP server
+ *   (one shared `bosonprotocol/agentic-commerce` server across every
+ *   Boson seller, not a per-seller MCP). Stamped into `fallback.mcp`;
+ *   the BosonMCP routes the identifier to the right exchange.
+ * - `escrow` — required Boson Diamond address.
+ *   `deriveNextActions` populates the full `fallback.onchainHints`
+ *   block (the meta-tx facet/entry-point constants plus the
+ *   per-emitted-action facets) automatically.
  */
 export interface ChannelRegistry {
   /** The seller's preferred channel order. */
@@ -37,16 +48,22 @@ export interface ChannelRegistry {
    */
   endpoints?: Partial<Record<ActionId, string>>;
 
+  /** Seller's XMTP address. Stamped into `fallback.xmtp`. */
+  xmtp?: string;
+
   /**
-   * Fallback hints embedded in the envelope's `fallback` field. The
-   * `actionFacets` map is `Partial` because a seller is not obliged to
-   * advertise every `ActionId` — actions absent from the map are
-   * effectively excluded from the `onchain` channel for that exchange
-   * (see `isUsableChannel` in `derive.ts`).
+   * Identifier within the escrow's Boson MCP server (the
+   * `bosonprotocol/agentic-commerce` MCP). Stamped into
+   * `fallback.mcp`. The MCP server itself is escrow-level and shared
+   * across every Boson seller; this value is the per-exchange routing
+   * URI the BosonMCP resolves.
    */
-  fallback: Omit<ActionsFallback, "onchainHints"> & {
-    onchainHints: Omit<OnchainHints, "actionFacets"> & {
-      actionFacets: Partial<Record<ActionId, string>>;
-    };
-  };
+  mcp?: string;
+
+  /**
+   * Boson Diamond address. The envelope's
+   * `fallback.onchainHints` block is populated automatically from this
+   * address plus the action ids the envelope advertises.
+   */
+  escrow: string;
 }

--- a/typescript/packages/actions/test/derive.test.ts
+++ b/typescript/packages/actions/test/derive.test.ts
@@ -46,14 +46,60 @@ describe("deriveInitialNextActions (PRE_COMMIT)", () => {
     ).toBeUndefined();
   });
 
-  it("emits the fallback block when populated", () => {
+  it("emits xmtp/mcp from the registry into fallback", () => {
     const envelope = deriveInitialNextActions(REGISTRY);
-    expect(envelope.fallback).toEqual(REGISTRY.fallback);
+    expect(envelope.fallback?.xmtp).toBe("0xSellerXMTP");
+    expect(envelope.fallback?.mcp).toBe("boson://seller/12345");
   });
 
-  it("always emits the on-chain fallback block", () => {
+  it("auto-stamps onchainHints from the registry's escrow + emitted actions", () => {
     const envelope = deriveInitialNextActions(REGISTRY);
-    expect(envelope.fallback?.onchainHints).toEqual(REGISTRY.fallback.onchainHints);
+    expect(envelope.fallback?.onchainHints).toEqual({
+      escrow: "0x0000000000000000000000000000000000000001",
+      metaTxFacet: "MetaTransactionsHandlerFacet",
+      metaTxEntrypoints: {
+        none: "executeMetaTransaction",
+        erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
+        permit: "executeMetaTransactionWithTokenTransferAuthorization",
+        permit2: "executeMetaTransactionWithTokenTransferAuthorization",
+      },
+      actionFacets: {
+        "boson-createOfferAndCommit": "ExchangeCommitFacet",
+        "boson-createOfferCommitAndRedeem": "OrchestrationHandlerFacet2",
+      },
+    });
+  });
+
+  it("emits mandatory onchainHints even when no optional fallback fields are configured", () => {
+    const envelope = deriveInitialNextActions({
+      channels: ["onchain"],
+      escrow: "0x0000000000000000000000000000000000000001",
+    });
+    expect(envelope.fallback?.onchainHints).toEqual({
+      escrow: "0x0000000000000000000000000000000000000001",
+      metaTxFacet: "MetaTransactionsHandlerFacet",
+      metaTxEntrypoints: {
+        none: "executeMetaTransaction",
+        erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
+        permit: "executeMetaTransactionWithTokenTransferAuthorization",
+        permit2: "executeMetaTransactionWithTokenTransferAuthorization",
+      },
+      actionFacets: {
+        "boson-createOfferAndCommit": "ExchangeCommitFacet",
+        "boson-createOfferCommitAndRedeem": "OrchestrationHandlerFacet2",
+      },
+    });
+  });
+
+  it("adds the mandatory onchain channel when omitted from preferred order", () => {
+    const envelope = deriveInitialNextActions({
+      channels: ["mcp"],
+      mcp: "boson://seller/12345",
+      escrow: "0x0000000000000000000000000000000000000001",
+    });
+    for (const entry of envelope.next) {
+      expect(entry.channels).toEqual(["mcp", "onchain"]);
+    }
   });
 });
 
@@ -89,30 +135,7 @@ describe("deriveNextActions — non-DISPUTED states", () => {
       { exchangeId: "12345", exchangeState: ExchangeState.REDEEMED },
       {
         channels: ["server", "facilitator", "onchain", "mcp", "xmtp"],
-        fallback: {
-          onchainHints: {
-            escrow: "0x0000000000000000000000000000000000000001",
-            metaTxFacet: "MetaTransactionsHandlerFacet",
-            metaTxEntrypoints: {
-              none: "executeMetaTransaction",
-              erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
-              permit: "executeMetaTransactionWithTokenTransferAuthorization",
-              permit2: "executeMetaTransactionWithTokenTransferAuthorization",
-            },
-            actionFacets: {
-              "boson-createOfferAndCommit": "ExchangeCommitFacet",
-              "boson-createOfferCommitAndRedeem": "OrchestrationHandlerFacet2",
-              "boson-redeem": "ExchangeHandlerFacet",
-              "boson-cancelVoucher": "ExchangeHandlerFacet",
-              "boson-revokeVoucher": "ExchangeHandlerFacet",
-              "boson-completeExchange": "ExchangeHandlerFacet",
-              "boson-raiseDispute": "DisputeHandlerFacet",
-              "boson-resolveDispute": "DisputeHandlerFacet",
-              "boson-escalateDispute": "DisputeHandlerFacet",
-              "boson-retractDispute": "DisputeHandlerFacet",
-            },
-          },
-        },
+        escrow: "0x0000000000000000000000000000000000000001",
       },
     );
 
@@ -141,18 +164,25 @@ describe("deriveNextActions — non-DISPUTED states", () => {
 });
 
 describe("deriveNextActions — unusable actions", () => {
-  it("throws when no configured channel can be used for a legal action", () => {
-    expect(() =>
-      deriveNextActions(
-        { exchangeId: "12345", exchangeState: ExchangeState.REDEEMED },
-        {
-          channels: ["server", "mcp", "xmtp"],
-          fallback: {
-            onchainHints: REGISTRY.fallback.onchainHints,
-          },
-        },
-      ),
-    ).toThrow("No usable channel configured for action boson-completeExchange");
+  it("uses mandatory onchain fallback when no optional configured channel can be used", () => {
+    const envelope = deriveNextActions(
+      { exchangeId: "12345", exchangeState: ExchangeState.REDEEMED },
+      {
+        channels: ["server", "mcp", "xmtp"],
+        escrow: "0x0000000000000000000000000000000000000001",
+      },
+    );
+
+    expect(envelope.next).toEqual([
+      {
+        id: "boson-completeExchange",
+        channels: ["onchain"],
+      },
+      {
+        id: "boson-raiseDispute",
+        channels: ["onchain"],
+      },
+    ]);
   });
 });
 

--- a/typescript/packages/actions/test/fixtures/registry.ts
+++ b/typescript/packages/actions/test/fixtures/registry.ts
@@ -10,30 +10,7 @@ export const REGISTRY: ChannelRegistry = {
     "boson-redeem": "https://seller.example/x402B/redeem",
     "boson-cancelVoucher": "https://seller.example/x402B/cancel",
   },
-  fallback: {
-    xmtp: "0xSellerXMTP",
-    mcp: "boson://seller/12345",
-    onchainHints: {
-      escrow: "0x0000000000000000000000000000000000000001",
-      metaTxFacet: "MetaTransactionsHandlerFacet",
-      metaTxEntrypoints: {
-        none: "executeMetaTransaction",
-        erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
-        permit: "executeMetaTransactionWithTokenTransferAuthorization",
-        permit2: "executeMetaTransactionWithTokenTransferAuthorization",
-      },
-      actionFacets: {
-        "boson-createOfferAndCommit": "ExchangeCommitFacet",
-        "boson-createOfferCommitAndRedeem": "OrchestrationHandlerFacet2",
-        "boson-redeem": "ExchangeHandlerFacet",
-        "boson-cancelVoucher": "ExchangeHandlerFacet",
-        "boson-revokeVoucher": "ExchangeHandlerFacet",
-        "boson-completeExchange": "ExchangeHandlerFacet",
-        "boson-raiseDispute": "DisputeHandlerFacet",
-        "boson-resolveDispute": "DisputeHandlerFacet",
-        "boson-escalateDispute": "DisputeHandlerFacet",
-        "boson-retractDispute": "DisputeHandlerFacet",
-      },
-    },
-  },
+  xmtp: "0xSellerXMTP",
+  mcp: "boson://seller/12345",
+  escrow: "0x0000000000000000000000000000000000000001",
 };

--- a/typescript/packages/actions/test/onchain-hints.test.ts
+++ b/typescript/packages/actions/test/onchain-hints.test.ts
@@ -1,0 +1,94 @@
+import { ACTION_IDS, type ActionId } from "@bosonprotocol/x402-core/state-machine";
+import { describe, expect, it } from "vitest";
+
+import {
+  ACTION_FACETS,
+  META_TX_ENTRYPOINTS,
+  META_TX_FACET,
+  actionFacetsFor,
+  buildOnchainHints,
+} from "../src/index.js";
+
+const ESCROW = "0x0000000000000000000000000000000000000042";
+
+describe("ACTION_FACETS", () => {
+  it("has an entry for every action id", () => {
+    for (const id of ACTION_IDS) {
+      expect(ACTION_FACETS[id]).toBeTypeOf("string");
+      expect(ACTION_FACETS[id].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("groups exchange-lifecycle actions on ExchangeHandlerFacet", () => {
+    expect(ACTION_FACETS["boson-redeem"]).toBe("ExchangeHandlerFacet");
+    expect(ACTION_FACETS["boson-cancelVoucher"]).toBe("ExchangeHandlerFacet");
+    expect(ACTION_FACETS["boson-revokeVoucher"]).toBe("ExchangeHandlerFacet");
+    expect(ACTION_FACETS["boson-completeExchange"]).toBe("ExchangeHandlerFacet");
+  });
+
+  it("groups all four dispute transitions on DisputeHandlerFacet", () => {
+    expect(ACTION_FACETS["boson-raiseDispute"]).toBe("DisputeHandlerFacet");
+    expect(ACTION_FACETS["boson-resolveDispute"]).toBe("DisputeHandlerFacet");
+    expect(ACTION_FACETS["boson-escalateDispute"]).toBe("DisputeHandlerFacet");
+    expect(ACTION_FACETS["boson-retractDispute"]).toBe("DisputeHandlerFacet");
+  });
+
+  it("routes commit-time actions to their specific facets", () => {
+    expect(ACTION_FACETS["boson-createOfferAndCommit"]).toBe("ExchangeCommitFacet");
+    expect(ACTION_FACETS["boson-createOfferCommitAndRedeem"]).toBe("OrchestrationHandlerFacet2");
+  });
+});
+
+describe("actionFacetsFor", () => {
+  it("returns only the requested action ids", () => {
+    const subset: readonly ActionId[] = ["boson-redeem", "boson-completeExchange"];
+    expect(actionFacetsFor(subset)).toEqual({
+      "boson-redeem": "ExchangeHandlerFacet",
+      "boson-completeExchange": "ExchangeHandlerFacet",
+    });
+  });
+
+  it("returns an empty object for an empty list", () => {
+    expect(actionFacetsFor([])).toEqual({});
+  });
+});
+
+describe("META_TX_ENTRYPOINTS", () => {
+  it("maps `none` to the legacy BPIP-9 entry point", () => {
+    expect(META_TX_ENTRYPOINTS.none).toBe("executeMetaTransaction");
+  });
+
+  it("maps every token-auth strategy other than `none` to the BPIP-12 entry point", () => {
+    for (const strategy of ["erc3009", "permit", "permit2"] as const) {
+      expect(META_TX_ENTRYPOINTS[strategy]).toBe(
+        "executeMetaTransactionWithTokenTransferAuthorization",
+      );
+    }
+  });
+});
+
+describe("buildOnchainHints", () => {
+  it("stamps the meta-tx facet verbatim and includes both entry points", () => {
+    const hints = buildOnchainHints(ESCROW, ACTION_IDS);
+    expect(hints.metaTxFacet).toBe(META_TX_FACET);
+    expect(hints.metaTxEntrypoints).toEqual({
+      none: "executeMetaTransaction",
+      erc3009: "executeMetaTransactionWithTokenTransferAuthorization",
+      permit: "executeMetaTransactionWithTokenTransferAuthorization",
+      permit2: "executeMetaTransactionWithTokenTransferAuthorization",
+    });
+  });
+
+  it("populates actionFacets only for the requested action ids", () => {
+    const hints = buildOnchainHints(ESCROW, ["boson-raiseDispute", "boson-redeem"]);
+    expect(hints.actionFacets).toEqual({
+      "boson-raiseDispute": "DisputeHandlerFacet",
+      "boson-redeem": "ExchangeHandlerFacet",
+    });
+  });
+
+  it("uses the supplied escrow address verbatim", () => {
+    const hints = buildOnchainHints(ESCROW, []);
+    expect(hints.escrow).toBe(ESCROW);
+  });
+});

--- a/typescript/packages/actions/test/types.test.ts
+++ b/typescript/packages/actions/test/types.test.ts
@@ -85,7 +85,7 @@ describe("@bosonprotocol/x402-actions public types", () => {
     expectTypeOf<Parameters<Adapter["describe"]>[1]>().toEqualTypeOf<ServerCfg>();
   });
 
-  it("ChannelRegistry types channel order and per-action server endpoints", () => {
+  it("ChannelRegistry types channel order, endpoints, and discrete fallback fields", () => {
     expectTypeOf(REGISTRY).toMatchTypeOf<ChannelRegistry>();
     expectTypeOf(REGISTRY.channels).toMatchTypeOf<readonly Channel[]>();
   });

--- a/typescript/packages/core/src/state-machine/action-ids.ts
+++ b/typescript/packages/core/src/state-machine/action-ids.ts
@@ -84,3 +84,38 @@ export const ACTION_POST_STATE: Record<ActionId, ActionPostState> = {
     dispute: DisputeState.RETRACTED,
   },
 };
+
+/**
+ * Boson Diamond facet that exposes the on-chain primitive for each
+ * `ActionId`. Used by `@bosonprotocol/x402-actions` to populate the
+ * `fallback.onchainHints.actionFacets` block of a `nextActions`
+ * envelope so buyers can reach the underlying contract method directly
+ * via the `onchain` channel.
+ *
+ * Mapping rationale:
+ * - `boson-createOfferAndCommit` lives on `ExchangeCommitFacet` (the
+ *   deferred-redeem entry point per spec doc 04).
+ * - `boson-createOfferCommitAndRedeem` lives on
+ *   `OrchestrationHandlerFacet2` (the atomic-redeem entry point added
+ *   in boson-protocol-contracts PR #1105).
+ * - `boson-redeem`, `boson-cancelVoucher`, `boson-revokeVoucher`, and
+ *   `boson-completeExchange` are exchange-lifecycle methods on
+ *   `ExchangeHandlerFacet`.
+ * - All four dispute transitions (`raise` / `resolve` / `escalate` /
+ *   `retract`) live on `DisputeHandlerFacet`.
+ *
+ * The keys are intentionally exhaustive over `ActionId` so adding a
+ * new action id at compile time forces a paired facet entry.
+ */
+export const ACTION_FACETS: Record<ActionId, string> = {
+  "boson-createOfferAndCommit": "ExchangeCommitFacet",
+  "boson-createOfferCommitAndRedeem": "OrchestrationHandlerFacet2",
+  "boson-redeem": "ExchangeHandlerFacet",
+  "boson-cancelVoucher": "ExchangeHandlerFacet",
+  "boson-revokeVoucher": "ExchangeHandlerFacet",
+  "boson-completeExchange": "ExchangeHandlerFacet",
+  "boson-raiseDispute": "DisputeHandlerFacet",
+  "boson-resolveDispute": "DisputeHandlerFacet",
+  "boson-escalateDispute": "DisputeHandlerFacet",
+  "boson-retractDispute": "DisputeHandlerFacet",
+};


### PR DESCRIPTION
## Summary

Centralize the action-id → Boson Diamond facet mapping and add the consumer-facing helpers that let the server SDK stop hand-authoring `fallback.onchainHints`.

### `@bosonprotocol/x402-core`

- New `ACTION_FACETS: Record<ActionId, string>` in [`state-machine`](typescript/packages/core/src/state-machine/action-ids.ts), keys exhaustive over `ActionId` so adding a new action at compile time forces a paired facet entry. Mapping covers exchange-lifecycle methods on `ExchangeHandlerFacet`, the four dispute transitions on `DisputeHandlerFacet`, and the two commit-time entry points on `ExchangeCommitFacet` / `OrchestrationHandlerFacet2`.

### `@bosonprotocol/x402-actions`

- **`buildOnchainHints(escrow, actionIds)`** — full `OnchainHints` block with the meta-tx facet name and the per-`tokenAuthStrategy` entry-point map stamped in.
- **`actionFacetsFor(actionIds)`** — subset map for exactly the actions an envelope advertises.
- **`META_TX_FACET`** and **`META_TX_ENTRYPOINTS`** (`Record<TokenAuthStrategy, string>`) — exposed for callers that compose hints by hand. The map mirrors the protocol's two entry points: legacy `executeMetaTransaction` for `none` (and post-commit actions that don't move tokens) and BPIP-12's `executeMetaTransactionWithTokenTransferAuthorization` for the other three strategies.
- **Refactored `ChannelRegistry`** to discrete fallback fields (`xmtp?`, `mcp?`, `escrow?`) instead of a nested `ActionsFallback`. When `escrow` is set, `deriveNextActions` populates the envelope's `fallback.onchainHints` automatically — including the `actionFacets` map for exactly the actions the envelope ends up emitting. Sellers no longer maintain that mapping by hand.
- **`mcp` documented** as the routing identifier within the *escrow's* Boson MCP server (the shared `bosonprotocol/agentic-commerce` MCP), not a per-seller MCP.

PR-2 tests updated for the new registry shape; new exhaustive coverage of `ACTION_FACETS` / `actionFacetsFor` / `buildOnchainHints` / `META_TX_ENTRYPOINTS`.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm build` (DTS clean across all packages)
- [x] `pnpm test` — 99 core + 2 fulfillment + 41 actions = **142 tests, all green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic population of onchain hints (escrow, meta-transaction entrypoints, and action facets) in action envelopes
  * New helper APIs for building and deriving onchain hints; server helpers expose facet and entrypoint mappings

* **Breaking Changes**
  * Simplified channel registry configuration: top-level xmtp, mcp, and escrow fields replace the nested fallback structure

* **Tests**
  * Expanded tests covering auto-stamping, channel selection rules, and onchain-hints helpers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/25)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->