### PR TITLE
feat(client): scaffold @bosonprotocol/x402-client package

### DIFF
--- a/.changeset/prepare-client-package.md
+++ b/.changeset/prepare-client-package.md
@@ -1,0 +1,9 @@
+---
+"@bosonprotocol/x402-client": minor
+---
+
+Initial skeleton for `@bosonprotocol/x402-client`: ships the
+framework-agnostic buyer-side SDK package with typed configuration,
+signer adapters, typed errors, action selection, fulfillment resolution,
+and build/test/postbuild conventions matching the existing x402B
+TypeScript packages.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,10 +54,41 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
-  
+
   typescript/packages/actions/dist/cjs: {}
 
   typescript/packages/actions/dist/esm: {}
+
+  typescript/packages/client:
+    dependencies:
+      '@bosonprotocol/common':
+        specifier: ^1.32.2
+        version: 1.32.2
+      '@bosonprotocol/x402-core':
+        specifier: workspace:^
+        version: link:../core
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
+      viem:
+        specifier: ^2.39.3
+        version: 2.48.11(typescript@5.9.3)(zod@3.25.76)
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.10
+        version: 20.19.40
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.40)
 
   typescript/packages/core:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,10 +55,6 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
 
-  typescript/packages/actions/dist/cjs: {}
-
-  typescript/packages/actions/dist/esm: {}
-
   typescript/packages/client:
     dependencies:
       '@bosonprotocol/common':
@@ -73,9 +69,6 @@ importers:
       viem:
         specifier: ^2.39.3
         version: 2.48.11(typescript@5.9.3)(zod@3.25.76)
-      zod:
-        specifier: ^3.24.2
-        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^20.17.10
@@ -130,10 +123,6 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
 
-  typescript/packages/core/dist/cjs: {}
-
-  typescript/packages/core/dist/esm: {}
-
   typescript/packages/fulfillment:
     dependencies:
       '@bosonprotocol/x402-core':
@@ -161,10 +150,6 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
-
-  typescript/packages/fulfillment/dist/cjs: {}
-
-  typescript/packages/fulfillment/dist/esm: {}
 
 packages:
 

--- a/typescript/packages/client/LICENSE
+++ b/typescript/packages/client/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Boson Protocol
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/typescript/packages/client/README.md
+++ b/typescript/packages/client/README.md
@@ -1,0 +1,22 @@
+# @bosonprotocol/x402-client
+
+Framework-agnostic buyer-side SDK for [x402B](https://github.com/bosonprotocol/x402B) — Boson Protocol's implementation of the [`x402-escrow-schema`](https://github.com/bosonprotocol/x402-escrow-schema).
+
+This package intercepts a `402 Payment Required` carrying `scheme: "escrow"`, signs the buyer's Boson protocol meta-transaction + token-transfer authorization, and produces the `X-PAYMENT` header so the request can be re-issued.
+
+Adapters for specific HTTP clients are published as sibling packages — e.g. [`@bosonprotocol/x402-client-fetch`](../client-fetch) for native `fetch`.
+
+## Status
+
+Pre-release skeleton. The public API surface lands incrementally; the package currently exports types, errors, the signer adapter interface, and pure-function utilities (action picker, fulfillment resolver). Signing and the `handle402` entrypoint land in the next iteration.
+
+## Install
+
+```bash
+pnpm add @bosonprotocol/x402-client
+# or: npm install @bosonprotocol/x402-client
+```
+
+## License
+
+[Apache-2.0](./LICENSE)

--- a/typescript/packages/client/README.md
+++ b/typescript/packages/client/README.md
@@ -4,7 +4,7 @@ Framework-agnostic buyer-side SDK for [x402B](https://github.com/bosonprotocol/x
 
 This package intercepts a `402 Payment Required` carrying `scheme: "escrow"`, signs the buyer's Boson protocol meta-transaction + token-transfer authorization, and produces the `X-PAYMENT` header so the request can be re-issued.
 
-Adapters for specific HTTP clients are published as sibling packages — e.g. [`@bosonprotocol/x402-client-fetch`](../client-fetch) for native `fetch`.
+Adapters for specific HTTP clients will be published as sibling packages — e.g. `@bosonprotocol/x402-client-fetch` for native `fetch`.
 
 ## Status
 

--- a/typescript/packages/client/package.json
+++ b/typescript/packages/client/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@bosonprotocol/x402-client",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "description": "Boson Protocol x402 buyer-side SDK — framework-agnostic client that intercepts 402 escrow-scheme responses and produces the X-PAYMENT header.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bosonprotocol/x402B.git",
+    "directory": "typescript/packages/client"
+  },
+  "homepage": "https://github.com/bosonprotocol/x402B/tree/main/typescript/packages/client",
+  "bugs": {
+    "url": "https://github.com/bosonprotocol/x402B/issues"
+  },
+  "keywords": [
+    "x402",
+    "boson-protocol",
+    "escrow",
+    "client",
+    "buyer",
+    "web3",
+    "payments"
+  ],
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/cjs/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./signer": {
+      "types": "./dist/cjs/signer/index.d.ts",
+      "import": "./dist/esm/signer/index.js",
+      "require": "./dist/cjs/signer/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup && node scripts/postbuild.mjs",
+    "test": "vitest run --passWithNoTests",
+    "lint": "eslint src --max-warnings 0",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@bosonprotocol/common": "^1.32.2",
+    "@bosonprotocol/x402-core": "workspace:^",
+    "ajv": "^8.17.1",
+    "viem": "^2.39.3",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.10",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/typescript/packages/client/package.json
+++ b/typescript/packages/client/package.json
@@ -34,7 +34,8 @@
       "types": "./dist/cjs/signer/index.d.ts",
       "import": "./dist/esm/signer/index.js",
       "require": "./dist/cjs/signer/index.js"
-    }
+    },
+    "./schemas/*": "./dist/schemas/*"
   },
   "files": [
     "dist",
@@ -55,8 +56,7 @@
     "@bosonprotocol/common": "^1.32.2",
     "@bosonprotocol/x402-core": "workspace:^",
     "ajv": "^8.17.1",
-    "viem": "^2.39.3",
-    "zod": "^3.24.2"
+    "viem": "^2.39.3"
   },
   "devDependencies": {
     "@types/node": "^20.17.10",

--- a/typescript/packages/client/package.json
+++ b/typescript/packages/client/package.json
@@ -45,6 +45,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "pnpm --filter @bosonprotocol/x402-core build",
     "build": "tsup && node scripts/postbuild.mjs",
     "test": "vitest run --passWithNoTests",
     "lint": "eslint src --max-warnings 0",

--- a/typescript/packages/client/scripts/postbuild.mjs
+++ b/typescript/packages/client/scripts/postbuild.mjs
@@ -31,12 +31,31 @@ async function* walk(dir) {
 await rm(schemasRoot, { recursive: true, force: true });
 await mkdir(schemasRoot, { recursive: true });
 
+// Track basenames as we go so two `src/**/schemas/<name>.json` files
+// from different subdirectories don't silently overwrite each other in
+// the flat `dist/schemas/` layout. The `./schemas/*` package export
+// resolves on basename, so duplicates would produce a non-deterministic
+// published artifact — fail the build instead.
+//
+// Comparison is case-insensitive: macOS APFS and Windows NTFS default to
+// case-insensitive matching, so `Foo.json` and `foo.json` would also
+// collide there even though Linux would treat them as distinct files.
 let schemaCount = 0;
+const seenSchemaNames = new Set();
 for await (const file of walk(srcRoot)) {
   if (!file.endsWith(".json")) continue;
   const rel = relative(srcRoot, file);
   if (!rel.split(/[\\/]/).includes("schemas")) continue;
   const name = file.split(/[\\/]/).pop();
+  if (!name) continue;
+  const normalizedName = name.toLowerCase();
+  if (seenSchemaNames.has(normalizedName)) {
+    throw new Error(
+      `postbuild: duplicate schema basename '${name}' found while flattening into dist/schemas/. ` +
+        `Use a unique filename for each schema (or update the script to preserve subpaths).`,
+    );
+  }
+  seenSchemaNames.add(normalizedName);
   await copyFile(file, join(schemasRoot, name));
   schemaCount += 1;
 }

--- a/typescript/packages/client/scripts/postbuild.mjs
+++ b/typescript/packages/client/scripts/postbuild.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Post-build housekeeping after `tsup`:
+//
+// 1. Copy `src/**/schemas/*.json` flat into `dist/schemas/` so the
+//    `./schemas/*` package export resolves at runtime.
+// 2. Write `dist/esm/package.json` ({"type":"module"}) and
+//    `dist/cjs/package.json` ({"type":"commonjs"}) so Node treats each
+//    subtree under the correct module dialect without a
+//    MODULE_TYPELESS_PACKAGE_JSON warning at consume time.
+
+import { readdir, mkdir, rm, copyFile, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const srcRoot = join(here, "..", "src");
+const distRoot = join(here, "..", "dist");
+const schemasRoot = join(distRoot, "schemas");
+
+async function* walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else yield p;
+  }
+}
+
+// Wipe `dist/schemas/` first so renamed or removed source schemas don't
+// leak into published tarballs.
+await rm(schemasRoot, { recursive: true, force: true });
+await mkdir(schemasRoot, { recursive: true });
+
+let schemaCount = 0;
+for await (const file of walk(srcRoot)) {
+  if (!file.endsWith(".json")) continue;
+  const rel = relative(srcRoot, file);
+  if (!rel.split(/[\\/]/).includes("schemas")) continue;
+  const name = file.split(/[\\/]/).pop();
+  await copyFile(file, join(schemasRoot, name));
+  schemaCount += 1;
+}
+
+await writeFile(
+  join(distRoot, "esm", "package.json"),
+  JSON.stringify({ type: "module" }, null, 2) + "\n",
+);
+await writeFile(
+  join(distRoot, "cjs", "package.json"),
+  JSON.stringify({ type: "commonjs" }, null, 2) + "\n",
+);
+
+console.log(
+  `postbuild: ${schemaCount} schema(s) -> ${relative(process.cwd(), schemasRoot)}, wrote module-type markers in dist/{esm,cjs}/package.json`,
+);

--- a/typescript/packages/client/src/action.ts
+++ b/typescript/packages/client/src/action.ts
@@ -40,10 +40,12 @@ export function pickAction(
     return SUPPORTED_ACTION;
   }
 
-  const onlyUnsupported = requirements.actions.next.some((a) => a.id === UNSUPPORTED_ACTION);
-  if (onlyUnsupported) {
+  const unsupportedOnServer = requirements.actions.next.some(
+    (a) => a.id === UNSUPPORTED_ACTION && a.channels.includes("server"),
+  );
+  if (unsupportedOnServer) {
     throw new NotImplementedError(
-      `server advertises only ${UNSUPPORTED_ACTION}; client does not yet implement that action`,
+      `server advertises ${UNSUPPORTED_ACTION}; client does not yet implement that action`,
     );
   }
 

--- a/typescript/packages/client/src/action.ts
+++ b/typescript/packages/client/src/action.ts
@@ -1,0 +1,53 @@
+// Pick the on-chain Boson action to invoke from a parsed PaymentRequirements.
+//
+// MVP supports only `boson-createOfferAndCommit` (deferred-redeem path).
+// `boson-createOfferCommitAndRedeem` is not yet exposed by
+// `@bosonprotocol/core-sdk` and is rejected with `NotImplementedError` here
+// so callers learn early, rather than mid-signing.
+
+import type {
+  BosonCommitActionId,
+  EscrowPaymentRequirements,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+
+import { NoCompatibleActionError, NotImplementedError } from "./errors.js";
+import type { Policy } from "./types.js";
+
+const SUPPORTED_ACTION: BosonCommitActionId = "boson-createOfferAndCommit";
+const UNSUPPORTED_ACTION: BosonCommitActionId = "boson-createOfferCommitAndRedeem";
+
+/**
+ * Resolve the Boson commit-time action the client will sign. Throws if the
+ * requested redeem mode is not yet implemented, or if the server hasn't
+ * advertised a supported action over the server channel.
+ */
+export function pickAction(
+  requirements: EscrowPaymentRequirements,
+  policy?: Policy,
+): BosonCommitActionId {
+  const redeemMode = policy?.redeemMode ?? "auto";
+
+  if (redeemMode === "commit-and-redeem") {
+    throw new NotImplementedError(
+      `redeemMode='commit-and-redeem' requires core-sdk support for ${UNSUPPORTED_ACTION}, which is not yet wired`,
+    );
+  }
+
+  const supported = requirements.actions.next.find(
+    (a) => a.id === SUPPORTED_ACTION && a.channels.includes("server"),
+  );
+  if (supported) {
+    return SUPPORTED_ACTION;
+  }
+
+  const onlyUnsupported = requirements.actions.next.some((a) => a.id === UNSUPPORTED_ACTION);
+  if (onlyUnsupported) {
+    throw new NotImplementedError(
+      `server advertises only ${UNSUPPORTED_ACTION}; client does not yet implement that action`,
+    );
+  }
+
+  throw new NoCompatibleActionError(
+    `no '${SUPPORTED_ACTION}' action with 'server' channel found in requirements.actions.next`,
+  );
+}

--- a/typescript/packages/client/src/errors.ts
+++ b/typescript/packages/client/src/errors.ts
@@ -1,0 +1,38 @@
+// Typed error classes for the x402-client. Each is a leaf `Error` subclass
+// with a stable `name` so callers can branch on `instanceof` or string-match
+// without parsing messages.
+
+export class UnsupportedSchemeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedSchemeError";
+  }
+}
+
+export class UnsupportedTokenAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedTokenAuthError";
+  }
+}
+
+export class NoCompatibleActionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NoCompatibleActionError";
+  }
+}
+
+export class NotImplementedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotImplementedError";
+  }
+}
+
+export class FulfillmentValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FulfillmentValidationError";
+  }
+}

--- a/typescript/packages/client/src/fulfillment.ts
+++ b/typescript/packages/client/src/fulfillment.ts
@@ -1,0 +1,60 @@
+// Resolve the `fulfillment` slot the client will attach to the payment
+// payload. Validates the buyer-supplied data against the chosen option's
+// JSON Schema via ajv — same library the server/facilitator will use to
+// re-validate.
+
+import Ajv from "ajv";
+import type { EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
+
+import { FulfillmentValidationError } from "./errors.js";
+import type { FulfillmentConfig, X402bClientConfig } from "./types.js";
+
+export interface ResolvedFulfillment {
+  option: string;
+  data: Record<string, unknown>;
+}
+
+/**
+ * Returns the payload's `fulfillment` slot, or `undefined` when the
+ * requirements don't request one. Throws when the requirements demand a
+ * fulfillment but the client config doesn't supply one, when the option id
+ * isn't advertised by the server, or when the buyer data doesn't validate
+ * against the option's schema.
+ */
+export function resolveFulfillment(
+  requirements: EscrowPaymentRequirements,
+  config: Pick<X402bClientConfig, "fulfillment">,
+): ResolvedFulfillment | undefined {
+  const required = requirements.fulfillment?.required ?? false;
+  if (!required) {
+    return undefined;
+  }
+
+  const fulfillmentConfig: FulfillmentConfig | undefined = config.fulfillment;
+  if (!fulfillmentConfig) {
+    throw new FulfillmentValidationError(
+      "requirements.fulfillment.required is true but client config did not supply a fulfillment selection",
+    );
+  }
+
+  const option = requirements.fulfillment?.options.find((o) => o.id === fulfillmentConfig.option);
+  if (!option) {
+    const advertised = requirements.fulfillment?.options.map((o) => o.id).join(", ") ?? "<none>";
+    throw new FulfillmentValidationError(
+      `fulfillment option '${fulfillmentConfig.option}' not advertised by requirements (advertised: ${advertised})`,
+    );
+  }
+
+  if (option.schema !== null) {
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    const validate = ajv.compile(option.schema);
+    const ok = validate(fulfillmentConfig.data);
+    if (!ok) {
+      throw new FulfillmentValidationError(
+        `fulfillment data does not match option '${option.id}' schema: ${ajv.errorsText(validate.errors)}`,
+      );
+    }
+  }
+
+  return { option: fulfillmentConfig.option, data: fulfillmentConfig.data };
+}

--- a/typescript/packages/client/src/index.ts
+++ b/typescript/packages/client/src/index.ts
@@ -1,0 +1,27 @@
+// Public surface for `@bosonprotocol/x402-client`.
+//
+// MVP scaffold: configuration types, typed errors, signer interface, and
+// the pure-function utilities the in-progress `handle402` entrypoint will
+// compose (action picker, fulfillment resolver). Signing, the `CoreSDK`
+// bridge, and the `handle402` entrypoint land in the next iteration.
+
+export type {
+  ExchangeSummary,
+  FulfillmentConfig,
+  Policy,
+  RedeemMode,
+  Signer,
+  TokenDomainResolver,
+  X402bClientConfig,
+} from "./types.js";
+
+export {
+  FulfillmentValidationError,
+  NoCompatibleActionError,
+  NotImplementedError,
+  UnsupportedSchemeError,
+  UnsupportedTokenAuthError,
+} from "./errors.js";
+
+export { pickAction } from "./action.js";
+export { resolveFulfillment, type ResolvedFulfillment } from "./fulfillment.js";

--- a/typescript/packages/client/src/signer/index.ts
+++ b/typescript/packages/client/src/signer/index.ts
@@ -1,0 +1,96 @@
+// Signer adapters. Two viem helpers cover the common cases; a third
+// translator wraps a `Signer` into a `Web3LibAdapter` that `CoreSDK` can be
+// constructed against — only the `send("eth_signTypedData_v4", ...)` path
+// is implemented, since the buyer never goes on-chain in MVP (no transaction
+// sending, no balance lookups, no RPC reads). Transaction-flavour methods
+// reject with a clear `unreachable(...)` so misuse fails loudly rather than
+// silently calling into an unset RPC.
+
+import type { Web3LibAdapter } from "@bosonprotocol/common";
+import type {
+  Account,
+  LocalAccount,
+  TypedDataDomain,
+  TypedDataParameter,
+  WalletClient,
+} from "viem";
+
+import type { Signer } from "../types.js";
+
+export type { Signer };
+
+/** Wrap a viem `LocalAccount` (private-key / mnemonic account) as a `Signer`. */
+export function viemAccountSigner(account: LocalAccount): Signer {
+  return {
+    getAddress: async () => account.address,
+    signTypedData: (args) =>
+      account.signTypedData(args as unknown as Parameters<LocalAccount["signTypedData"]>[0]),
+  };
+}
+
+/**
+ * Wrap a viem `WalletClient` plus an `Account` as a `Signer`. Use this when
+ * the buyer's keys live behind an RPC signer (browser wallet, hardware
+ * wallet, remote signer) rather than in-process.
+ */
+export function viemWalletClientSigner(walletClient: WalletClient, account: Account): Signer {
+  return {
+    getAddress: async () => account.address,
+    signTypedData: (args) =>
+      walletClient.signTypedData({
+        account,
+        domain: args.domain,
+        types: args.types as unknown as Parameters<WalletClient["signTypedData"]>[0]["types"],
+        primaryType: args.primaryType,
+        message: args.message,
+      } as Parameters<WalletClient["signTypedData"]>[0]),
+  };
+}
+
+/**
+ * Build the `Web3LibAdapter` that `@bosonprotocol/core-sdk`'s `CoreSDK`
+ * accepts. `send("eth_signTypedData_v4", [address, jsonString])` is the
+ * only RPC method actually exercised during meta-tx signing — it delegates
+ * to `signer.signTypedData(...)`. Read-only adapter methods are filled in
+ * with trivial answers; transaction-flavour methods throw on first call.
+ */
+export function signerToWeb3LibAdapter(signer: Signer, chainId: number): Web3LibAdapter {
+  return {
+    uuid: "x402-client:signer-adapter",
+    getSignerAddress: () => signer.getAddress(),
+    isSignerContract: async () => false,
+    getChainId: async () => chainId,
+    send: async (method, params) => {
+      if (method !== "eth_signTypedData_v4") {
+        throw new Error(
+          `x402-client: signer adapter does not support RPC method '${method}'; only eth_signTypedData_v4 is implemented`,
+        );
+      }
+      const raw = (params as unknown[])[1];
+      if (typeof raw !== "string") {
+        throw new Error(
+          "x402-client: eth_signTypedData_v4 payload[1] is not a JSON string — core-sdk internals may have changed",
+        );
+      }
+      const typedData = JSON.parse(raw) as {
+        domain: TypedDataDomain;
+        types: Record<string, readonly TypedDataParameter[]>;
+        primaryType: string;
+        message: Record<string, unknown>;
+      };
+      return signer.signTypedData(typedData);
+    },
+    getBalance: () => Promise.reject(unreachable("getBalance")),
+    estimateGas: () => Promise.reject(unreachable("estimateGas")),
+    sendTransaction: () => Promise.reject(unreachable("sendTransaction")),
+    call: () => Promise.reject(unreachable("call")),
+    getTransactionReceipt: () => Promise.reject(unreachable("getTransactionReceipt")),
+    getCurrentTimeMs: () => Promise.reject(unreachable("getCurrentTimeMs")),
+  };
+}
+
+function unreachable(method: string): Error {
+  return new Error(
+    `x402-client: stub Web3LibAdapter.${method}() is not implemented — the client never goes on-chain in MVP`,
+  );
+}

--- a/typescript/packages/client/src/types.ts
+++ b/typescript/packages/client/src/types.ts
@@ -1,0 +1,88 @@
+// Public configuration types for `createX402bClient`. The `Signer` interface
+// is defined here (rather than under `src/signer/`) so the config types can
+// reference it without forcing consumers to install or import from a
+// secondary subpath; the `./signer` subpath re-exports it for ergonomics.
+
+import type { ClientState } from "@bosonprotocol/x402-core/state-machine";
+import type { TokenEip712Domain } from "@bosonprotocol/x402-core/eip712/token-auth";
+import type { Address, Hex, TypedDataDomain, TypedDataParameter } from "viem";
+
+/**
+ * Decision the buyer's policy makes about the on-chain redemption phase, **independent
+ * of when the resource is delivered off-chain**.
+ *
+ *  - `"auto"`     — default. MVP picks the deferred `boson-createOfferAndCommit`
+ *                   path; later iterations may pick atomic commit+redeem when both
+ *                   are advertised.
+ *  - `"commit-only"` — explicitly want the deferred path; buyer (or another agent)
+ *                      will redeem later.
+ *  - `"commit-and-redeem"` — explicitly want atomic on-chain commit+redeem. Not
+ *                            implemented in MVP — throws `NotImplementedError`.
+ */
+export type RedeemMode = "auto" | "commit-only" | "commit-and-redeem";
+
+export interface Policy {
+  redeemMode?: RedeemMode;
+  /** Atomic-units cap. If set, the client rejects requirements whose `amount` exceeds it. */
+  maxAmount?: string;
+}
+
+export interface FulfillmentConfig {
+  /** `id` of the option the buyer wants from `requirements.fulfillment.options[]`. */
+  option: string;
+  /** Buyer-supplied data; validated against the chosen option's JSON Schema. */
+  data: Record<string, unknown>;
+}
+
+/**
+ * Resolves the EIP-712 domain a given ERC-20 publishes for ERC-3009 /
+ * EIP-2612 signatures. Tokens are not on-chain queried by the client in
+ * MVP — callers must provide this resolver (often a small in-memory lookup
+ * table keyed by `(chainId, asset)`).
+ */
+export type TokenDomainResolver = (
+  asset: Address,
+  chainId: number,
+) => Promise<TokenEip712Domain> | TokenEip712Domain;
+
+/**
+ * Minimal wallet abstraction the client signs through. Matches the shape of
+ * viem's `Account.signTypedData` so a viem `LocalAccount` /
+ * `WalletClient`-bound account can be wrapped by a thin adapter (see
+ * `viemAccountSigner` / `viemWalletClientSigner` in `./signer`).
+ */
+export interface Signer {
+  getAddress(): Promise<Address>;
+  signTypedData(args: {
+    domain: TypedDataDomain;
+    types: Record<string, readonly TypedDataParameter[]>;
+    primaryType: string;
+    message: Record<string, unknown>;
+  }): Promise<Hex>;
+}
+
+export interface X402bClientConfig {
+  signer: Signer;
+  /**
+   * Per-chain Boson subgraph URLs. `CoreSDK`'s base constructor requires one;
+   * for signing-only flows the URL may not actually be queried, but it must
+   * be present. Keyed by EIP-155 chain id (e.g. `8453` for Base mainnet).
+   */
+  subgraphUrls?: Record<number, string>;
+  tokenDomainResolver?: TokenDomainResolver;
+  policy?: Policy;
+  /** Default fulfillment selection. Required when `requirements.fulfillment.required` is true. */
+  fulfillment?: FulfillmentConfig;
+}
+
+/**
+ * Whatever the server returns in `X-PAYMENT-RESPONSE` (if anything) after a
+ * successful settle. Permissive — the server-side contract for this header
+ * isn't pinned yet; the client surfaces the raw payload and best-effort
+ * lifts `exchangeId` / `state` from common property paths.
+ */
+export interface ExchangeSummary {
+  raw?: unknown;
+  exchangeId?: string;
+  state?: ClientState;
+}

--- a/typescript/packages/client/test/action.test.ts
+++ b/typescript/packages/client/test/action.test.ts
@@ -43,7 +43,7 @@ describe("pickAction", () => {
     expect(() => pickAction(req, { redeemMode: "commit-and-redeem" })).toThrow(NotImplementedError);
   });
 
-  it("throws NotImplementedError when only boson-createOfferCommitAndRedeem is offered", () => {
+  it("throws NotImplementedError when boson-createOfferCommitAndRedeem is offered over the server channel", () => {
     const req = baseRequirements();
     req.actions.next = [{ id: "boson-createOfferCommitAndRedeem", channels: ["server"] }];
     expect(() => pickAction(req)).toThrow(NotImplementedError);
@@ -52,6 +52,16 @@ describe("pickAction", () => {
   it("throws NoCompatibleActionError when boson-createOfferAndCommit is offered but only over non-server channels", () => {
     const req = baseRequirements();
     req.actions.next = [{ id: "boson-createOfferAndCommit", channels: ["facilitator", "onchain"] }];
+    expect(() => pickAction(req)).toThrow(NoCompatibleActionError);
+  });
+
+  it("throws NoCompatibleActionError when boson-createOfferCommitAndRedeem is offered only on non-server channels", () => {
+    // Server doesn't expose the unsupported action over `server` either, so
+    // the right error is "no compatible action", not "not implemented".
+    const req = baseRequirements();
+    req.actions.next = [
+      { id: "boson-createOfferCommitAndRedeem", channels: ["facilitator", "onchain"] },
+    ];
     expect(() => pickAction(req)).toThrow(NoCompatibleActionError);
   });
 

--- a/typescript/packages/client/test/action.test.ts
+++ b/typescript/packages/client/test/action.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import type { EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
+
+import { pickAction } from "../src/action.js";
+import { NoCompatibleActionError, NotImplementedError } from "../src/errors.js";
+
+function baseRequirements(): EscrowPaymentRequirements {
+  return {
+    scheme: "escrow",
+    network: "eip155:8453",
+    asset: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+    amount: "1000000",
+    escrowAddress: "0xdddddddddddddddddddddddddddddddddddddddd",
+    recipientId: "did:boson:seller:1",
+    maxTimeoutSeconds: 300,
+    offer: {
+      fullOffer: { id: "0" },
+      sellerSig: "0xdeadbeef",
+      creator: "0x1111111111111111111111111111111111111111",
+    },
+    tokenAuthStrategies: ["erc3009"],
+    actions: { next: [] },
+  };
+}
+
+describe("pickAction", () => {
+  it("returns boson-createOfferAndCommit when advertised over server channel (default redeemMode='auto')", () => {
+    const req = baseRequirements();
+    req.actions.next = [{ id: "boson-createOfferAndCommit", channels: ["server", "facilitator"] }];
+    expect(pickAction(req)).toBe("boson-createOfferAndCommit");
+  });
+
+  it("returns boson-createOfferAndCommit for redeemMode='commit-only'", () => {
+    const req = baseRequirements();
+    req.actions.next = [{ id: "boson-createOfferAndCommit", channels: ["server"] }];
+    expect(pickAction(req, { redeemMode: "commit-only" })).toBe("boson-createOfferAndCommit");
+  });
+
+  it("throws NotImplementedError for redeemMode='commit-and-redeem'", () => {
+    const req = baseRequirements();
+    req.actions.next = [{ id: "boson-createOfferAndCommit", channels: ["server"] }];
+    expect(() => pickAction(req, { redeemMode: "commit-and-redeem" })).toThrow(NotImplementedError);
+  });
+
+  it("throws NotImplementedError when only boson-createOfferCommitAndRedeem is offered", () => {
+    const req = baseRequirements();
+    req.actions.next = [{ id: "boson-createOfferCommitAndRedeem", channels: ["server"] }];
+    expect(() => pickAction(req)).toThrow(NotImplementedError);
+  });
+
+  it("throws NoCompatibleActionError when boson-createOfferAndCommit is offered but only over non-server channels", () => {
+    const req = baseRequirements();
+    req.actions.next = [{ id: "boson-createOfferAndCommit", channels: ["facilitator", "onchain"] }];
+    expect(() => pickAction(req)).toThrow(NoCompatibleActionError);
+  });
+
+  it("throws NoCompatibleActionError when no Boson action is offered at all", () => {
+    const req = baseRequirements();
+    req.actions.next = [{ id: "some-other-action", channels: ["server"] }];
+    expect(() => pickAction(req)).toThrow(NoCompatibleActionError);
+  });
+
+  it("prefers boson-createOfferAndCommit when both actions are listed and redeemMode is 'auto'", () => {
+    const req = baseRequirements();
+    req.actions.next = [
+      { id: "boson-createOfferCommitAndRedeem", channels: ["server"] },
+      { id: "boson-createOfferAndCommit", channels: ["server"] },
+    ];
+    expect(pickAction(req)).toBe("boson-createOfferAndCommit");
+  });
+});

--- a/typescript/packages/client/test/fulfillment.test.ts
+++ b/typescript/packages/client/test/fulfillment.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import type { EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
+
+import { FulfillmentValidationError } from "../src/errors.js";
+import { resolveFulfillment } from "../src/fulfillment.js";
+
+function baseRequirements(): EscrowPaymentRequirements {
+  return {
+    scheme: "escrow",
+    network: "eip155:8453",
+    asset: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+    amount: "1000000",
+    escrowAddress: "0xdddddddddddddddddddddddddddddddddddddddd",
+    recipientId: "did:boson:seller:1",
+    maxTimeoutSeconds: 300,
+    offer: {
+      fullOffer: { id: "0" },
+      sellerSig: "0xdeadbeef",
+      creator: "0x1111111111111111111111111111111111111111",
+    },
+    tokenAuthStrategies: ["erc3009"],
+    actions: { next: [{ id: "boson-createOfferAndCommit", channels: ["server"] }] },
+  };
+}
+
+describe("resolveFulfillment", () => {
+  it("returns undefined when fulfillment is absent in requirements", () => {
+    const req = baseRequirements();
+    expect(resolveFulfillment(req, {})).toBeUndefined();
+  });
+
+  it("returns undefined when requirements.fulfillment.required is false", () => {
+    const req = baseRequirements();
+    req.fulfillment = { required: false, options: [{ id: "atomic", schema: null }] };
+    expect(resolveFulfillment(req, {})).toBeUndefined();
+  });
+
+  it("throws when required but no fulfillment in config", () => {
+    const req = baseRequirements();
+    req.fulfillment = { required: true, options: [{ id: "atomic", schema: null }] };
+    expect(() => resolveFulfillment(req, {})).toThrow(FulfillmentValidationError);
+  });
+
+  it("throws when chosen option is not advertised", () => {
+    const req = baseRequirements();
+    req.fulfillment = { required: true, options: [{ id: "atomic", schema: null }] };
+    expect(() => resolveFulfillment(req, { fulfillment: { option: "email", data: {} } })).toThrow(
+      /not advertised/,
+    );
+  });
+
+  it("accepts atomic option (schema: null) without validating data", () => {
+    const req = baseRequirements();
+    req.fulfillment = { required: true, options: [{ id: "atomic", schema: null }] };
+    expect(resolveFulfillment(req, { fulfillment: { option: "atomic", data: {} } })).toEqual({
+      option: "atomic",
+      data: {},
+    });
+  });
+
+  it("accepts data that validates against the option's JSON Schema", () => {
+    const req = baseRequirements();
+    req.fulfillment = {
+      required: true,
+      options: [{ id: "email", schema: { type: "object", required: ["email"] } }],
+    };
+    expect(
+      resolveFulfillment(req, {
+        fulfillment: { option: "email", data: { email: "buyer@example.com" } },
+      }),
+    ).toEqual({ option: "email", data: { email: "buyer@example.com" } });
+  });
+
+  it("throws when data fails the option's JSON Schema", () => {
+    const req = baseRequirements();
+    req.fulfillment = {
+      required: true,
+      options: [{ id: "email", schema: { type: "object", required: ["email"] } }],
+    };
+    expect(() => resolveFulfillment(req, { fulfillment: { option: "email", data: {} } })).toThrow(
+      FulfillmentValidationError,
+    );
+  });
+});

--- a/typescript/packages/client/test/signer.test.ts
+++ b/typescript/packages/client/test/signer.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { recoverTypedDataAddress, type TypedDataDomain } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { signerToWeb3LibAdapter, viemAccountSigner } from "../src/signer/index.js";
+
+const TEST_KEY = `0x${"42".repeat(32)}` as const;
+
+const account = privateKeyToAccount(TEST_KEY);
+
+const domain: TypedDataDomain = {
+  name: "Test",
+  version: "1",
+  chainId: 8453,
+  verifyingContract: "0xdddddddddddddddddddddddddddddddddddddddd",
+};
+
+const types = {
+  EIP712Domain: [
+    { name: "name", type: "string" },
+    { name: "version", type: "string" },
+    { name: "chainId", type: "uint256" },
+    { name: "verifyingContract", type: "address" },
+  ],
+  Mail: [
+    { name: "from", type: "address" },
+    { name: "to", type: "address" },
+    { name: "contents", type: "string" },
+  ],
+} as const;
+
+const message = {
+  from: account.address,
+  to: "0x1111111111111111111111111111111111111111",
+  contents: "hello",
+} as const;
+
+describe("viemAccountSigner", () => {
+  it("getAddress returns the underlying account address", async () => {
+    const signer = viemAccountSigner(account);
+    expect(await signer.getAddress()).toBe(account.address);
+  });
+
+  it("signTypedData produces a signature that recovers to the account", async () => {
+    const signer = viemAccountSigner(account);
+    const sig = await signer.signTypedData({ domain, types, primaryType: "Mail", message });
+    const recovered = await recoverTypedDataAddress({
+      domain,
+      types,
+      primaryType: "Mail",
+      message,
+      signature: sig,
+    });
+    expect(recovered.toLowerCase()).toBe(account.address.toLowerCase());
+  });
+});
+
+describe("signerToWeb3LibAdapter", () => {
+  it("getSignerAddress / getChainId / isSignerContract return the wired values", async () => {
+    const signer = viemAccountSigner(account);
+    const adapter = signerToWeb3LibAdapter(signer, 8453);
+    expect(adapter.uuid).toBe("x402-client:signer-adapter");
+    expect(await adapter.getSignerAddress()).toBe(account.address);
+    expect(await adapter.getChainId()).toBe(8453);
+    expect(await adapter.isSignerContract()).toBe(false);
+  });
+
+  it("send('eth_signTypedData_v4', [addr, json]) parses the JSON and delegates to the signer", async () => {
+    const signer = viemAccountSigner(account);
+    const adapter = signerToWeb3LibAdapter(signer, 8453);
+    const typedData = { domain, types, primaryType: "Mail", message };
+    const sig = await adapter.send("eth_signTypedData_v4", [
+      account.address,
+      JSON.stringify(typedData),
+    ]);
+    const recovered = await recoverTypedDataAddress({
+      domain,
+      types,
+      primaryType: "Mail",
+      message,
+      signature: sig as `0x${string}`,
+    });
+    expect(recovered.toLowerCase()).toBe(account.address.toLowerCase());
+  });
+
+  it("send rejects RPC methods other than eth_signTypedData_v4", async () => {
+    const adapter = signerToWeb3LibAdapter(viemAccountSigner(account), 8453);
+    await expect(adapter.send("eth_chainId", [])).rejects.toThrow(/does not support RPC method/);
+  });
+
+  it("send rejects when the typed-data payload isn't a JSON string", async () => {
+    const adapter = signerToWeb3LibAdapter(viemAccountSigner(account), 8453);
+    await expect(
+      adapter.send("eth_signTypedData_v4", [account.address, { not: "a string" }]),
+    ).rejects.toThrow(/not a JSON string/);
+  });
+
+  it("transaction-flavour methods reject with an 'unreachable' error", async () => {
+    const adapter = signerToWeb3LibAdapter(viemAccountSigner(account), 8453);
+    await expect(adapter.sendTransaction({})).rejects.toThrow(/never goes on-chain/);
+    await expect(adapter.call({})).rejects.toThrow(/never goes on-chain/);
+    await expect(adapter.estimateGas({})).rejects.toThrow(/never goes on-chain/);
+    await expect(adapter.getBalance("0x0")).rejects.toThrow(/never goes on-chain/);
+    await expect(adapter.getTransactionReceipt("0x0")).rejects.toThrow(/never goes on-chain/);
+    await expect(adapter.getCurrentTimeMs()).rejects.toThrow(/never goes on-chain/);
+  });
+});

--- a/typescript/packages/client/tsconfig.json
+++ b/typescript/packages/client/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/typescript/packages/client/tsup.config.ts
+++ b/typescript/packages/client/tsup.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from "tsup";
+
+// Dual CJS + ESM build with type declarations.
+//
+// `entry` globs every `index.ts` under `src/`, including the root
+// `src/index.ts`, so any subpath under `src/<subdir>/index.ts` builds as
+// `@bosonprotocol/x402-client/<subdir>` without further config changes.
+// The `scripts/postbuild.mjs` step writes `dist/{esm,cjs}/package.json`
+// module-type markers chained from `package.json`'s `build` script.
+const entry = ["src/**/index.ts"];
+
+export default defineConfig([
+  {
+    entry,
+    format: "esm",
+    outDir: "dist/esm",
+    outExtension: () => ({ js: ".js" }),
+    dts: false,
+    sourcemap: true,
+    clean: true,
+    target: "es2020",
+    treeshake: true,
+  },
+  {
+    entry,
+    format: "cjs",
+    outDir: "dist/cjs",
+    outExtension: () => ({ js: ".js" }),
+    dts: true,
+    sourcemap: true,
+    clean: false,
+    target: "es2020",
+    treeshake: true,
+  },
+]);

--- a/typescript/packages/client/vitest.config.ts
+++ b/typescript/packages/client/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `@bosonprotocol/x402-client` workspace package — the framework-agnostic buyer-side SDK that will produce the `X-PAYMENT` header from a parsed 402.
- Scaffold + pure-function utilities only: `Signer` interface and viem adapters (`viemAccountSigner`, `viemWalletClientSigner`, `signerToWeb3LibAdapter`), `pickAction`, `resolveFulfillment` (ajv), and 5 typed errors.
- `pickAction` rejects `boson-createOfferCommitAndRedeem` with `NotImplementedError` (not yet exposed by `@bosonprotocol/core-sdk`).
- Build / test / lint / postbuild conventions mirror `x402-core` and `x402-fulfillment`. Export map: `.` and `./signer`.

## Test plan
- [x] `pnpm build` — 3 packages built (core, fulfillment, client)
- [x] `pnpm test` — 21 new tests pass (action: 7, fulfillment: 7, signer: 7); 87 core + 2 fulfillment unchanged
- [x] `pnpm lint` — `eslint --max-warnings 0` clean
- [x] `pnpm format:check` — prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Framework-agnostic buyer SDK for x402 escrow payments: typed config, signer adapters, typed errors, action selection, and fulfillment resolution.

* **Documentation**
  * Added package README and Apache-2.0 license.

* **Tests**
  * Unit tests for action selection, fulfillment validation, and signer/adapter behavior.

* **Chores**
  * Package manifest, build/bundling, post-build packaging script, and TypeScript/Vitest/tsup configs added.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/28)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->