### PR TITLE
feat(actions): channel-registry helpers

### DIFF
--- a/.changeset/channel-registry-helpers.md
+++ b/.changeset/channel-registry-helpers.md
@@ -1,0 +1,18 @@
+---
+"@bosonprotocol/x402-actions": minor
+---
+
+Add channel-registry helpers to `@bosonprotocol/x402-actions`:
+
+- `buildChannelRegistry(input)` and `channelRegistryZodSchema` —
+  zod-validated constructor for `ChannelRegistry`. Catches malformed
+  URLs, malformed addresses, duplicate channel ids, unknown channel
+  ids, and unknown action-id keys at boot time rather than letting
+  bad config silently leak into `nextActions` envelopes.
+- `BUYER_ONCHAIN_FALLBACK`, `hasBuyerOnchainFallback(entry)`, and
+  `isBuyerOnchainResilient(id)` — codify the censorship-resistance
+  table from
+  docs/boson-impl-04-state-machine-and-next-actions.md
+  §"Censorship resistance — guarantees", letting clients short-circuit
+  channel fallback to direct on-chain submission when the seller's
+  preferred channels are unreachable.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@bosonprotocol/x402-core':
         specifier: workspace:^
         version: link:../core
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^20.17.10

--- a/typescript/packages/actions/package.json
+++ b/typescript/packages/actions/package.json
@@ -54,7 +54,8 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
-    "@bosonprotocol/x402-core": "workspace:^"
+    "@bosonprotocol/x402-core": "workspace:^",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/node": "^20.17.10",

--- a/typescript/packages/actions/src/index.ts
+++ b/typescript/packages/actions/src/index.ts
@@ -22,6 +22,13 @@ export type { Channel, ChannelAdapter } from "./channels/index.js";
 export { CHANNEL_IDS } from "./channels/index.js";
 
 export type { ChannelRegistry } from "./registry/index.js";
+export {
+  BUYER_ONCHAIN_FALLBACK,
+  buildChannelRegistry,
+  channelRegistryZodSchema,
+  hasBuyerOnchainFallback,
+  isBuyerOnchainResilient,
+} from "./registry/index.js";
 
 export type { DeriveDecorations, DeriveNextActionsInput } from "./derive.js";
 export { deriveInitialNextActions, deriveNextActions } from "./derive.js";

--- a/typescript/packages/actions/src/registry/builder.ts
+++ b/typescript/packages/actions/src/registry/builder.ts
@@ -6,6 +6,7 @@
 // Source of truth: docs/boson-impl-04-state-machine-and-next-actions.md
 // §"Channels".
 
+import { addressSchema } from "@bosonprotocol/x402-core/schemes/escrow";
 import { ACTION_IDS, type ActionId } from "@bosonprotocol/x402-core/state-machine";
 import { z } from "zod";
 
@@ -22,10 +23,6 @@ const httpsUrlSchema = z
   .refine((u) => u.startsWith("http://") || u.startsWith("https://"), {
     message: "must be an http(s) URL",
   });
-
-const addressSchema = z.string().regex(/^0x[a-fA-F0-9]{40}$/, {
-  message: "must be a 0x-prefixed 40-char hex address",
-});
 
 const channelRegistrySchema = z
   .object({

--- a/typescript/packages/actions/src/registry/builder.ts
+++ b/typescript/packages/actions/src/registry/builder.ts
@@ -38,7 +38,7 @@ const channelRegistrySchema = z
     endpoints: z.record(actionIdSchema, httpsUrlSchema).optional(),
     xmtp: addressSchema.optional(),
     mcp: z.string().min(1).optional(),
-    escrow: addressSchema.optional(),
+    escrow: addressSchema,
   })
   .strict();
 

--- a/typescript/packages/actions/src/registry/builder.ts
+++ b/typescript/packages/actions/src/registry/builder.ts
@@ -1,0 +1,73 @@
+// `buildChannelRegistry` — ergonomic constructor + zod validator for
+// `ChannelRegistry`. Catches mistakes in seller config at boot time
+// rather than letting them silently leak into `nextActions` envelopes
+// that fail downstream client validation.
+//
+// Source of truth: docs/boson-impl-04-state-machine-and-next-actions.md
+// §"Channels".
+
+import { ACTION_IDS, type ActionId } from "@bosonprotocol/x402-core/state-machine";
+import { z } from "zod";
+
+import { CHANNEL_IDS, type Channel } from "../channels/index.js";
+import type { ChannelRegistry } from "./index.js";
+
+const channelSchema = z.enum(CHANNEL_IDS as readonly [Channel, ...Channel[]]);
+
+const actionIdSchema = z.enum(ACTION_IDS as readonly [ActionId, ...ActionId[]]);
+
+const httpsUrlSchema = z
+  .string()
+  .url()
+  .refine((u) => u.startsWith("http://") || u.startsWith("https://"), {
+    message: "must be an http(s) URL",
+  });
+
+const addressSchema = z.string().regex(/^0x[a-fA-F0-9]{40}$/, {
+  message: "must be a 0x-prefixed 40-char hex address",
+});
+
+const channelRegistrySchema = z
+  .object({
+    channels: z
+      .array(channelSchema)
+      .min(1, { message: "at least one channel is required" })
+      .refine((channels) => new Set(channels).size === channels.length, {
+        message: "channels must contain unique items",
+      }),
+    endpoints: z.record(actionIdSchema, httpsUrlSchema).optional(),
+    xmtp: addressSchema.optional(),
+    mcp: z.string().min(1).optional(),
+    escrow: addressSchema.optional(),
+  })
+  .strict();
+
+/**
+ * Build a validated `ChannelRegistry` from raw seller config. Throws a
+ * `ZodError` (with field-level paths) on bad input — invalid URL,
+ * malformed address, duplicate channel id, unknown action id, etc.
+ *
+ * Usage:
+ *
+ * ```ts
+ * const registry = buildChannelRegistry({
+ *   channels: ["server", "facilitator", "onchain", "mcp"],
+ *   endpoints: {
+ *     "boson-redeem": "https://seller.example/x402B/redeem",
+ *   },
+ *   xmtp: "0xSellerXMTP...",
+ *   mcp: "boson://seller/12345",
+ *   escrow: "0xDIAMOND...",
+ * });
+ * ```
+ */
+export function buildChannelRegistry(input: ChannelRegistry): ChannelRegistry {
+  return channelRegistrySchema.parse(input) as ChannelRegistry;
+}
+
+/**
+ * Schema-only export for callers that want to validate without
+ * throwing — `safeParse` returns a discriminated `{ success, data |
+ * error }`.
+ */
+export const channelRegistryZodSchema = channelRegistrySchema;

--- a/typescript/packages/actions/src/registry/buyer-fallback.ts
+++ b/typescript/packages/actions/src/registry/buyer-fallback.ts
@@ -1,0 +1,66 @@
+// Buyer-only on-chain fallback table — codifies the censorship
+// resistance guarantees from
+// docs/boson-impl-04-state-machine-and-next-actions.md §"Censorship
+// resistance — guarantees".
+//
+// For each buyer-invokable action, the table records whether the buyer
+// can advance the exchange via the `onchain` channel without any
+// seller cooperation. Clients use this to short-circuit channel
+// fallback: if a server's preferred channels are all unreachable but
+// `BUYER_ONCHAIN_FALLBACK[action]` is `true`, the SDK signs and
+// submits the transaction directly.
+
+import type { ActionId } from "@bosonprotocol/x402-core/state-machine";
+
+import type { ActionEntry } from "../types.js";
+
+/**
+ * For each `ActionId`, whether the buyer has a guaranteed
+ * censorship-resistant on-chain path. Values come from the table at
+ * docs/boson-impl-04-state-machine-and-next-actions.md
+ * §"Censorship resistance — guarantees".
+ *
+ * Note: `boson-resolveDispute` requires a counterparty signature
+ * (it's the mutual settlement step), so the buyer cannot
+ * unilaterally complete it on-chain — `false`. `boson-revokeVoucher`
+ * is seller-only and not a buyer action; it's listed as `false` for
+ * type completeness but will never appear on a buyer-side envelope.
+ */
+export const BUYER_ONCHAIN_FALLBACK: Record<ActionId, boolean> = {
+  "boson-createOfferAndCommit": true,
+  "boson-createOfferCommitAndRedeem": true,
+  "boson-redeem": true,
+  "boson-cancelVoucher": true,
+  "boson-completeExchange": true,
+  "boson-raiseDispute": true,
+  "boson-escalateDispute": true,
+  "boson-retractDispute": true,
+  "boson-resolveDispute": false,
+  "boson-revokeVoucher": false,
+};
+
+/**
+ * Whether the buyer can complete this action on-chain without any
+ * seller cooperation.
+ *
+ * Two checks combined: the spec-level guarantee (action is one of the
+ * buyer-onchain-resilient ids) AND the envelope advertises `onchain`
+ * as one of its channels. A seller that advertises an action but
+ * omits `onchain` from `channels` has not made the censorship-resistant
+ * fallback available — the buyer must reach for the protocol facets
+ * directly via `fallback.onchainHints`.
+ */
+export function hasBuyerOnchainFallback(entry: ActionEntry): boolean {
+  if (!isBuyerOnchainResilient(entry.id)) return false;
+  return entry.channels.includes("onchain");
+}
+
+/**
+ * Whether the action id, in principle, supports a buyer-only on-chain
+ * path. Useful when validating registry config (e.g. warning the seller
+ * that their channel order doesn't expose onchain for an action that
+ * could otherwise have been censorship-resistant).
+ */
+export function isBuyerOnchainResilient(id: string): boolean {
+  return id in BUYER_ONCHAIN_FALLBACK ? BUYER_ONCHAIN_FALLBACK[id as ActionId] : false;
+}

--- a/typescript/packages/actions/src/registry/buyer-fallback.ts
+++ b/typescript/packages/actions/src/registry/buyer-fallback.ts
@@ -62,5 +62,9 @@ export function hasBuyerOnchainFallback(entry: ActionEntry): boolean {
  * could otherwise have been censorship-resistant).
  */
 export function isBuyerOnchainResilient(id: string): boolean {
-  return id in BUYER_ONCHAIN_FALLBACK ? BUYER_ONCHAIN_FALLBACK[id as ActionId] : false;
+  // Use `hasOwnProperty` rather than `in` so prototype keys like
+  // `"toString"` / `"constructor"` don't accidentally read as resilient.
+  return Object.prototype.hasOwnProperty.call(BUYER_ONCHAIN_FALLBACK, id)
+    ? BUYER_ONCHAIN_FALLBACK[id as ActionId]
+    : false;
 }

--- a/typescript/packages/actions/src/registry/index.ts
+++ b/typescript/packages/actions/src/registry/index.ts
@@ -9,6 +9,13 @@ import type { ActionId } from "@bosonprotocol/x402-core/state-machine";
 
 import type { Channel } from "../channels/index.js";
 
+export {
+  BUYER_ONCHAIN_FALLBACK,
+  hasBuyerOnchainFallback,
+  isBuyerOnchainResilient,
+} from "./buyer-fallback.js";
+export { buildChannelRegistry, channelRegistryZodSchema } from "./builder.js";
+
 /**
  * Per-seller channel configuration.
  *

--- a/typescript/packages/actions/test/buyer-fallback.test.ts
+++ b/typescript/packages/actions/test/buyer-fallback.test.ts
@@ -73,4 +73,13 @@ describe("isBuyerOnchainResilient", () => {
     expect(isBuyerOnchainResilient("boson-unknown")).toBe(false);
     expect(isBuyerOnchainResilient("not-a-boson-id")).toBe(false);
   });
+
+  it("returns false for `Object.prototype` keys (no prototype-chain leak)", () => {
+    // Regression: a naive `in` check would short-circuit to truthy on
+    // these (since they're inherited) and return `undefined` from the
+    // lookup, which is neither `true` nor `false`.
+    expect(isBuyerOnchainResilient("toString")).toBe(false);
+    expect(isBuyerOnchainResilient("constructor")).toBe(false);
+    expect(isBuyerOnchainResilient("hasOwnProperty")).toBe(false);
+  });
 });

--- a/typescript/packages/actions/test/buyer-fallback.test.ts
+++ b/typescript/packages/actions/test/buyer-fallback.test.ts
@@ -1,0 +1,76 @@
+import { ACTION_IDS } from "@bosonprotocol/x402-core/state-machine";
+import { describe, expect, it } from "vitest";
+
+import {
+  BUYER_ONCHAIN_FALLBACK,
+  hasBuyerOnchainFallback,
+  isBuyerOnchainResilient,
+  type ActionEntry,
+} from "../src/index.js";
+
+describe("BUYER_ONCHAIN_FALLBACK", () => {
+  it("has an entry for every action id", () => {
+    for (const id of ACTION_IDS) {
+      expect(BUYER_ONCHAIN_FALLBACK[id]).toBeTypeOf("boolean");
+    }
+  });
+
+  it("matches the spec table — buyer-resilient actions", () => {
+    // From docs/boson-impl-04-state-machine-and-next-actions.md
+    // §"Censorship resistance — guarantees".
+    expect(BUYER_ONCHAIN_FALLBACK["boson-redeem"]).toBe(true);
+    expect(BUYER_ONCHAIN_FALLBACK["boson-completeExchange"]).toBe(true);
+    expect(BUYER_ONCHAIN_FALLBACK["boson-raiseDispute"]).toBe(true);
+    expect(BUYER_ONCHAIN_FALLBACK["boson-escalateDispute"]).toBe(true);
+    expect(BUYER_ONCHAIN_FALLBACK["boson-retractDispute"]).toBe(true);
+    expect(BUYER_ONCHAIN_FALLBACK["boson-cancelVoucher"]).toBe(true);
+    expect(BUYER_ONCHAIN_FALLBACK["boson-createOfferAndCommit"]).toBe(true);
+    expect(BUYER_ONCHAIN_FALLBACK["boson-createOfferCommitAndRedeem"]).toBe(true);
+  });
+
+  it("excludes mutual / seller-only actions", () => {
+    expect(BUYER_ONCHAIN_FALLBACK["boson-resolveDispute"]).toBe(false);
+    expect(BUYER_ONCHAIN_FALLBACK["boson-revokeVoucher"]).toBe(false);
+  });
+});
+
+describe("hasBuyerOnchainFallback", () => {
+  it("returns true when the action is resilient AND the envelope advertises onchain", () => {
+    const entry: ActionEntry = {
+      id: "boson-redeem",
+      channels: ["server", "facilitator", "onchain"],
+    };
+    expect(hasBuyerOnchainFallback(entry)).toBe(true);
+  });
+
+  it("returns false when the envelope omits onchain", () => {
+    const entry: ActionEntry = {
+      id: "boson-redeem",
+      channels: ["server", "facilitator"],
+    };
+    expect(hasBuyerOnchainFallback(entry)).toBe(false);
+  });
+
+  it("returns false when the action is not buyer-resilient", () => {
+    const entry: ActionEntry = {
+      id: "boson-resolveDispute",
+      channels: ["server", "onchain"],
+    };
+    expect(hasBuyerOnchainFallback(entry)).toBe(false);
+  });
+});
+
+describe("isBuyerOnchainResilient", () => {
+  it("returns true for buyer-resilient action ids", () => {
+    expect(isBuyerOnchainResilient("boson-redeem")).toBe(true);
+  });
+
+  it("returns false for non-resilient action ids", () => {
+    expect(isBuyerOnchainResilient("boson-resolveDispute")).toBe(false);
+  });
+
+  it("returns false for unknown ids", () => {
+    expect(isBuyerOnchainResilient("boson-unknown")).toBe(false);
+    expect(isBuyerOnchainResilient("not-a-boson-id")).toBe(false);
+  });
+});

--- a/typescript/packages/actions/test/registry-builder.test.ts
+++ b/typescript/packages/actions/test/registry-builder.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { buildChannelRegistry, channelRegistryZodSchema } from "../src/index.js";
+
+describe("buildChannelRegistry — happy path", () => {
+  it("accepts the canonical full config", () => {
+    const registry = buildChannelRegistry({
+      channels: ["server", "facilitator", "onchain", "mcp"],
+      endpoints: {
+        "boson-redeem": "https://seller.example/x402B/redeem",
+        "boson-completeExchange": "https://seller.example/x402B/complete",
+      },
+      xmtp: "0xdddddddddddddddddddddddddddddddddddddddd",
+      mcp: "boson://seller/12345",
+      escrow: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    });
+    expect(registry.channels).toEqual(["server", "facilitator", "onchain", "mcp"]);
+    expect(registry.escrow).toBe("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+  });
+
+  it("accepts a minimal config (channels only)", () => {
+    const registry = buildChannelRegistry({ channels: ["onchain"] });
+    expect(registry.channels).toEqual(["onchain"]);
+  });
+});
+
+describe("buildChannelRegistry — rejection cases", () => {
+  it("rejects an empty channels array", () => {
+    expect(() => buildChannelRegistry({ channels: [] })).toThrow();
+  });
+
+  it("rejects duplicate channel ids", () => {
+    expect(() =>
+      buildChannelRegistry({
+        channels: ["server", "server"],
+      } as never),
+    ).toThrow();
+  });
+
+  it("rejects an unknown channel id", () => {
+    expect(() =>
+      buildChannelRegistry({
+        channels: ["server", "telegram"],
+      } as never),
+    ).toThrow();
+  });
+
+  it("rejects a non-https endpoint", () => {
+    expect(() =>
+      buildChannelRegistry({
+        channels: ["server"],
+        endpoints: { "boson-redeem": "ftp://seller.example/redeem" } as never,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an unknown action id key in endpoints", () => {
+    expect(() =>
+      buildChannelRegistry({
+        channels: ["server"],
+        endpoints: { "boson-doesnt-exist": "https://seller.example/x" } as never,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects a malformed escrow address", () => {
+    expect(() =>
+      buildChannelRegistry({
+        channels: ["onchain"],
+        escrow: "not-an-address",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an unknown top-level field", () => {
+    const result = channelRegistryZodSchema.safeParse({
+      channels: ["onchain"],
+      surprise: "extra",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("safeParse returns a structured ZodError", () => {
+    const result = channelRegistryZodSchema.safeParse({
+      channels: [],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/typescript/packages/actions/test/registry-builder.test.ts
+++ b/typescript/packages/actions/test/registry-builder.test.ts
@@ -18,21 +18,39 @@ describe("buildChannelRegistry — happy path", () => {
     expect(registry.escrow).toBe("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
   });
 
-  it("accepts a minimal config (channels only)", () => {
-    const registry = buildChannelRegistry({ channels: ["onchain"] });
+  it("accepts a minimal config", () => {
+    const registry = buildChannelRegistry({
+      channels: ["onchain"],
+      escrow: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    });
     expect(registry.channels).toEqual(["onchain"]);
+    expect(registry.escrow).toBe("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
   });
 });
 
 describe("buildChannelRegistry — rejection cases", () => {
   it("rejects an empty channels array", () => {
-    expect(() => buildChannelRegistry({ channels: [] })).toThrow();
+    expect(() =>
+      buildChannelRegistry({
+        channels: [],
+        escrow: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects a missing escrow address", () => {
+    expect(() =>
+      buildChannelRegistry({
+        channels: ["onchain"],
+      } as never),
+    ).toThrow();
   });
 
   it("rejects duplicate channel ids", () => {
     expect(() =>
       buildChannelRegistry({
         channels: ["server", "server"],
+        escrow: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       } as never),
     ).toThrow();
   });
@@ -41,6 +59,7 @@ describe("buildChannelRegistry — rejection cases", () => {
     expect(() =>
       buildChannelRegistry({
         channels: ["server", "telegram"],
+        escrow: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       } as never),
     ).toThrow();
   });
@@ -50,6 +69,7 @@ describe("buildChannelRegistry — rejection cases", () => {
       buildChannelRegistry({
         channels: ["server"],
         endpoints: { "boson-redeem": "ftp://seller.example/redeem" } as never,
+        escrow: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       }),
     ).toThrow();
   });
@@ -59,6 +79,7 @@ describe("buildChannelRegistry — rejection cases", () => {
       buildChannelRegistry({
         channels: ["server"],
         endpoints: { "boson-doesnt-exist": "https://seller.example/x" } as never,
+        escrow: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       }),
     ).toThrow();
   });
@@ -75,6 +96,7 @@ describe("buildChannelRegistry — rejection cases", () => {
   it("rejects an unknown top-level field", () => {
     const result = channelRegistryZodSchema.safeParse({
       channels: ["onchain"],
+      escrow: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       surprise: "extra",
     });
     expect(result.success).toBe(false);


### PR DESCRIPTION
## Summary

Two helper modules under [`@bosonprotocol/x402-actions/registry`](typescript/packages/actions/src/registry/):

- **`buildChannelRegistry(input)`** and the underlying **`channelRegistryZodSchema`** — zod-validated constructor for `ChannelRegistry`. Catches malformed URLs, malformed addresses, duplicate / unknown channel ids, and unknown action-id keys at boot time rather than letting bad seller config silently leak into `nextActions` envelopes that would then fail downstream client validation. `safeParse` returns a structured `ZodError` for callers that prefer not to throw.

- **`BUYER_ONCHAIN_FALLBACK`**, **`hasBuyerOnchainFallback(entry)`**, and **`isBuyerOnchainResilient(id)`** — codify the censorship-resistance table from [`docs/boson-impl-04`](docs/boson-impl-04-state-machine-and-next-actions.md) §"Censorship resistance — guarantees". Lets clients short-circuit channel fallback to direct on-chain submission when the seller's preferred channels are unreachable but the action is one of the buyer-resilient ids (every buyer-invokable action except the mutual `boson-resolveDispute`).

`zod` added as a runtime dependency (already used in `@bosonprotocol/x402-core` and `@bosonprotocol/x402-fulfillment`). Both helpers re-exported from the package root and the `./registry` subpath.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test` — 99 core + 2 fulfillment + 60 actions = **161 tests, all green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added channel registry validation with Zod schemas to detect malformed URLs/addresses and duplicate/unknown channel IDs
  * Introduced buyer onchain fallback helpers to ensure censorship‑resistant action execution when preferred channels are unavailable

* **Tests**
  * Added comprehensive tests covering registry validation, rejection cases, and buyer fallback behavior

* **Documentation**
  * Added a changeset documenting the new channel-registry helpers and fallback behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/26)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->