### PR TITLE
feat(client): implement handle402 + signAction for buyer flows

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@bosonprotocol/common':
         specifier: ^1.32.2
         version: 1.32.2
+      '@bosonprotocol/core-sdk':
+        specifier: 1.47.1-alpha.0
+        version: 1.47.1-alpha.0
       '@bosonprotocol/x402-core':
         specifier: workspace:^
         version: link:../core

--- a/typescript/packages/client/package.json
+++ b/typescript/packages/client/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@bosonprotocol/common": "^1.32.2",
+    "@bosonprotocol/core-sdk": "1.47.1-alpha.0",
     "@bosonprotocol/x402-core": "workspace:^",
     "ajv": "^8.17.1",
     "viem": "^2.39.3"

--- a/typescript/packages/client/src/client.ts
+++ b/typescript/packages/client/src/client.ts
@@ -25,6 +25,7 @@ import { signCreateOfferAndCommitMetaTx } from "./pre-commit.js";
 import { signPostCommitAction, type SignActionArgs } from "./post-commit.js";
 import { parsePaymentResponse } from "./response.js";
 import { buildAndSignTokenAuth } from "./token-auth/index.js";
+import { MaxAmountExceededError } from "./errors.js";
 import type { ExchangeSummary, TokenDomainResolver, X402bClientConfig } from "./types.js";
 
 export interface X402bClient {
@@ -76,6 +77,7 @@ export function createX402bClient(config: X402bClientConfig): X402bClient {
 
       const action = pickAction(requirements, config.policy);
       const fulfillment = resolveFulfillment(requirements, config);
+      enforceMaxAmount(requirements.amount, config.policy?.maxAmount);
       const buyer = await getBuyerAddress();
 
       if (!tokenDomainResolver) {
@@ -119,4 +121,18 @@ export function createX402bClient(config: X402bClientConfig): X402bClient {
       return parsePaymentResponse(response);
     },
   };
+}
+
+function enforceMaxAmount(amount: string, maxAmount?: string): void {
+  if (maxAmount === undefined) {
+    return;
+  }
+
+  const amountBigInt = BigInt(amount);
+  const maxAmountBigInt = BigInt(maxAmount);
+  if (amountBigInt > maxAmountBigInt) {
+    throw new MaxAmountExceededError(
+      `x402-client: requirements.amount ${amount} exceeds policy.maxAmount ${maxAmount}`,
+    );
+  }
 }

--- a/typescript/packages/client/src/client.ts
+++ b/typescript/packages/client/src/client.ts
@@ -1,0 +1,122 @@
+// Top-level `createX402bClient` factory.
+//
+// Wires the action picker, token-auth strategy dispatcher, meta-tx signer
+// (via `CoreSDK`), fulfillment resolver, and payload assembler into:
+//
+//   - `handle402(requirements)` — commit-time flow that emits the base64
+//     `X-PAYMENT` value for the 402 retry.
+//   - `signAction(args)` — post-commit flow that signs one of the buyer's
+//     follow-up meta-transactions (redeem / cancel / complete / dispute
+//     family). No token-auth or X-PAYMENT wrapping; the caller picks a
+//     channel and POSTs the wire envelope.
+
+import {
+  parseEscrowPaymentRequirements,
+  type BosonMetaTx,
+  type EscrowPaymentRequirements,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+import type { Address } from "viem";
+
+import { pickAction } from "./action.js";
+import { createCoreSdkFactory } from "./core-sdk-factory.js";
+import { resolveFulfillment } from "./fulfillment.js";
+import { assembleAndEncodePayload } from "./payload.js";
+import { signCreateOfferAndCommitMetaTx } from "./pre-commit.js";
+import { signPostCommitAction, type SignActionArgs } from "./post-commit.js";
+import { parsePaymentResponse } from "./response.js";
+import { buildAndSignTokenAuth } from "./token-auth/index.js";
+import type { ExchangeSummary, TokenDomainResolver, X402bClientConfig } from "./types.js";
+
+export interface X402bClient {
+  /**
+   * Consume a parsed escrow PaymentRequirements and return the base64
+   * value to set as the `X-PAYMENT` header on the retry.
+   */
+  handle402(requirements: unknown): Promise<string>;
+
+  /**
+   * Sign a Boson protocol meta-transaction for a buyer-driven post-commit
+   * action (redeem, cancel, complete, dispute family). Returns the
+   * wire-format `BosonMetaTx` envelope the caller delivers to the chosen
+   * channel — typically as the JSON body of a POST to the server endpoint
+   * the prior response advertised under `actions.next[].endpoints.server`.
+   *
+   * Note: `boson-escalateDispute` signs only the meta-tx. If the dispute
+   * resolver requires an escalation deposit, the resolver/server returns
+   * its own 402 with an `escrow` `PaymentRequirements` and the buyer pairs
+   * this meta-tx with a token-auth payload — the deposit wrapper is out
+   * of MVP.
+   */
+  signAction(args: SignActionArgs): Promise<BosonMetaTx>;
+
+  /**
+   * Best-effort decode of `X-PAYMENT-RESPONSE` after a successful retry.
+   * Returns `undefined` when the header isn't present.
+   */
+  parsePaymentResponse(response: {
+    headers: { get(name: string): string | null };
+  }): ExchangeSummary | undefined;
+}
+
+/**
+ * Build a stateless client bound to a buyer signer + policy. The
+ * underlying `CoreSDK` is built lazily per `(chainId, escrowAddress)` and
+ * cached across calls — both `handle402` and `signAction` reuse it.
+ */
+export function createX402bClient(config: X402bClientConfig): X402bClient {
+  const tokenDomainResolver: TokenDomainResolver | undefined = config.tokenDomainResolver;
+  const buildCoreSdk = createCoreSdkFactory(config.signer, config);
+
+  const getBuyerAddress = async () => (await config.signer.getAddress()) as Address;
+
+  return {
+    async handle402(rawRequirements) {
+      const requirements: EscrowPaymentRequirements =
+        parseEscrowPaymentRequirements(rawRequirements);
+
+      const action = pickAction(requirements, config.policy);
+      const fulfillment = resolveFulfillment(requirements, config);
+      const buyer = await getBuyerAddress();
+
+      if (!tokenDomainResolver) {
+        // Defensive: ERC-3009 is the only MVP strategy and it needs the
+        // token's EIP-712 domain. Fail fast rather than at signing time.
+        throw new Error(
+          "x402-client: tokenDomainResolver is required for MVP (ERC-3009 needs the token EIP-712 domain)",
+        );
+      }
+
+      const { tokenAuth, strategy } = await buildAndSignTokenAuth({
+        requirements,
+        buyer,
+        signer: config.signer,
+        tokenDomainResolver,
+      });
+
+      const { coreSdk } = buildCoreSdk(requirements.network, requirements.escrowAddress as Address);
+      const metaTx = await signCreateOfferAndCommitMetaTx({
+        requirements,
+        coreSdk,
+        buyer,
+      });
+
+      return assembleAndEncodePayload({
+        requirements,
+        action,
+        tokenAuthStrategy: strategy,
+        metaTx,
+        tokenAuth,
+        fulfillment,
+        buyer,
+      });
+    },
+
+    signAction(args) {
+      return signPostCommitAction(args, { buildCoreSdk, getBuyerAddress });
+    },
+
+    parsePaymentResponse(response) {
+      return parsePaymentResponse(response);
+    },
+  };
+}

--- a/typescript/packages/client/src/core-sdk-factory.ts
+++ b/typescript/packages/client/src/core-sdk-factory.ts
@@ -33,7 +33,13 @@ export function parseChainId(network: string): number {
       `x402-client: unsupported network '${network}' (expected CAIP-2 'eip155:<chainId>')`,
     );
   }
-  return Number(match[1]);
+  const chainId = Number(match[1]);
+  if (!Number.isSafeInteger(chainId) || chainId <= 0) {
+    throw new Error(
+      `x402-client: unsupported network '${network}' (chainId must be a positive safe integer)`,
+    );
+  }
+  return chainId;
 }
 
 /**

--- a/typescript/packages/client/src/core-sdk-factory.ts
+++ b/typescript/packages/client/src/core-sdk-factory.ts
@@ -1,0 +1,73 @@
+// Construct (and cache) the `CoreSDK` instance the client signs through.
+//
+// The buyer never queries Boson's subgraph in MVP — only the EIP-712 meta-tx
+// signing path is invoked — but `CoreSDK`'s base constructor requires a
+// `subgraphUrl` string. Callers can configure real URLs per chain via
+// `subgraphUrls`, or omit it and rely on the placeholder sentinel below;
+// either way no HTTP call to that URL is made during signing.
+
+import { CoreSDK } from "@bosonprotocol/core-sdk";
+import type { Address } from "viem";
+
+import { signerToWeb3LibAdapter } from "./signer/index.js";
+import type { Signer, X402bClientConfig } from "./types.js";
+
+// Sentinel used when the caller did not configure a real subgraph URL for
+// the chain. The signing path never reads from it; the value just needs to
+// be a non-empty string the constructor accepts.
+const PLACEHOLDER_SUBGRAPH_URL = "https://x402-client.placeholder.invalid/subgraph";
+
+export interface CoreSdkContext {
+  coreSdk: CoreSDK;
+  chainId: number;
+}
+
+/**
+ * Parse a CAIP-2 EVM network identifier (e.g. `"eip155:8453"`) into its
+ * numeric chain id. Throws if the network is not a well-formed `eip155:<N>`.
+ */
+export function parseChainId(network: string): number {
+  const match = network.match(/^eip155:(\d+)$/);
+  if (!match) {
+    throw new Error(
+      `x402-client: unsupported network '${network}' (expected CAIP-2 'eip155:<chainId>')`,
+    );
+  }
+  return Number(match[1]);
+}
+
+/**
+ * Lazy factory that returns a `CoreSDK` instance configured against the
+ * escrow contract advertised in the network. Instances are cached per
+ * `(chainId, escrowAddress)` so repeated calls on the same network — for
+ * commit and subsequent post-commit actions on the same exchange — reuse a
+ * single SDK.
+ */
+export function createCoreSdkFactory(
+  signer: Signer,
+  config: Pick<X402bClientConfig, "subgraphUrls">,
+) {
+  const cache = new Map<string, CoreSDK>();
+
+  return function buildCoreSdk(network: string, escrowAddress: Address): CoreSdkContext {
+    const chainId = parseChainId(network);
+    const cacheKey = `${chainId}:${escrowAddress.toLowerCase()}`;
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      return { coreSdk: cached, chainId };
+    }
+
+    const subgraphUrl = config.subgraphUrls?.[chainId] ?? PLACEHOLDER_SUBGRAPH_URL;
+    const web3Lib = signerToWeb3LibAdapter(signer, chainId);
+
+    const coreSdk = new CoreSDK({
+      web3Lib,
+      subgraphUrl,
+      protocolDiamond: escrowAddress,
+      chainId,
+    });
+
+    cache.set(cacheKey, coreSdk);
+    return { coreSdk, chainId };
+  };
+}

--- a/typescript/packages/client/src/errors.ts
+++ b/typescript/packages/client/src/errors.ts
@@ -36,3 +36,10 @@ export class FulfillmentValidationError extends Error {
     this.name = "FulfillmentValidationError";
   }
 }
+
+export class MaxAmountExceededError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MaxAmountExceededError";
+  }
+}

--- a/typescript/packages/client/src/index.ts
+++ b/typescript/packages/client/src/index.ts
@@ -20,6 +20,7 @@ export type {
 
 export {
   FulfillmentValidationError,
+  MaxAmountExceededError,
   NoCompatibleActionError,
   NotImplementedError,
   UnsupportedSchemeError,

--- a/typescript/packages/client/src/index.ts
+++ b/typescript/packages/client/src/index.ts
@@ -1,9 +1,8 @@
 // Public surface for `@bosonprotocol/x402-client`.
 //
-// MVP scaffold: configuration types, typed errors, signer interface, and
-// the pure-function utilities the in-progress `handle402` entrypoint will
-// compose (action picker, fulfillment resolver). Signing, the `CoreSDK`
-// bridge, and the `handle402` entrypoint land in the next iteration.
+// MVP: ERC-3009 token-auth, server-channel submission only,
+// `boson-createOfferAndCommit` action only. Signing routes through
+// `CoreSDK.signMetaTxCreateOfferAndCommit` directly.
 
 export type {
   ExchangeSummary,
@@ -25,3 +24,7 @@ export {
 
 export { pickAction } from "./action.js";
 export { resolveFulfillment, type ResolvedFulfillment } from "./fulfillment.js";
+export { parseChainId } from "./core-sdk-factory.js";
+export { parsePaymentResponse } from "./response.js";
+export { createX402bClient, type X402bClient } from "./client.js";
+export type { ResolveDisputeArgs, SignActionArgs, SimplePostCommitArgs } from "./post-commit.js";

--- a/typescript/packages/client/src/index.ts
+++ b/typescript/packages/client/src/index.ts
@@ -1,8 +1,12 @@
 // Public surface for `@bosonprotocol/x402-client`.
 //
-// MVP: ERC-3009 token-auth, server-channel submission only,
-// `boson-createOfferAndCommit` action only. Signing routes through
-// `CoreSDK.signMetaTxCreateOfferAndCommit` directly.
+// MVP: ERC-3009 token-auth and server-channel submission only. The
+// commit-time `boson-createOfferAndCommit` action is signed via
+// `CoreSDK.signMetaTxCreateOfferAndCommit` inside `handle402`; buyer-side
+// post-commit transitions (`boson-redeem`, `boson-cancelVoucher`,
+// `boson-completeExchange`, and the dispute family — `raiseDispute`,
+// `retractDispute`, `escalateDispute`, `resolveDispute`) are signed via
+// the matching `CoreSDK.signMetaTx*` mixin behind `client.signAction`.
 
 export type {
   ExchangeSummary,

--- a/typescript/packages/client/src/payload.ts
+++ b/typescript/packages/client/src/payload.ts
@@ -72,7 +72,16 @@ export function assembleAndEncodePayload(args: AssembleArgs): string {
   if (typeof Buffer !== "undefined") {
     return Buffer.from(json, "utf8").toString("base64");
   }
-  // Browser fallback. `btoa` is available in every modern browser and in
-  // Node 18+; the `Buffer` branch above takes precedence on Node anyway.
-  return btoa(json);
+  // Browser fallback. Wire payloads mostly carry hex/numeric strings, but
+  // `fulfillment.data` is a `Record<string, unknown>` that the buyer
+  // populates — emails, addresses, free-form notes. `btoa` accepts only
+  // a binary string (code units 0–255) and throws `InvalidCharacterError`
+  // on any character above U+00FF. UTF-8 encode the JSON first, then map
+  // the bytes into the binary-string form `btoa` expects.
+  const bytes = new TextEncoder().encode(json);
+  let binary = "";
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary);
 }

--- a/typescript/packages/client/src/payload.ts
+++ b/typescript/packages/client/src/payload.ts
@@ -1,0 +1,78 @@
+// Assemble the X-PAYMENT body and base64-encode it.
+//
+// Defense-in-depth: the assembled `EscrowPaymentPayload` is re-validated
+// through `parseEscrowPaymentPayload` from `@bosonprotocol/x402-core`
+// before serialization, so shape bugs surface here instead of at the
+// server. Base64 encoding picks `Buffer` on Node and `btoa` on browser
+// targets — tsup builds both, so the runtime branch matters.
+
+import {
+  parseEscrowPaymentPayload,
+  type BosonMetaTx,
+  type BosonTokenAuth,
+  type EscrowPaymentPayload,
+  type EscrowPaymentRequirements,
+  type TokenAuthStrategy,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+import type { Address } from "viem";
+
+import type { ResolvedFulfillment } from "./fulfillment.js";
+
+/** Current x402 protocol version embedded in the payload envelope. */
+export const X402_VERSION = 2;
+
+export interface AssembleArgs {
+  requirements: EscrowPaymentRequirements;
+  action: string;
+  tokenAuthStrategy: TokenAuthStrategy;
+  metaTx: BosonMetaTx;
+  tokenAuth?: BosonTokenAuth;
+  fulfillment?: ResolvedFulfillment;
+  buyer: Address;
+}
+
+/** Construct and re-validate the payload, returning the structured object. */
+export function assemblePayload({
+  requirements,
+  action,
+  tokenAuthStrategy,
+  metaTx,
+  tokenAuth,
+  fulfillment,
+  buyer,
+}: AssembleArgs): EscrowPaymentPayload {
+  const payload: EscrowPaymentPayload = {
+    x402Version: X402_VERSION,
+    scheme: "escrow",
+    network: requirements.network,
+    payload: {
+      action,
+      tokenAuthStrategy,
+      offerRef: {
+        fullOffer: requirements.offer.fullOffer,
+        sellerSig: requirements.offer.sellerSig,
+      },
+      buyer,
+      metaTx,
+      ...(tokenAuth ? { tokenAuth } : {}),
+    },
+    ...(fulfillment ? { fulfillment } : {}),
+  };
+
+  // Defensive re-parse — surfaces shape bugs (e.g. malformed hex) before
+  // the payload escapes the client.
+  parseEscrowPaymentPayload(payload);
+  return payload;
+}
+
+/** Build, validate, and base64-encode the payload for the `X-PAYMENT` header. */
+export function assembleAndEncodePayload(args: AssembleArgs): string {
+  const payload = assemblePayload(args);
+  const json = JSON.stringify(payload);
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(json, "utf8").toString("base64");
+  }
+  // Browser fallback. `btoa` is available in every modern browser and in
+  // Node 18+; the `Buffer` branch above takes precedence on Node anyway.
+  return btoa(json);
+}

--- a/typescript/packages/client/src/post-commit.ts
+++ b/typescript/packages/client/src/post-commit.ts
@@ -15,12 +15,12 @@
 // meta-tx with a token-auth payload — that wrapper lives outside MVP. Here
 // we only sign the meta-tx itself; the deposit flow is a later PR.
 
-import { randomBytes } from "node:crypto";
-
 import type { CoreSDK } from "@bosonprotocol/core-sdk";
 import type { BosonMetaTx } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { ActionId } from "@bosonprotocol/x402-core/state-machine";
 import type { Address, Hex } from "viem";
+
+import { randomUint256 } from "./utils/crypto.js";
 
 // Matches the subset of ethers' `BigNumberish` core-sdk actually accepts at
 // runtime, without pulling `@ethersproject/bignumber` into this package's
@@ -136,14 +136,15 @@ async function callSignMetaTx(
         buyerPercent: args.buyerPercent,
         counterpartySig: args.counterpartySig,
       });
+    default: {
+      // The discriminated union makes this unreachable at the type level;
+      // the `never` annotation enforces exhaustiveness at compile time, and
+      // the throw guarantees a clear error if a runtime value ever slips
+      // past the type checker.
+      const _exhaustive: never = args;
+      throw new Error(
+        `x402-client: unsupported post-commit action '${(_exhaustive as { actionId: string }).actionId}'`,
+      );
+    }
   }
-}
-
-function randomUint256(): bigint {
-  const bytes = randomBytes(32);
-  let n = 0n;
-  for (const byte of bytes) {
-    n = (n << 8n) | BigInt(byte);
-  }
-  return n;
 }

--- a/typescript/packages/client/src/post-commit.ts
+++ b/typescript/packages/client/src/post-commit.ts
@@ -1,0 +1,149 @@
+// Sign Boson protocol meta-transactions for post-commit buyer actions.
+//
+// These are the transitions the buyer can drive once an exchange exists on
+// chain: redeem the voucher, cancel/complete the exchange, or move through
+// the dispute family. Each is a single-call meta-tx that the
+// server/facilitator submits via
+// `MetaTransactionsHandlerFacet.executeMetaTransaction`. None of them
+// carry a token-auth payload (the funds are already escrowed) so the
+// returned `BosonMetaTx` is the full wire-format the server consumes —
+// usually as a JSON POST body, not an `X-PAYMENT` header.
+//
+// `boson-escalateDispute` is the one exception. If the dispute resolver
+// requires an escalation deposit, the resolver/server can return its own
+// 402 carrying an `escrow` `PaymentRequirements` and the buyer pairs this
+// meta-tx with a token-auth payload — that wrapper lives outside MVP. Here
+// we only sign the meta-tx itself; the deposit flow is a later PR.
+
+import { randomBytes } from "node:crypto";
+
+import type { CoreSDK } from "@bosonprotocol/core-sdk";
+import type { BosonMetaTx } from "@bosonprotocol/x402-core/schemes/escrow";
+import type { ActionId } from "@bosonprotocol/x402-core/state-machine";
+import type { Address, Hex } from "viem";
+
+// Matches the subset of ethers' `BigNumberish` core-sdk actually accepts at
+// runtime, without pulling `@ethersproject/bignumber` into this package's
+// declared deps. Callers usually pass decimal strings (the wire format).
+type BigNumberish = string | number | bigint;
+
+/**
+ * Buyer-invokable post-commit action ids — derived from `ActionId` in
+ * `@bosonprotocol/x402-core/state-machine` (the single source of truth)
+ * by excluding:
+ *
+ *  - the commit-time ids, which the buyer signs via `handle402`;
+ *  - `boson-revokeVoucher`, which is seller-only.
+ *
+ * `boson-resolveDispute` is included here but discriminated separately
+ * in `SignActionArgs` because it takes extra parameters.
+ */
+type BuyerPostCommitActionId = Exclude<
+  ActionId,
+  "boson-createOfferAndCommit" | "boson-createOfferCommitAndRedeem" | "boson-revokeVoucher"
+>;
+
+/** Caller-supplied arguments for `client.signAction`. */
+export type SignActionArgs = SimplePostCommitArgs | ResolveDisputeArgs;
+
+interface BaseArgs {
+  exchangeId: BigNumberish;
+  /** CAIP-2 network identifier (e.g. `"eip155:8453"`). */
+  network: string;
+  /** Boson Diamond address (the `escrowAddress` from the prior 402). */
+  escrowAddress: Address;
+}
+
+export interface SimplePostCommitArgs extends BaseArgs {
+  actionId: Exclude<BuyerPostCommitActionId, "boson-resolveDispute">;
+}
+
+export interface ResolveDisputeArgs extends BaseArgs {
+  actionId: "boson-resolveDispute";
+  /** Buyer share of the disputed amount, in the units the protocol expects (basis points). */
+  buyerPercent: BigNumberish;
+  /** Counterparty (seller) signature over the proposal. Hex string or `{r, s, v}`. */
+  counterpartySig: Hex | { r: Hex; s: Hex; v: number };
+}
+
+export interface SignPostCommitActionDeps {
+  buildCoreSdk: (network: string, escrowAddress: Address) => { coreSdk: CoreSDK; chainId: number };
+  getBuyerAddress: () => Promise<Address>;
+}
+
+/**
+ * Sign a post-commit action through the appropriate `CoreSDK.signMetaTx*`
+ * mixin method. Returns the wire-format `BosonMetaTx` envelope ready to be
+ * delivered to whichever channel the caller chooses (server POST,
+ * facilitator, direct on-chain submission).
+ */
+export async function signPostCommitAction(
+  args: SignActionArgs,
+  deps: SignPostCommitActionDeps,
+): Promise<BosonMetaTx> {
+  const nonce = randomUint256();
+  const buyer = await deps.getBuyerAddress();
+  const { coreSdk } = deps.buildCoreSdk(args.network, args.escrowAddress);
+
+  const signed = await callSignMetaTx(coreSdk, args, nonce);
+
+  return {
+    from: buyer,
+    nonce: nonce.toString(),
+    functionName: signed.functionName,
+    functionSignature: signed.functionSignature as Hex,
+    sig: {
+      v: Number(signed.v),
+      r: signed.r as Hex,
+      s: signed.s as Hex,
+    },
+  };
+}
+
+interface SignedMetaTxShape {
+  functionName: string;
+  functionSignature: string;
+  r: string;
+  s: string;
+  v: number;
+}
+
+async function callSignMetaTx(
+  coreSdk: CoreSDK,
+  args: SignActionArgs,
+  nonce: bigint,
+): Promise<SignedMetaTxShape> {
+  const nonceStr = nonce.toString();
+  const exchangeId = args.exchangeId;
+
+  switch (args.actionId) {
+    case "boson-redeem":
+      return coreSdk.signMetaTxRedeemVoucher({ nonce: nonceStr, exchangeId });
+    case "boson-cancelVoucher":
+      return coreSdk.signMetaTxCancelVoucher({ nonce: nonceStr, exchangeId });
+    case "boson-completeExchange":
+      return coreSdk.signMetaTxCompleteExchange({ nonce: nonceStr, exchangeId });
+    case "boson-raiseDispute":
+      return coreSdk.signMetaTxRaiseDispute({ nonce: nonceStr, exchangeId });
+    case "boson-retractDispute":
+      return coreSdk.signMetaTxRetractDispute({ nonce: nonceStr, exchangeId });
+    case "boson-escalateDispute":
+      return coreSdk.signMetaTxEscalateDispute({ nonce: nonceStr, exchangeId });
+    case "boson-resolveDispute":
+      return coreSdk.signMetaTxResolveDispute({
+        nonce: nonceStr,
+        exchangeId,
+        buyerPercent: args.buyerPercent,
+        counterpartySig: args.counterpartySig,
+      });
+  }
+}
+
+function randomUint256(): bigint {
+  const bytes = randomBytes(32);
+  let n = 0n;
+  for (const byte of bytes) {
+    n = (n << 8n) | BigInt(byte);
+  }
+  return n;
+}

--- a/typescript/packages/client/src/pre-commit.ts
+++ b/typescript/packages/client/src/pre-commit.ts
@@ -7,8 +7,6 @@
 // against; we re-shape it into the escrow scheme's wire-format
 // `BosonMetaTx` for the X-PAYMENT payload.
 
-import { randomBytes } from "node:crypto";
-
 import type { CoreSDK } from "@bosonprotocol/core-sdk";
 import type { FullOfferArgs } from "@bosonprotocol/common";
 import type {
@@ -16,6 +14,8 @@ import type {
   EscrowPaymentRequirements,
 } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { Address, Hex } from "viem";
+
+import { randomUint256 } from "./utils/crypto.js";
 
 export interface SignCreateOfferAndCommitMetaTxArgs {
   requirements: EscrowPaymentRequirements;
@@ -66,13 +66,4 @@ export async function signCreateOfferAndCommitMetaTx({
       s: signed.s as Hex,
     },
   };
-}
-
-function randomUint256(): bigint {
-  const bytes = randomBytes(32);
-  let n = 0n;
-  for (const byte of bytes) {
-    n = (n << 8n) | BigInt(byte);
-  }
-  return n;
 }

--- a/typescript/packages/client/src/pre-commit.ts
+++ b/typescript/packages/client/src/pre-commit.ts
@@ -1,0 +1,78 @@
+// Sign the Boson protocol meta-transaction for `createOfferAndCommit`.
+//
+// Routes through `CoreSDK.signMetaTxCreateOfferAndCommit` directly so the
+// EIP-712 domain, function signature, and calldata encoding stay in
+// lock-step with the deployed protocol. The returned `SignedMetaTx` is
+// shaped exactly as the on-chain `MetaTransactionsHandlerFacet` recovers
+// against; we re-shape it into the escrow scheme's wire-format
+// `BosonMetaTx` for the X-PAYMENT payload.
+
+import { randomBytes } from "node:crypto";
+
+import type { CoreSDK } from "@bosonprotocol/core-sdk";
+import type { FullOfferArgs } from "@bosonprotocol/common";
+import type {
+  BosonMetaTx,
+  EscrowPaymentRequirements,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+import type { Address, Hex } from "viem";
+
+export interface SignCreateOfferAndCommitMetaTxArgs {
+  requirements: EscrowPaymentRequirements;
+  coreSdk: CoreSDK;
+  buyer: Address;
+}
+
+/**
+ * Builds the buyer-side meta-tx for `createOfferAndCommit`, signs it via
+ * `CoreSDK`, and returns the wire-format envelope ready to be embedded in
+ * an `EscrowPaymentPayload`.
+ *
+ * The `createOfferAndCommitArgs` are reconstructed from the
+ * `requirements.offer` triple — the opaque `fullOffer` carries the
+ * `Omit<FullOfferArgs, "signature">` shape, `sellerSig` becomes the
+ * `signature`, and the buyer's address is spliced in as `committer`. Any
+ * shape drift between the wire format and `FullOfferArgs` surfaces as a
+ * yup validation error from core-sdk's
+ * `createOfferAndCommitArgsSchema.validateSync` — propagate it rather than
+ * patch silently (CLAUDE.md "Production over spec when they diverge").
+ */
+export async function signCreateOfferAndCommitMetaTx({
+  requirements,
+  coreSdk,
+  buyer,
+}: SignCreateOfferAndCommitMetaTxArgs): Promise<BosonMetaTx> {
+  const nonce = randomUint256();
+
+  const createOfferAndCommitArgs = {
+    ...(requirements.offer.fullOffer as object),
+    signature: requirements.offer.sellerSig,
+    committer: buyer,
+  } as unknown as FullOfferArgs;
+
+  const signed = await coreSdk.signMetaTxCreateOfferAndCommit({
+    nonce: nonce.toString(),
+    createOfferAndCommitArgs,
+  });
+
+  return {
+    from: buyer,
+    nonce: nonce.toString(),
+    functionName: signed.functionName,
+    functionSignature: signed.functionSignature as Hex,
+    sig: {
+      v: Number(signed.v),
+      r: signed.r as Hex,
+      s: signed.s as Hex,
+    },
+  };
+}
+
+function randomUint256(): bigint {
+  const bytes = randomBytes(32);
+  let n = 0n;
+  for (const byte of bytes) {
+    n = (n << 8n) | BigInt(byte);
+  }
+  return n;
+}

--- a/typescript/packages/client/src/response.ts
+++ b/typescript/packages/client/src/response.ts
@@ -39,18 +39,33 @@ export function parsePaymentResponse(response: ResponseLike): ExchangeSummary | 
     summary.exchangeId = exchangeId;
   }
 
-  // `ClientState` is `"PRE_COMMIT"` (string literal) OR an
-  // `{ exchange, dispute? }` object, so accept either shape and reject
-  // numbers / booleans / `null` rather than letting them flow into a
-  // field typed as the union. The `as` cast stays permissive because the
-  // server-side header contract isn't pinned yet — callers needing
-  // stronger guarantees can read `raw` directly.
   const state = (parsed as { state?: unknown }).state;
-  if (typeof state === "string" || (typeof state === "object" && state !== null)) {
-    summary.state = state as ExchangeSummary["state"];
+  if (isClientStateShape(state)) {
+    summary.state = state;
   }
 
   return summary;
+}
+
+/**
+ * Shape gate for `state` arriving from the permissive server header. We
+ * keep the file-header promise of permissiveness — `ClientState` is
+ * `"PRE_COMMIT"` or an `{ exchange, dispute? }` record today, but the
+ * wire contract isn't pinned, so any non-empty string (e.g. raw
+ * `ExchangeState` value) or non-array `{ exchange }`-shaped record is
+ * surfaced verbatim. Numbers, booleans, `null`, empty strings, arrays,
+ * and records missing a string `exchange` field are rejected so garbage
+ * payloads can't masquerade as a typed `ClientState`.
+ */
+function isClientStateShape(v: unknown): v is NonNullable<ExchangeSummary["state"]> {
+  if (typeof v === "string") return v.length > 0;
+  if (typeof v !== "object" || v === null || Array.isArray(v)) return false;
+  const rec = v as Record<string, unknown>;
+  if (typeof rec.exchange !== "string") return false;
+  if ("dispute" in rec && rec.dispute !== undefined && typeof rec.dispute !== "string") {
+    return false;
+  }
+  return true;
 }
 
 function decodeBase64(value: string): string {

--- a/typescript/packages/client/src/response.ts
+++ b/typescript/packages/client/src/response.ts
@@ -39,8 +39,14 @@ export function parsePaymentResponse(response: ResponseLike): ExchangeSummary | 
     summary.exchangeId = exchangeId;
   }
 
+  // `ClientState` is `"PRE_COMMIT"` (string literal) OR an
+  // `{ exchange, dispute? }` object, so accept either shape and reject
+  // numbers / booleans / `null` rather than letting them flow into a
+  // field typed as the union. The `as` cast stays permissive because the
+  // server-side header contract isn't pinned yet — callers needing
+  // stronger guarantees can read `raw` directly.
   const state = (parsed as { state?: unknown }).state;
-  if (state !== undefined) {
+  if (typeof state === "string" || (typeof state === "object" && state !== null)) {
     summary.state = state as ExchangeSummary["state"];
   }
 

--- a/typescript/packages/client/src/response.ts
+++ b/typescript/packages/client/src/response.ts
@@ -1,0 +1,65 @@
+// Parse the optional `X-PAYMENT-RESPONSE` header the server may emit after
+// settling.
+//
+// The escrow-scheme spec doesn't pin a strict contract for this header yet,
+// so the parser is permissive: base64-decode the value, JSON-parse it, and
+// return `{ raw }`. Best-effort lifting picks `exchangeId` / `state` from
+// the common property paths an x402B server might use. Callers who need
+// stronger guarantees can read `raw` directly.
+
+import type { ExchangeSummary } from "./types.js";
+
+const HEADER_NAME = "X-PAYMENT-RESPONSE";
+
+/** Read a header value from anything that exposes `.get(name)`. */
+interface HeaderLike {
+  get(name: string): string | null;
+}
+
+interface ResponseLike {
+  headers: HeaderLike;
+}
+
+/**
+ * Decode the `X-PAYMENT-RESPONSE` header on a Response-like object. Returns
+ * `undefined` when the header isn't set; throws on a malformed payload.
+ */
+export function parsePaymentResponse(response: ResponseLike): ExchangeSummary | undefined {
+  const raw = response.headers.get(HEADER_NAME);
+  if (!raw) {
+    return undefined;
+  }
+
+  const json = decodeBase64(raw);
+  const parsed = JSON.parse(json) as Record<string, unknown>;
+  const summary: ExchangeSummary = { raw: parsed };
+
+  const exchangeId = pickString(parsed, ["exchangeId", "exchange_id"]);
+  if (exchangeId !== undefined) {
+    summary.exchangeId = exchangeId;
+  }
+
+  const state = (parsed as { state?: unknown }).state;
+  if (state !== undefined) {
+    summary.state = state as ExchangeSummary["state"];
+  }
+
+  return summary;
+}
+
+function decodeBase64(value: string): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value, "base64").toString("utf8");
+  }
+  return atob(value);
+}
+
+function pickString(obj: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const v = obj[key];
+    if (typeof v === "string" && v.length > 0) {
+      return v;
+    }
+  }
+  return undefined;
+}

--- a/typescript/packages/client/src/response.ts
+++ b/typescript/packages/client/src/response.ts
@@ -51,7 +51,12 @@ function decodeBase64(value: string): string {
   if (typeof Buffer !== "undefined") {
     return Buffer.from(value, "base64").toString("utf8");
   }
-  return atob(value);
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
 }
 
 function pickString(obj: Record<string, unknown>, keys: string[]): string | undefined {

--- a/typescript/packages/client/src/response.ts
+++ b/typescript/packages/client/src/response.ts
@@ -31,17 +31,23 @@ export function parsePaymentResponse(response: ResponseLike): ExchangeSummary | 
   }
 
   const json = decodeBase64(raw);
-  const parsed = JSON.parse(json) as Record<string, unknown>;
+  const parsed: unknown = JSON.parse(json);
   const summary: ExchangeSummary = { raw: parsed };
 
-  const exchangeId = pickString(parsed, ["exchangeId", "exchange_id"]);
-  if (exchangeId !== undefined) {
-    summary.exchangeId = exchangeId;
-  }
+  // Only walk into the payload when it's actually a plain record. A valid
+  // JSON value can be `null`, an array, or a primitive — touching keys on
+  // those would crash, defeating the file-header permissive promise.
+  if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+    const obj = parsed as Record<string, unknown>;
 
-  const state = (parsed as { state?: unknown }).state;
-  if (isClientStateShape(state)) {
-    summary.state = state;
+    const exchangeId = pickString(obj, ["exchangeId", "exchange_id"]);
+    if (exchangeId !== undefined) {
+      summary.exchangeId = exchangeId;
+    }
+
+    if (isClientStateShape(obj.state)) {
+      summary.state = obj.state;
+    }
   }
 
   return summary;

--- a/typescript/packages/client/src/token-auth/erc3009.ts
+++ b/typescript/packages/client/src/token-auth/erc3009.ts
@@ -1,0 +1,98 @@
+// Build and sign the buyer's ERC-3009 `ReceiveWithAuthorization` for the
+// escrow contract.
+//
+// The typed-data builder lives in `@bosonprotocol/x402-core` — reused here
+// rather than redeclared so the type-list and primary-type stay in
+// lock-step with the canonical EIP-3009 shape Boson expects. The buyer
+// signs through the configured `Signer`; the resulting 65-byte hex
+// signature is split into wire-format `{ v, r, s }` via viem's
+// `parseSignature`.
+
+import { randomBytes } from "node:crypto";
+
+import {
+  erc3009TypedData,
+  type TokenEip712Domain,
+} from "@bosonprotocol/x402-core/eip712/token-auth";
+import type {
+  Erc3009AuthData,
+  EscrowPaymentRequirements,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+import { parseSignature, type Address, type Hex } from "viem";
+
+import { parseChainId } from "../core-sdk-factory.js";
+import type { Signer, TokenDomainResolver } from "../types.js";
+
+export interface SignErc3009Args {
+  requirements: EscrowPaymentRequirements;
+  buyer: Address;
+  signer: Signer;
+  tokenDomainResolver: TokenDomainResolver;
+  /** Override the wall-clock; injected by tests for determinism. Defaults to `Date.now()`. */
+  now?: () => number;
+}
+
+/**
+ * Build the ERC-3009 typed-data, sign it, and shape the result into the
+ * `Erc3009AuthData` slot of the escrow payment payload.
+ */
+export async function signErc3009({
+  requirements,
+  buyer,
+  signer,
+  tokenDomainResolver,
+  now = Date.now,
+}: SignErc3009Args): Promise<Erc3009AuthData> {
+  const chainId = parseChainId(requirements.network);
+  const domain: TokenEip712Domain = await tokenDomainResolver(
+    requirements.asset as Address,
+    chainId,
+  );
+
+  const nonce = randomBytes32();
+  const validAfter = 0n;
+  const validBefore = BigInt(Math.floor(now() / 1000) + requirements.maxTimeoutSeconds);
+
+  const typedData = erc3009TypedData({
+    domain,
+    message: {
+      from: buyer,
+      to: requirements.escrowAddress as Address,
+      value: BigInt(requirements.amount),
+      validAfter,
+      validBefore,
+      nonce,
+    },
+  });
+
+  const signature = await signer.signTypedData({
+    domain: typedData.domain,
+    types: typedData.types,
+    primaryType: typedData.primaryType,
+    message: {
+      from: typedData.message.from,
+      to: typedData.message.to,
+      value: typedData.message.value,
+      validAfter: typedData.message.validAfter,
+      validBefore: typedData.message.validBefore,
+      nonce: typedData.message.nonce,
+    },
+  });
+  const { v, r, s } = parseSignature(signature);
+
+  return {
+    from: buyer,
+    to: requirements.escrowAddress,
+    value: requirements.amount,
+    validAfter: Number(validAfter),
+    validBefore: Number(validBefore),
+    nonce,
+    v: Number(v),
+    r,
+    s,
+  };
+}
+
+function randomBytes32(): Hex {
+  return `0x${randomBytes(32).toString("hex")}`;
+}

--- a/typescript/packages/client/src/token-auth/erc3009.ts
+++ b/typescript/packages/client/src/token-auth/erc3009.ts
@@ -8,8 +8,6 @@
 // signature is split into wire-format `{ v, r, s }` via viem's
 // `parseSignature`.
 
-import { randomBytes } from "node:crypto";
-
 import {
   erc3009TypedData,
   type TokenEip712Domain,
@@ -18,10 +16,11 @@ import type {
   Erc3009AuthData,
   EscrowPaymentRequirements,
 } from "@bosonprotocol/x402-core/schemes/escrow";
-import { parseSignature, type Address, type Hex } from "viem";
+import { parseSignature, type Address } from "viem";
 
 import { parseChainId } from "../core-sdk-factory.js";
 import type { Signer, TokenDomainResolver } from "../types.js";
+import { randomBytes32 } from "../utils/crypto.js";
 
 export interface SignErc3009Args {
   requirements: EscrowPaymentRequirements;
@@ -91,8 +90,4 @@ export async function signErc3009({
     r,
     s,
   };
-}
-
-function randomBytes32(): Hex {
-  return `0x${randomBytes(32).toString("hex")}`;
 }

--- a/typescript/packages/client/src/token-auth/index.ts
+++ b/typescript/packages/client/src/token-auth/index.ts
@@ -1,0 +1,52 @@
+// Token-authorization strategy dispatcher.
+//
+// MVP supports only the ERC-3009 `ReceiveWithAuthorization` path. The
+// `none` / `permit` / `permit2` strategies are advertised in the wire
+// format but not yet implemented client-side — calling with one of those
+// (without `"erc3009"` also being on offer) raises
+// `UnsupportedTokenAuthError`. The picker prefers `"erc3009"` whenever the
+// server lists it alongside other strategies.
+
+import type {
+  BosonTokenAuth,
+  EscrowPaymentRequirements,
+  TokenAuthStrategy,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+import type { Address } from "viem";
+
+import { UnsupportedTokenAuthError } from "../errors.js";
+import type { Signer, TokenDomainResolver } from "../types.js";
+
+import { signErc3009 } from "./erc3009.js";
+
+export interface BuildTokenAuthArgs {
+  requirements: EscrowPaymentRequirements;
+  buyer: Address;
+  signer: Signer;
+  tokenDomainResolver: TokenDomainResolver;
+  now?: () => number;
+}
+
+export interface BuiltTokenAuth {
+  strategy: TokenAuthStrategy;
+  tokenAuth: BosonTokenAuth;
+}
+
+/**
+ * Pick a supported strategy from `requirements.tokenAuthStrategies`, build
+ * the corresponding typed-data, sign it through the buyer's signer, and
+ * return the wire-format `BosonTokenAuth` slot.
+ */
+export async function buildAndSignTokenAuth(args: BuildTokenAuthArgs): Promise<BuiltTokenAuth> {
+  if (!args.requirements.tokenAuthStrategies.includes("erc3009")) {
+    throw new UnsupportedTokenAuthError(
+      `server advertises tokenAuthStrategies=[${args.requirements.tokenAuthStrategies.join(", ")}]; client only supports 'erc3009' in MVP`,
+    );
+  }
+
+  const data = await signErc3009(args);
+  return {
+    strategy: "erc3009",
+    tokenAuth: { kind: "erc3009", data },
+  };
+}

--- a/typescript/packages/client/src/utils/crypto.ts
+++ b/typescript/packages/client/src/utils/crypto.ts
@@ -1,0 +1,48 @@
+// Cross-platform random helpers.
+//
+// The client is framework-agnostic: it must run in browsers (where
+// `node:crypto` is unavailable) as well as Node. The Web Crypto API
+// (`globalThis.crypto.getRandomValues`) covers both — it's been a Node
+// global since 19 and is universally available in modern browsers.
+// The package's `engines.node` already requires Node ≥ 22, so we can
+// rely on the global without a `node:crypto` fallback.
+//
+// Centralizing the helpers here keeps `pre-commit.ts`, `post-commit.ts`,
+// and `token-auth/erc3009.ts` from each importing their own crypto
+// primitive and re-deriving the same byte → bigint / byte → hex
+// conversion (CLAUDE.md "Move duplicated constants ... into a shared
+// file the moment they appear in two places").
+
+import type { Hex } from "viem";
+
+/** Fill a fresh `Uint8Array` of `size` bytes with cryptographically random bytes. */
+export function randomBytes(size: number): Uint8Array {
+  const bytes = new Uint8Array(size);
+  if (typeof globalThis.crypto?.getRandomValues !== "function") {
+    throw new Error(
+      "x402-client: globalThis.crypto.getRandomValues is unavailable — environment lacks the Web Crypto API",
+    );
+  }
+  globalThis.crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+/** 32-byte cryptographically random `0x`-prefixed hex string. */
+export function randomBytes32(): Hex {
+  const bytes = randomBytes(32);
+  let hex = "0x";
+  for (const b of bytes) {
+    hex += b.toString(16).padStart(2, "0");
+  }
+  return hex as Hex;
+}
+
+/** Cryptographically random `uint256`. Used for protocol meta-tx replay-protection nonces. */
+export function randomUint256(): bigint {
+  const bytes = randomBytes(32);
+  let n = 0n;
+  for (const byte of bytes) {
+    n = (n << 8n) | BigInt(byte);
+  }
+  return n;
+}

--- a/typescript/packages/client/test/handle402.test.ts
+++ b/typescript/packages/client/test/handle402.test.ts
@@ -19,7 +19,11 @@ import { recoverTypedDataAddress } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 
 import { createX402bClient } from "../src/client.js";
-import { NotImplementedError, UnsupportedTokenAuthError } from "../src/errors.js";
+import {
+  MaxAmountExceededError,
+  NotImplementedError,
+  UnsupportedTokenAuthError,
+} from "../src/errors.js";
 import { viemAccountSigner } from "../src/signer/index.js";
 
 const TEST_KEY = `0x${"42".repeat(32)}` as const;
@@ -223,5 +227,16 @@ describe("handle402 — round-trip", () => {
     requirements.tokenAuthStrategies = ["none", "permit"];
     const client = makeClient();
     await expect(client.handle402(requirements)).rejects.toThrow(UnsupportedTokenAuthError);
+  });
+
+  it("rejects requirements whose amount exceeds policy.maxAmount before signing", async () => {
+    const requirements = baseRequirements();
+    requirements.amount = "1000001";
+    const client = createX402bClient({
+      signer: viemAccountSigner(BUYER_ACCOUNT),
+      policy: { maxAmount: "1000000" },
+    });
+
+    await expect(client.handle402(requirements)).rejects.toThrow(MaxAmountExceededError);
   });
 });

--- a/typescript/packages/client/test/handle402.test.ts
+++ b/typescript/packages/client/test/handle402.test.ts
@@ -1,0 +1,227 @@
+// Round-trip test for the `handle402` entrypoint.
+//
+// Feeds an `EscrowPaymentRequirements` shaped after the spec example, runs
+// `handle402` with a deterministic viem `LocalAccount`, decodes the base64
+// `X-PAYMENT` value back to the structured payload, and asserts the
+// docs/boson-impl-01-escrow-scheme.md §5 validation rules pass locally.
+//
+// The `requirements.offer.fullOffer` carries a full `Omit<FullOfferArgs,
+// "signature">` shape so core-sdk's yup validation inside
+// `signMetaTxCreateOfferAndCommit` accepts it.
+
+import { describe, expect, it } from "vitest";
+import {
+  parseEscrowPaymentPayload,
+  type EscrowPaymentRequirements,
+  type Erc3009AuthData,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+import { recoverTypedDataAddress } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { createX402bClient } from "../src/client.js";
+import { NotImplementedError, UnsupportedTokenAuthError } from "../src/errors.js";
+import { viemAccountSigner } from "../src/signer/index.js";
+
+const TEST_KEY = `0x${"42".repeat(32)}` as const;
+const BUYER_ACCOUNT = privateKeyToAccount(TEST_KEY);
+
+const USDC_BASE = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" as const;
+const ESCROW = "0xdddddddddddddddddddddddddddddddddddddddd" as const;
+const SELLER = "0x1111111111111111111111111111111111111111" as const;
+const ZERO = "0x0000000000000000000000000000000000000000" as const;
+
+const SELLER_SIG = "0xdeadbeef"; // opaque; protocol verifies on-chain
+
+// `validUntilDateInMS` must be in the future for core-sdk's yup validator.
+const NOW_MS = Date.now();
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+const VALID_UNTIL = NOW_MS + ONE_YEAR_MS;
+
+const fullOffer = {
+  price: "1000000",
+  sellerDeposit: "0",
+  agentId: "0",
+  buyerCancelPenalty: "0",
+  quantityAvailable: "1",
+  validFromDateInMS: NOW_MS.toString(),
+  validUntilDateInMS: VALID_UNTIL.toString(),
+  voucherRedeemableFromDateInMS: NOW_MS.toString(),
+  voucherRedeemableUntilDateInMS: (VALID_UNTIL + ONE_YEAR_MS).toString(),
+  voucherValidDurationInMS: "0", // exactly one of {voucherValidDurationInMS, voucherRedeemableUntilDateInMS} must be non-zero
+  disputePeriodDurationInMS: (7 * 24 * 60 * 60 * 1000).toString(),
+  resolutionPeriodDurationInMS: (7 * 24 * 60 * 60 * 1000).toString(),
+  exchangeToken: USDC_BASE,
+  disputeResolverId: "1",
+  metadataUri: "ipfs://bafyabc",
+  metadataHash: "0xabcd",
+  collectionIndex: "0",
+  offerCreator: SELLER,
+  condition: {
+    method: 0,
+    tokenType: 0,
+    tokenAddress: ZERO,
+    gatingType: 0,
+    minTokenId: "0",
+    maxTokenId: "0",
+    threshold: "0",
+    maxCommits: "0",
+  },
+  useDepositedFunds: false,
+  sellerId: "1",
+  buyerId: "0",
+  sellerOfferParams: {
+    collectionIndex: "0",
+    royaltyInfo: { recipients: [], bps: [] },
+    mutualizerAddress: ZERO,
+  },
+};
+
+function baseRequirements(): EscrowPaymentRequirements {
+  return {
+    scheme: "escrow",
+    network: "eip155:8453",
+    asset: USDC_BASE,
+    amount: "1000000",
+    escrowAddress: ESCROW,
+    recipientId: "did:boson:seller:1",
+    maxTimeoutSeconds: 300,
+    offer: { fullOffer, sellerSig: SELLER_SIG, creator: SELLER },
+    tokenAuthStrategies: ["erc3009"],
+    actions: {
+      next: [
+        {
+          id: "boson-createOfferAndCommit",
+          channels: ["server", "facilitator", "onchain"],
+          endpoints: { server: "https://seller.example/x402B/commit" },
+        },
+      ],
+    },
+  };
+}
+
+function makeClient() {
+  return createX402bClient({
+    signer: viemAccountSigner(BUYER_ACCOUNT),
+    tokenDomainResolver: async (asset, chainId) => ({
+      name: "USD Coin",
+      version: "2",
+      chainId,
+      verifyingContract: asset,
+    }),
+  });
+}
+
+describe("handle402 — round-trip", () => {
+  it("produces a base64 payload that re-parses as EscrowPaymentPayload", async () => {
+    const client = makeClient();
+    const header = await client.handle402(baseRequirements());
+
+    expect(typeof header).toBe("string");
+    const decoded = JSON.parse(Buffer.from(header, "base64").toString("utf8"));
+    expect(() => parseEscrowPaymentPayload(decoded)).not.toThrow();
+  });
+
+  it("payload satisfies §5 validation rules 1, 2, 3, 4, 5, 6, 7, 8, 9 locally", async () => {
+    const requirements = baseRequirements();
+    const client = makeClient();
+    const header = await client.handle402(requirements);
+    const decoded = parseEscrowPaymentPayload(
+      JSON.parse(Buffer.from(header, "base64").toString("utf8")),
+    );
+
+    // 1. scheme equality
+    expect(decoded.scheme).toBe("escrow");
+    expect(decoded.scheme).toBe(requirements.scheme);
+
+    // 2. network equality
+    expect(decoded.network).toBe(requirements.network);
+
+    // 3. echoed fullOffer matches requirements
+    expect(decoded.payload.offerRef.fullOffer).toEqual(requirements.offer.fullOffer);
+
+    // 4. echoed sellerSig matches requirements
+    expect(decoded.payload.offerRef.sellerSig).toBe(requirements.offer.sellerSig);
+
+    // 5. action is in requirements.actions.next[]
+    expect(requirements.actions.next.some((a) => a.id === decoded.payload.action)).toBe(true);
+
+    // 6. tokenAuthStrategy is in requirements.tokenAuthStrategies
+    expect(requirements.tokenAuthStrategies).toContain(decoded.payload.tokenAuthStrategy);
+
+    // 7. metaTx.functionName encodes createOfferAndCommit
+    expect(decoded.payload.metaTx.functionName.startsWith("createOfferAndCommit(")).toBe(true);
+
+    // 8. buyer matches account; nonce + functionSignature are present
+    expect(decoded.payload.buyer.toLowerCase()).toBe(BUYER_ACCOUNT.address.toLowerCase());
+    expect(decoded.payload.metaTx.from.toLowerCase()).toBe(BUYER_ACCOUNT.address.toLowerCase());
+    expect(decoded.payload.metaTx.nonce).toMatch(/^\d+$/);
+    expect(decoded.payload.metaTx.functionSignature.startsWith("0x")).toBe(true);
+
+    // 9. ERC-3009 token-auth shape (assert escrow `to`, exact `value`, and `validBefore` window)
+    expect(decoded.payload.tokenAuth?.kind).toBe("erc3009");
+    const tokenAuth = decoded.payload.tokenAuth?.data as Erc3009AuthData;
+    expect(tokenAuth.to.toLowerCase()).toBe(requirements.escrowAddress.toLowerCase());
+    expect(tokenAuth.value).toBe(requirements.amount);
+    const nowSec = Math.floor(Date.now() / 1000);
+    expect(tokenAuth.validBefore - nowSec).toBeLessThanOrEqual(requirements.maxTimeoutSeconds + 5);
+    expect(tokenAuth.validBefore - nowSec).toBeGreaterThan(0);
+  });
+
+  it("ERC-3009 signature recovers to the buyer account", async () => {
+    const requirements = baseRequirements();
+    const client = makeClient();
+    const header = await client.handle402(requirements);
+    const decoded = parseEscrowPaymentPayload(
+      JSON.parse(Buffer.from(header, "base64").toString("utf8")),
+    );
+    const tokenAuth = decoded.payload.tokenAuth?.data as Erc3009AuthData;
+
+    // Re-build the typed-data exactly as the client did and recover the signer.
+    const signature = `0x${tokenAuth.r.slice(2)}${tokenAuth.s.slice(2)}${tokenAuth.v
+      .toString(16)
+      .padStart(2, "0")}` as `0x${string}`;
+    const recovered = await recoverTypedDataAddress({
+      domain: {
+        name: "USD Coin",
+        version: "2",
+        chainId: 8453,
+        verifyingContract: requirements.asset as `0x${string}`,
+      },
+      types: {
+        ReceiveWithAuthorization: [
+          { name: "from", type: "address" },
+          { name: "to", type: "address" },
+          { name: "value", type: "uint256" },
+          { name: "validAfter", type: "uint256" },
+          { name: "validBefore", type: "uint256" },
+          { name: "nonce", type: "bytes32" },
+        ],
+      },
+      primaryType: "ReceiveWithAuthorization",
+      message: {
+        from: tokenAuth.from as `0x${string}`,
+        to: tokenAuth.to as `0x${string}`,
+        value: BigInt(tokenAuth.value),
+        validAfter: BigInt(tokenAuth.validAfter),
+        validBefore: BigInt(tokenAuth.validBefore),
+        nonce: tokenAuth.nonce as `0x${string}`,
+      },
+      signature,
+    });
+    expect(recovered.toLowerCase()).toBe(BUYER_ACCOUNT.address.toLowerCase());
+  });
+
+  it("rejects requirements offering only boson-createOfferCommitAndRedeem with NotImplementedError", async () => {
+    const requirements = baseRequirements();
+    requirements.actions.next = [{ id: "boson-createOfferCommitAndRedeem", channels: ["server"] }];
+    const client = makeClient();
+    await expect(client.handle402(requirements)).rejects.toThrow(NotImplementedError);
+  });
+
+  it("rejects requirements without 'erc3009' in tokenAuthStrategies", async () => {
+    const requirements = baseRequirements();
+    requirements.tokenAuthStrategies = ["none", "permit"];
+    const client = makeClient();
+    await expect(client.handle402(requirements)).rejects.toThrow(UnsupportedTokenAuthError);
+  });
+});

--- a/typescript/packages/client/test/post-commit.test.ts
+++ b/typescript/packages/client/test/post-commit.test.ts
@@ -1,0 +1,121 @@
+// Unit tests for `client.signAction` covering each post-commit action.
+//
+// Verifies the dispatcher routes to the matching `CoreSDK.signMetaTx*`
+// method (asserted via the `functionName` core-sdk embeds in the result)
+// and shapes the result into a wire-format `BosonMetaTx` with the buyer's
+// address, a numeric-string nonce, and a 65-byte signature split into
+// `{ v, r, s }`. The protocol meta-tx domain is salt-based; verifying
+// recoverability here would mean reconstructing core-sdk's domain by hand,
+// so we instead lean on the round-trip test in `handle402.test.ts` (which
+// already exercises the same signing path through createOfferAndCommit).
+
+import { describe, expect, it } from "vitest";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { createX402bClient } from "../src/client.js";
+import { viemAccountSigner } from "../src/signer/index.js";
+
+const TEST_KEY = `0x${"42".repeat(32)}` as const;
+const BUYER_ACCOUNT = privateKeyToAccount(TEST_KEY);
+
+const ESCROW = "0xdddddddddddddddddddddddddddddddddddddddd" as const;
+const NETWORK = "eip155:8453";
+const EXCHANGE_ID = "42";
+
+function makeClient() {
+  return createX402bClient({
+    signer: viemAccountSigner(BUYER_ACCOUNT),
+  });
+}
+
+const SIMPLE_CASES: Array<{
+  actionId: Parameters<ReturnType<typeof makeClient>["signAction"]>[0]["actionId"];
+  functionName: string;
+}> = [
+  { actionId: "boson-redeem", functionName: "redeemVoucher(uint256)" },
+  { actionId: "boson-cancelVoucher", functionName: "cancelVoucher(uint256)" },
+  { actionId: "boson-completeExchange", functionName: "completeExchange(uint256)" },
+  { actionId: "boson-raiseDispute", functionName: "raiseDispute(uint256)" },
+  { actionId: "boson-retractDispute", functionName: "retractDispute(uint256)" },
+  { actionId: "boson-escalateDispute", functionName: "escalateDispute(uint256)" },
+];
+
+describe("signAction — simple post-commit actions", () => {
+  it.each(SIMPLE_CASES)(
+    "%s signs a meta-tx with functionName=$functionName and the buyer's address",
+    async ({ actionId, functionName }) => {
+      const client = makeClient();
+      const meta = await client.signAction({
+        actionId: actionId as Exclude<typeof actionId, "boson-resolveDispute">,
+        exchangeId: EXCHANGE_ID,
+        network: NETWORK,
+        escrowAddress: ESCROW,
+      });
+
+      expect(meta.from.toLowerCase()).toBe(BUYER_ACCOUNT.address.toLowerCase());
+      expect(meta.nonce).toMatch(/^\d+$/);
+      expect(meta.functionName).toBe(functionName);
+      expect(meta.functionSignature.startsWith("0x")).toBe(true);
+      expect(meta.functionSignature.length).toBeGreaterThan(2);
+      expect(meta.sig.r.startsWith("0x")).toBe(true);
+      expect(meta.sig.r).toHaveLength(66);
+      expect(meta.sig.s.startsWith("0x")).toBe(true);
+      expect(meta.sig.s).toHaveLength(66);
+      expect(typeof meta.sig.v).toBe("number");
+    },
+  );
+
+  it("produces different nonces across consecutive calls (collision protection)", async () => {
+    const client = makeClient();
+    const a = await client.signAction({
+      actionId: "boson-redeem",
+      exchangeId: EXCHANGE_ID,
+      network: NETWORK,
+      escrowAddress: ESCROW,
+    });
+    const b = await client.signAction({
+      actionId: "boson-redeem",
+      exchangeId: EXCHANGE_ID,
+      network: NETWORK,
+      escrowAddress: ESCROW,
+    });
+    expect(a.nonce).not.toBe(b.nonce);
+  });
+});
+
+describe("signAction — boson-resolveDispute", () => {
+  it("threads buyerPercent and counterpartySig through to the meta-tx", async () => {
+    const client = makeClient();
+    const counterpartySig = `0x${"11".repeat(32)}${"22".repeat(32)}1b` as `0x${string}`; // dummy 65-byte hex
+
+    const meta = await client.signAction({
+      actionId: "boson-resolveDispute",
+      exchangeId: EXCHANGE_ID,
+      network: NETWORK,
+      escrowAddress: ESCROW,
+      buyerPercent: "5000",
+      counterpartySig,
+    });
+
+    expect(meta.functionName).toBe("resolveDispute(uint256,uint256,bytes)");
+    expect(meta.from.toLowerCase()).toBe(BUYER_ACCOUNT.address.toLowerCase());
+    expect(meta.functionSignature.startsWith("0x")).toBe(true);
+  });
+
+  it("accepts an object-form counterpartySig", async () => {
+    const client = makeClient();
+    const r = `0x${"aa".repeat(32)}` as const;
+    const s = `0x${"bb".repeat(32)}` as const;
+
+    const meta = await client.signAction({
+      actionId: "boson-resolveDispute",
+      exchangeId: EXCHANGE_ID,
+      network: NETWORK,
+      escrowAddress: ESCROW,
+      buyerPercent: 5000,
+      counterpartySig: { r, s, v: 27 },
+    });
+
+    expect(meta.functionName).toBe("resolveDispute(uint256,uint256,bytes)");
+  });
+});

--- a/typescript/packages/client/test/response.test.ts
+++ b/typescript/packages/client/test/response.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { parsePaymentResponse } from "../src/response.js";
+
+describe("parsePaymentResponse", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns undefined when X-PAYMENT-RESPONSE is absent", () => {
+    expect(parsePaymentResponse({ headers: { get: () => null } })).toBeUndefined();
+  });
+
+  it("decodes UTF-8 payloads in browser-like runtimes without Buffer", () => {
+    const payload = {
+      exchangeId: "42",
+      state: "COMMITTED",
+      message: "čokolada",
+    };
+    const header = Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
+
+    vi.stubGlobal("Buffer", undefined);
+
+    const parsed = parsePaymentResponse({
+      headers: { get: () => header },
+    });
+
+    expect(parsed).toEqual({
+      raw: payload,
+      exchangeId: "42",
+      state: "COMMITTED",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Wires the buyer-side signing pipeline. `createX402bClient(config)` returns a client with `handle402`, `signAction`, and `parsePaymentResponse`.
- `handle402(requirements)` produces the base64 `X-PAYMENT` value: parses requirements, signs the ERC-3009 `ReceiveWithAuthorization` for the escrow, signs `createOfferAndCommit` via `coreSdk.signMetaTxCreateOfferAndCommit`, re-validates through `parseEscrowPaymentPayload`, base64s.
- `signAction(args)` covers all buyer-side post-commit transitions: `boson-redeem` / `cancelVoucher` / `completeExchange` / `raiseDispute` / `retractDispute` / `escalateDispute` / `resolveDispute`. Each routes to the matching `CoreSDK.signMetaTx*` mixin; returns a wire-format `BosonMetaTx` (no `X-PAYMENT` wrapping — caller delivers to whichever channel).
- `SignActionArgs.actionId` derives from `ActionId` in `@bosonprotocol/x402-core/state-machine` (single source of truth) via `Exclude<>` — drops commit-time ids and seller-only `boson-revokeVoucher`.
- Bumps `@bosonprotocol/core-sdk` `1.46.1` → `1.47.1-alpha.0` (the latest alpha; surfaces `signMetaTxCreateOfferAndCommit` with the `returnTypedDataToSign` overloads).

## Test plan
- [x] `pnpm build` — all workspace packages built
- [x] `pnpm test` — **36** client tests (commit round-trip incl. ERC-3009 signature recovery to the buyer key, plus the 7 post-commit dispatch cases + nonce-uniqueness + `resolveDispute` discriminated-union threading); sibling packages unchanged
- [x] `pnpm lint` — `eslint --max-warnings 0` clean
- [x] `pnpm format:check` — prettier clean
- [x] Round-trip asserts spec §5 rules 1–9 hold locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * X402 client for escrow-based X-PAYMENT flows with ERC-3009 token-auth (MVP), pre-commit/post-commit signing, dispute-resolution actions, response parsing, and chain-id parsing with lazy Core SDK creation.

* **Utilities**
  * Cross-platform cryptographic randomness helpers and payload assembly/encoding helpers.

* **Errors**
  * New MaxAmountExceededError.

* **Tests**
  * End-to-end and unit tests for handle402, post-commit signing, and response parsing.

* **Chores**
  * Added explicit runtime dependency on the core SDK.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/29)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->