### PR TITLE
fix(postbuild): detect duplicate schema basenames before flattening

### DIFF
--- a/typescript/packages/actions/scripts/postbuild.mjs
+++ b/typescript/packages/actions/scripts/postbuild.mjs
@@ -31,12 +31,26 @@ async function* walk(dir) {
 await rm(schemasRoot, { recursive: true, force: true });
 await mkdir(schemasRoot, { recursive: true });
 
+// Track basenames as we go so two `src/**/schemas/<name>.json` files
+// from different subdirectories don't silently overwrite each other in
+// the flat `dist/schemas/` layout. The `./schemas/*` package export
+// resolves on basename, so duplicates would produce a non-deterministic
+// published artifact — fail the build instead.
 let schemaCount = 0;
+const seenSchemaNames = new Set();
 for await (const file of walk(srcRoot)) {
   if (!file.endsWith(".json")) continue;
   const rel = relative(srcRoot, file);
   if (!rel.split(/[\\/]/).includes("schemas")) continue;
   const name = file.split(/[\\/]/).pop();
+  if (!name) continue;
+  if (seenSchemaNames.has(name)) {
+    throw new Error(
+      `postbuild: duplicate schema basename '${name}' found while flattening into dist/schemas/. ` +
+        `Use a unique filename for each schema (or update the script to preserve subpaths).`,
+    );
+  }
+  seenSchemaNames.add(name);
   await copyFile(file, join(schemasRoot, name));
   schemaCount += 1;
 }

--- a/typescript/packages/actions/scripts/postbuild.mjs
+++ b/typescript/packages/actions/scripts/postbuild.mjs
@@ -36,6 +36,10 @@ await mkdir(schemasRoot, { recursive: true });
 // the flat `dist/schemas/` layout. The `./schemas/*` package export
 // resolves on basename, so duplicates would produce a non-deterministic
 // published artifact — fail the build instead.
+//
+// Comparison is case-insensitive: macOS APFS and Windows NTFS default to
+// case-insensitive matching, so `Foo.json` and `foo.json` would also
+// collide there even though Linux would treat them as distinct files.
 let schemaCount = 0;
 const seenSchemaNames = new Set();
 for await (const file of walk(srcRoot)) {
@@ -44,13 +48,14 @@ for await (const file of walk(srcRoot)) {
   if (!rel.split(/[\\/]/).includes("schemas")) continue;
   const name = file.split(/[\\/]/).pop();
   if (!name) continue;
-  if (seenSchemaNames.has(name)) {
+  const normalizedName = name.toLowerCase();
+  if (seenSchemaNames.has(normalizedName)) {
     throw new Error(
       `postbuild: duplicate schema basename '${name}' found while flattening into dist/schemas/. ` +
         `Use a unique filename for each schema (or update the script to preserve subpaths).`,
     );
   }
-  seenSchemaNames.add(name);
+  seenSchemaNames.add(normalizedName);
   await copyFile(file, join(schemasRoot, name));
   schemaCount += 1;
 }

--- a/typescript/packages/core/scripts/postbuild.mjs
+++ b/typescript/packages/core/scripts/postbuild.mjs
@@ -31,12 +31,26 @@ async function* walk(dir) {
 await rm(schemasRoot, { recursive: true, force: true });
 await mkdir(schemasRoot, { recursive: true });
 
+// Track basenames as we go so two `src/**/schemas/<name>.json` files
+// from different subdirectories don't silently overwrite each other in
+// the flat `dist/schemas/` layout. The `./schemas/*` package export
+// resolves on basename, so duplicates would produce a non-deterministic
+// published artifact — fail the build instead.
 let schemaCount = 0;
+const seenSchemaNames = new Set();
 for await (const file of walk(srcRoot)) {
   if (!file.endsWith(".json")) continue;
   const rel = relative(srcRoot, file);
   if (!rel.split(/[\\/]/).includes("schemas")) continue;
   const name = file.split(/[\\/]/).pop();
+  if (!name) continue;
+  if (seenSchemaNames.has(name)) {
+    throw new Error(
+      `postbuild: duplicate schema basename '${name}' found while flattening into dist/schemas/. ` +
+        `Use a unique filename for each schema (or update the script to preserve subpaths).`,
+    );
+  }
+  seenSchemaNames.add(name);
   await copyFile(file, join(schemasRoot, name));
   schemaCount += 1;
 }

--- a/typescript/packages/core/scripts/postbuild.mjs
+++ b/typescript/packages/core/scripts/postbuild.mjs
@@ -36,6 +36,10 @@ await mkdir(schemasRoot, { recursive: true });
 // the flat `dist/schemas/` layout. The `./schemas/*` package export
 // resolves on basename, so duplicates would produce a non-deterministic
 // published artifact — fail the build instead.
+//
+// Comparison is case-insensitive: macOS APFS and Windows NTFS default to
+// case-insensitive matching, so `Foo.json` and `foo.json` would also
+// collide there even though Linux would treat them as distinct files.
 let schemaCount = 0;
 const seenSchemaNames = new Set();
 for await (const file of walk(srcRoot)) {
@@ -44,13 +48,14 @@ for await (const file of walk(srcRoot)) {
   if (!rel.split(/[\\/]/).includes("schemas")) continue;
   const name = file.split(/[\\/]/).pop();
   if (!name) continue;
-  if (seenSchemaNames.has(name)) {
+  const normalizedName = name.toLowerCase();
+  if (seenSchemaNames.has(normalizedName)) {
     throw new Error(
       `postbuild: duplicate schema basename '${name}' found while flattening into dist/schemas/. ` +
         `Use a unique filename for each schema (or update the script to preserve subpaths).`,
     );
   }
-  seenSchemaNames.add(name);
+  seenSchemaNames.add(normalizedName);
   await copyFile(file, join(schemasRoot, name));
   schemaCount += 1;
 }

--- a/typescript/packages/fulfillment/scripts/postbuild.mjs
+++ b/typescript/packages/fulfillment/scripts/postbuild.mjs
@@ -31,12 +31,26 @@ async function* walk(dir) {
 await rm(schemasRoot, { recursive: true, force: true });
 await mkdir(schemasRoot, { recursive: true });
 
+// Track basenames as we go so two `src/**/schemas/<name>.json` files
+// from different subdirectories don't silently overwrite each other in
+// the flat `dist/schemas/` layout. The `./schemas/*` package export
+// resolves on basename, so duplicates would produce a non-deterministic
+// published artifact — fail the build instead.
 let schemaCount = 0;
+const seenSchemaNames = new Set();
 for await (const file of walk(srcRoot)) {
   if (!file.endsWith(".json")) continue;
   const rel = relative(srcRoot, file);
   if (!rel.split(/[\\/]/).includes("schemas")) continue;
   const name = file.split(/[\\/]/).pop();
+  if (!name) continue;
+  if (seenSchemaNames.has(name)) {
+    throw new Error(
+      `postbuild: duplicate schema basename '${name}' found while flattening into dist/schemas/. ` +
+        `Use a unique filename for each schema (or update the script to preserve subpaths).`,
+    );
+  }
+  seenSchemaNames.add(name);
   await copyFile(file, join(schemasRoot, name));
   schemaCount += 1;
 }

--- a/typescript/packages/fulfillment/scripts/postbuild.mjs
+++ b/typescript/packages/fulfillment/scripts/postbuild.mjs
@@ -36,6 +36,10 @@ await mkdir(schemasRoot, { recursive: true });
 // the flat `dist/schemas/` layout. The `./schemas/*` package export
 // resolves on basename, so duplicates would produce a non-deterministic
 // published artifact — fail the build instead.
+//
+// Comparison is case-insensitive: macOS APFS and Windows NTFS default to
+// case-insensitive matching, so `Foo.json` and `foo.json` would also
+// collide there even though Linux would treat them as distinct files.
 let schemaCount = 0;
 const seenSchemaNames = new Set();
 for await (const file of walk(srcRoot)) {
@@ -44,13 +48,14 @@ for await (const file of walk(srcRoot)) {
   if (!rel.split(/[\\/]/).includes("schemas")) continue;
   const name = file.split(/[\\/]/).pop();
   if (!name) continue;
-  if (seenSchemaNames.has(name)) {
+  const normalizedName = name.toLowerCase();
+  if (seenSchemaNames.has(normalizedName)) {
     throw new Error(
       `postbuild: duplicate schema basename '${name}' found while flattening into dist/schemas/. ` +
         `Use a unique filename for each schema (or update the script to preserve subpaths).`,
     );
   }
-  seenSchemaNames.add(name);
+  seenSchemaNames.add(normalizedName);
   await copyFile(file, join(schemasRoot, name));
   schemaCount += 1;
 }


### PR DESCRIPTION
## Summary
- The `src/**/schemas/*.json` → `dist/schemas/` copy in each package's `scripts/postbuild.mjs` flattens on basename. If two source schemas share a filename under different subdirectories, the second silently overwrites the first — the published `./schemas/<name>` export then resolves non-deterministically depending on filesystem walk order.
- Track basenames in a `Set` and throw on collision so the build fails loudly instead of leaking a corrupted artifact.
- Applied byte-identically across all three copies (`actions`, `core`, `fulfillment`) to keep them in sync. None of the packages currently ships colliding schemas; this is a defensive guard.

## Test plan
- [x] `pnpm build` — 3 packages build, postbuild logs match prior counts (0 schemas for actions/fulfillment; existing count for core)
- [x] `pnpm test` — 88 core + 8 actions + 7 fulfillment tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened build validation to detect case-insensitive duplicate schema basenames when flattening schemas; the build now fails on naming collisions to prevent nondeterministic overwrites and ensure consistent schema output across packages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/30)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->