### PR TITLE
feat(client-fetch): scaffold @bosonprotocol/x402-client-fetch package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,25 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
 
+  typescript/packages/client-fetch:
+    dependencies:
+      '@bosonprotocol/x402-client':
+        specifier: workspace:^
+        version: link:../client
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.10
+        version: 20.19.40
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.40)
+
   typescript/packages/core:
     dependencies:
       '@bosonprotocol/common':

--- a/typescript/packages/client-fetch/LICENSE
+++ b/typescript/packages/client-fetch/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Boson Protocol
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/typescript/packages/client-fetch/README.md
+++ b/typescript/packages/client-fetch/README.md
@@ -1,0 +1,46 @@
+# @bosonprotocol/x402-client-fetch
+
+Native-`fetch` adapter for [x402B](https://github.com/bosonprotocol/x402B) — Boson Protocol's implementation of the [`x402-escrow-schema`](https://github.com/bosonprotocol/x402-escrow-schema).
+
+This package wraps a `fetch` implementation so a request that gets a `402` carrying `scheme: "escrow"` is transparently retried with the `X-PAYMENT` header produced by [`@bosonprotocol/x402-client`](https://github.com/bosonprotocol/x402B/tree/main/typescript/packages/client). 402 responses without an `escrow` accept entry are passed through unchanged so other x402 schemes coexist cleanly.
+
+## Status
+
+Pre-release skeleton. MVP exposes only the wrapper; channel fallback, response-header decoding, and per-action retry remain on the [`@bosonprotocol/x402-client`](https://github.com/bosonprotocol/x402B/tree/main/typescript/packages/client) surface.
+
+## Install
+
+```bash
+pnpm add @bosonprotocol/x402-client-fetch
+# or: npm install @bosonprotocol/x402-client-fetch
+```
+
+`@bosonprotocol/x402-client`'s public API is re-exported from this package, so a single install covers the common case.
+
+## Usage
+
+```ts
+import {
+  createX402bClient,
+  viemAccountSigner,
+  wrapFetchWithPayment,
+} from "@bosonprotocol/x402-client-fetch";
+import { privateKeyToAccount } from "viem/accounts";
+
+const client = createX402bClient({
+  signer: viemAccountSigner(privateKeyToAccount("0x...")),
+  tokenDomainResolver: async (asset, chainId) => ({
+    name: "USD Coin",
+    version: "2",
+    chainId,
+    verifyingContract: asset,
+  }),
+});
+
+const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+const res = await fetchWithPayment("https://seller.example/resource");
+```
+
+## License
+
+[Apache-2.0](./LICENSE)

--- a/typescript/packages/client-fetch/README.md
+++ b/typescript/packages/client-fetch/README.md
@@ -6,7 +6,7 @@ This package wraps a `fetch` implementation so a request that gets a `402` carry
 
 ## Status
 
-Pre-release skeleton. MVP exposes only the wrapper; channel fallback, response-header decoding, and per-action retry remain on the [`@bosonprotocol/x402-client`](https://github.com/bosonprotocol/x402B/tree/main/typescript/packages/client) surface.
+Pre-release skeleton. The only adapter-specific export is `wrapFetchWithPayment`; the rest of the public API — `createX402bClient`, the signer adapters, error classes, `client.handle402`, `client.signAction`, `client.parsePaymentResponse`, and the configuration types — is re-exported verbatim from [`@bosonprotocol/x402-client`](https://github.com/bosonprotocol/x402B/tree/main/typescript/packages/client), so a single install of this package covers the common case.
 
 ## Install
 
@@ -14,8 +14,6 @@ Pre-release skeleton. MVP exposes only the wrapper; channel fallback, response-h
 pnpm add @bosonprotocol/x402-client-fetch
 # or: npm install @bosonprotocol/x402-client-fetch
 ```
-
-`@bosonprotocol/x402-client`'s public API is re-exported from this package, so a single install covers the common case.
 
 ## Usage
 

--- a/typescript/packages/client-fetch/package.json
+++ b/typescript/packages/client-fetch/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@bosonprotocol/x402-client-fetch",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "description": "Native-fetch adapter for the Boson Protocol x402 buyer-side SDK — intercepts 402 escrow-scheme responses and retries with the X-PAYMENT header produced by @bosonprotocol/x402-client.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bosonprotocol/x402B.git",
+    "directory": "typescript/packages/client-fetch"
+  },
+  "homepage": "https://github.com/bosonprotocol/x402B/tree/main/typescript/packages/client-fetch",
+  "bugs": {
+    "url": "https://github.com/bosonprotocol/x402B/issues"
+  },
+  "keywords": [
+    "x402",
+    "boson-protocol",
+    "escrow",
+    "fetch",
+    "client",
+    "buyer",
+    "web3",
+    "payments"
+  ],
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/cjs/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup && node scripts/postbuild.mjs",
+    "test": "vitest run --passWithNoTests",
+    "lint": "eslint src --max-warnings 0",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@bosonprotocol/x402-client": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.10",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/typescript/packages/client-fetch/scripts/postbuild.mjs
+++ b/typescript/packages/client-fetch/scripts/postbuild.mjs
@@ -31,12 +31,31 @@ async function* walk(dir) {
 await rm(schemasRoot, { recursive: true, force: true });
 await mkdir(schemasRoot, { recursive: true });
 
+// Track basenames as we go so two `src/**/schemas/<name>.json` files
+// from different subdirectories don't silently overwrite each other in
+// the flat `dist/schemas/` layout. The `./schemas/*` package export
+// resolves on basename, so duplicates would produce a non-deterministic
+// published artifact — fail the build instead.
+//
+// Comparison is case-insensitive: macOS APFS and Windows NTFS default to
+// case-insensitive matching, so `Foo.json` and `foo.json` would also
+// collide there even though Linux would treat them as distinct files.
 let schemaCount = 0;
+const seenSchemaNames = new Set();
 for await (const file of walk(srcRoot)) {
   if (!file.endsWith(".json")) continue;
   const rel = relative(srcRoot, file);
   if (!rel.split(/[\\/]/).includes("schemas")) continue;
   const name = file.split(/[\\/]/).pop();
+  if (!name) continue;
+  const normalizedName = name.toLowerCase();
+  if (seenSchemaNames.has(normalizedName)) {
+    throw new Error(
+      `postbuild: duplicate schema basename '${name}' found while flattening into dist/schemas/. ` +
+        `Use a unique filename for each schema (or update the script to preserve subpaths).`,
+    );
+  }
+  seenSchemaNames.add(normalizedName);
   await copyFile(file, join(schemasRoot, name));
   schemaCount += 1;
 }

--- a/typescript/packages/client-fetch/scripts/postbuild.mjs
+++ b/typescript/packages/client-fetch/scripts/postbuild.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Post-build housekeeping after `tsup`:
+//
+// 1. Copy `src/**/schemas/*.json` flat into `dist/schemas/` so the
+//    `./schemas/*` package export resolves at runtime.
+// 2. Write `dist/esm/package.json` ({"type":"module"}) and
+//    `dist/cjs/package.json` ({"type":"commonjs"}) so Node treats each
+//    subtree under the correct module dialect without a
+//    MODULE_TYPELESS_PACKAGE_JSON warning at consume time.
+
+import { readdir, mkdir, rm, copyFile, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const srcRoot = join(here, "..", "src");
+const distRoot = join(here, "..", "dist");
+const schemasRoot = join(distRoot, "schemas");
+
+async function* walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else yield p;
+  }
+}
+
+// Wipe `dist/schemas/` first so renamed or removed source schemas don't
+// leak into published tarballs.
+await rm(schemasRoot, { recursive: true, force: true });
+await mkdir(schemasRoot, { recursive: true });
+
+let schemaCount = 0;
+for await (const file of walk(srcRoot)) {
+  if (!file.endsWith(".json")) continue;
+  const rel = relative(srcRoot, file);
+  if (!rel.split(/[\\/]/).includes("schemas")) continue;
+  const name = file.split(/[\\/]/).pop();
+  await copyFile(file, join(schemasRoot, name));
+  schemaCount += 1;
+}
+
+await writeFile(
+  join(distRoot, "esm", "package.json"),
+  JSON.stringify({ type: "module" }, null, 2) + "\n",
+);
+await writeFile(
+  join(distRoot, "cjs", "package.json"),
+  JSON.stringify({ type: "commonjs" }, null, 2) + "\n",
+);
+
+console.log(
+  `postbuild: ${schemaCount} schema(s) -> ${relative(process.cwd(), schemasRoot)}, wrote module-type markers in dist/{esm,cjs}/package.json`,
+);

--- a/typescript/packages/client-fetch/src/index.ts
+++ b/typescript/packages/client-fetch/src/index.ts
@@ -1,0 +1,9 @@
+// Public surface for `@bosonprotocol/x402-client-fetch`.
+//
+// Re-exports the entire `@bosonprotocol/x402-client` API so a consumer
+// installing just this package gets `createX402bClient`, the signer
+// adapters, error classes, types — everything needed to set up a
+// payment-aware fetch — in one import path.
+
+export { wrapFetchWithPayment } from "./wrap.js";
+export * from "@bosonprotocol/x402-client";

--- a/typescript/packages/client-fetch/src/wrap.ts
+++ b/typescript/packages/client-fetch/src/wrap.ts
@@ -33,7 +33,10 @@ export function wrapFetchWithPayment(
   client: X402bClient,
 ): typeof fetch {
   return async function fetchWithPayment(input, init) {
-    const initial = await originalFetch(input, init);
+    const initialRequest = new Request(input, init);
+    const retryBase = initialRequest.clone();
+
+    const initial = await originalFetch(initialRequest);
     if (initial.status !== 402) {
       return initial;
     }
@@ -45,11 +48,11 @@ export function wrapFetchWithPayment(
 
     const headerValue = await client.handle402(escrowEntry);
 
-    const headers = new Headers(init?.headers);
+    const headers = new Headers(retryBase.headers);
     headers.set(X_PAYMENT_HEADER, headerValue);
-    const retryInit: RequestInit = { ...init, headers };
+    const retryRequest = new Request(retryBase, { headers });
 
-    return originalFetch(input, retryInit);
+    return originalFetch(retryRequest);
   };
 }
 

--- a/typescript/packages/client-fetch/src/wrap.ts
+++ b/typescript/packages/client-fetch/src/wrap.ts
@@ -1,0 +1,82 @@
+// `wrapFetchWithPayment` — turns a `fetch` implementation into one that
+// transparently settles `402 Payment Required` responses carrying
+// `scheme: "escrow"`.
+//
+// Behaviour mirrors upstream `x402-fetch`:
+//
+//  1. Run the original request.
+//  2. If the response is not `402` → return as-is.
+//  3. Try to parse the body as JSON and look for an `accepts[]` entry with
+//     `scheme === "escrow"`. If none is present — e.g. the server only
+//     advertises other x402 schemes — the original 402 is returned
+//     unchanged so a non-Boson client further up the stack can still try
+//     them (or surface the structured error).
+//  4. Delegate the matched escrow PaymentRequirements to
+//     `client.handle402(...)` which produces the base64 `X-PAYMENT`
+//     header value.
+//  5. Re-issue the original URL with the new header set; pass through
+//     method, body, and every other init field.
+//  6. Return the retry response. A second `402` is NOT re-retried — the
+//     server has spoken twice, surface the error.
+
+import type { X402bClient } from "@bosonprotocol/x402-client";
+
+const X_PAYMENT_HEADER = "X-PAYMENT";
+
+/**
+ * Wrap a `fetch` implementation so 402 responses carrying the Boson
+ * `escrow` scheme get signed and retried automatically. Non-402 responses
+ * and 402s without an `escrow` accept entry are passed through unchanged.
+ */
+export function wrapFetchWithPayment(
+  originalFetch: typeof fetch,
+  client: X402bClient,
+): typeof fetch {
+  return async function fetchWithPayment(input, init) {
+    const initial = await originalFetch(input, init);
+    if (initial.status !== 402) {
+      return initial;
+    }
+
+    const escrowEntry = await extractEscrowEntry(initial);
+    if (!escrowEntry) {
+      return initial;
+    }
+
+    const headerValue = await client.handle402(escrowEntry);
+
+    const headers = new Headers(init?.headers);
+    headers.set(X_PAYMENT_HEADER, headerValue);
+    const retryInit: RequestInit = { ...init, headers };
+
+    return originalFetch(input, retryInit);
+  };
+}
+
+/**
+ * Best-effort decode of the 402 body. Returns the first `accepts[]` entry
+ * with `scheme === "escrow"`, or `undefined` when the body isn't JSON, has
+ * no `accepts[]`, or carries only other schemes. Reads from a clone so the
+ * caller can still consume the original response if we hand it back.
+ */
+async function extractEscrowEntry(response: Response): Promise<unknown | undefined> {
+  let body: unknown;
+  try {
+    body = await response.clone().json();
+  } catch {
+    return undefined;
+  }
+  if (typeof body !== "object" || body === null) {
+    return undefined;
+  }
+  const accepts = (body as { accepts?: unknown }).accepts;
+  if (!Array.isArray(accepts)) {
+    return undefined;
+  }
+  return accepts.find(
+    (entry) =>
+      typeof entry === "object" &&
+      entry !== null &&
+      (entry as { scheme?: unknown }).scheme === "escrow",
+  );
+}

--- a/typescript/packages/client-fetch/test/wrap.test.ts
+++ b/typescript/packages/client-fetch/test/wrap.test.ts
@@ -82,9 +82,8 @@ describe("wrapFetchWithPayment", () => {
     expect(client.handle402).toHaveBeenCalledTimes(1);
     expect(client.handle402.mock.calls[0][0]).toMatchObject({ scheme: "escrow" });
 
-    const retryInit = fakeFetch.mock.calls[1][1] as RequestInit;
-    const retryHeaders = new Headers(retryInit.headers);
-    expect(retryHeaders.get("X-PAYMENT")).toBe("hdr-base64");
+    const retryRequest = fakeFetch.mock.calls[1][0] as Request;
+    expect(retryRequest.headers.get("X-PAYMENT")).toBe("hdr-base64");
   });
 
   it("preserves the request URL, method, and existing headers/body on the retry", async () => {
@@ -101,13 +100,44 @@ describe("wrapFetchWithPayment", () => {
       body: '{"foo":1}',
     });
 
-    expect(fakeFetch.mock.calls[1][0]).toBe("https://example/resource");
-    const retryInit = fakeFetch.mock.calls[1][1] as RequestInit;
-    expect(retryInit.method).toBe("POST");
-    expect(retryInit.body).toBe('{"foo":1}');
-    const retryHeaders = new Headers(retryInit.headers);
-    expect(retryHeaders.get("x-trace-id")).toBe("abc");
-    expect(retryHeaders.get("X-PAYMENT")).toBe("hdr");
+    const retryRequest = fakeFetch.mock.calls[1][0] as Request;
+    expect(retryRequest.url).toBe("https://example/resource");
+    expect(retryRequest.method).toBe("POST");
+    expect(await retryRequest.text()).toBe('{"foo":1}');
+    expect(retryRequest.headers.get("x-trace-id")).toBe("abc");
+    expect(retryRequest.headers.get("X-PAYMENT")).toBe("hdr");
+  });
+
+  it("can retry a Request input after the initial fetch consumes its body", async () => {
+    const client = makeClient("hdr");
+    const bodies: string[] = [];
+    const retryHeaders: string[] = [];
+    const fakeFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const request = input instanceof Request ? input : new Request(input);
+      bodies.push(await request.text());
+      retryHeaders.push(request.headers.get("X-PAYMENT") ?? "");
+
+      if (bodies.length === 1) {
+        return jsonResponse(escrow402Body(), { status: 402 });
+      }
+      return new Response("ok", { status: 200 });
+    });
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client);
+    const request = new Request("https://example/resource", {
+      method: "POST",
+      headers: { "x-trace-id": "abc" },
+      body: "streamed-payload",
+    });
+
+    const res = await wrapped(request);
+
+    expect(res.status).toBe(200);
+    expect(fakeFetch).toHaveBeenCalledTimes(2);
+    expect(bodies).toEqual(["streamed-payload", "streamed-payload"]);
+    expect(retryHeaders).toEqual(["", "hdr"]);
+    const retryRequest = fakeFetch.mock.calls[1][0] as Request;
+    expect(retryRequest.headers.get("x-trace-id")).toBe("abc");
   });
 
   it("passes a 402 through unchanged when no accepts[] entry has scheme='escrow'", async () => {

--- a/typescript/packages/client-fetch/test/wrap.test.ts
+++ b/typescript/packages/client-fetch/test/wrap.test.ts
@@ -1,0 +1,155 @@
+// Unit tests for `wrapFetchWithPayment`.
+//
+// Drives the wrapper with a stubbed `fetch` (vitest `Mock`) and a stubbed
+// `X402bClient` so the assertions focus on the wrapper's behaviour:
+// pass-through on success, retry-with-X-PAYMENT on a 402 carrying
+// `scheme: "escrow"`, pass-through on a 402 with no escrow entry, and
+// no infinite-retry on a second 402.
+
+import { describe, expect, it, vi, type Mock } from "vitest";
+import type { X402bClient } from "@bosonprotocol/x402-client";
+
+import { wrapFetchWithPayment } from "../src/wrap.js";
+
+function makeClient(headerValue = "base64-encoded-payment"): X402bClient & {
+  handle402: Mock;
+  parsePaymentResponse: Mock;
+  signAction: Mock;
+} {
+  return {
+    handle402: vi.fn().mockResolvedValue(headerValue),
+    parsePaymentResponse: vi.fn().mockReturnValue(undefined),
+    signAction: vi.fn(),
+  };
+}
+
+function escrow402Body() {
+  return {
+    x402Version: 2,
+    accepts: [
+      {
+        scheme: "escrow",
+        network: "eip155:8453",
+        asset: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        amount: "1000000",
+        escrowAddress: "0xdddddddddddddddddddddddddddddddddddddddd",
+        recipientId: "did:boson:seller:1",
+        maxTimeoutSeconds: 300,
+        offer: {
+          fullOffer: {},
+          sellerSig: "0xdead",
+          creator: "0x1111111111111111111111111111111111111111",
+        },
+        tokenAuthStrategies: ["erc3009"],
+        actions: { next: [{ id: "boson-createOfferAndCommit", channels: ["server"] }] },
+      },
+    ],
+  };
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+describe("wrapFetchWithPayment", () => {
+  it("passes a 200 through without consulting the client", async () => {
+    const fakeFetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+    const client = makeClient();
+    const wrapped = wrapFetchWithPayment(fakeFetch, client);
+
+    const res = await wrapped("https://example/resource");
+
+    expect(res.status).toBe(200);
+    expect(fakeFetch).toHaveBeenCalledTimes(1);
+    expect(client.handle402).not.toHaveBeenCalled();
+  });
+
+  it("on 402 with escrow accept entry: signs via handle402 and retries with X-PAYMENT", async () => {
+    const client = makeClient("hdr-base64");
+    const fakeFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(escrow402Body(), { status: 402 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client);
+    const res = await wrapped("https://example/resource");
+
+    expect(res.status).toBe(200);
+    expect(fakeFetch).toHaveBeenCalledTimes(2);
+    expect(client.handle402).toHaveBeenCalledTimes(1);
+    expect(client.handle402.mock.calls[0][0]).toMatchObject({ scheme: "escrow" });
+
+    const retryInit = fakeFetch.mock.calls[1][1] as RequestInit;
+    const retryHeaders = new Headers(retryInit.headers);
+    expect(retryHeaders.get("X-PAYMENT")).toBe("hdr-base64");
+  });
+
+  it("preserves the request URL, method, and existing headers/body on the retry", async () => {
+    const client = makeClient("hdr");
+    const fakeFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(escrow402Body(), { status: 402 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client);
+    await wrapped("https://example/resource", {
+      method: "POST",
+      headers: { "x-trace-id": "abc" },
+      body: '{"foo":1}',
+    });
+
+    expect(fakeFetch.mock.calls[1][0]).toBe("https://example/resource");
+    const retryInit = fakeFetch.mock.calls[1][1] as RequestInit;
+    expect(retryInit.method).toBe("POST");
+    expect(retryInit.body).toBe('{"foo":1}');
+    const retryHeaders = new Headers(retryInit.headers);
+    expect(retryHeaders.get("x-trace-id")).toBe("abc");
+    expect(retryHeaders.get("X-PAYMENT")).toBe("hdr");
+  });
+
+  it("passes a 402 through unchanged when no accepts[] entry has scheme='escrow'", async () => {
+    const body = { x402Version: 2, accepts: [{ scheme: "exact", network: "eip155:8453" }] };
+    const client = makeClient();
+    const fakeFetch = vi.fn().mockResolvedValue(jsonResponse(body, { status: 402 }));
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client);
+    const res = await wrapped("https://example/resource");
+
+    expect(res.status).toBe(402);
+    expect(fakeFetch).toHaveBeenCalledTimes(1);
+    expect(client.handle402).not.toHaveBeenCalled();
+  });
+
+  it("passes a 402 through unchanged when the body is not JSON", async () => {
+    const client = makeClient();
+    const fakeFetch = vi.fn().mockResolvedValue(
+      new Response("not json", {
+        status: 402,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client);
+    const res = await wrapped("https://example/resource");
+
+    expect(res.status).toBe(402);
+    expect(fakeFetch).toHaveBeenCalledTimes(1);
+    expect(client.handle402).not.toHaveBeenCalled();
+  });
+
+  it("does not re-retry on a second 402 (no infinite loop)", async () => {
+    const client = makeClient();
+    const fakeFetch = vi.fn().mockResolvedValue(jsonResponse(escrow402Body(), { status: 402 }));
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client);
+    const res = await wrapped("https://example/resource");
+
+    expect(res.status).toBe(402);
+    // initial + 1 retry = 2, never more
+    expect(fakeFetch).toHaveBeenCalledTimes(2);
+    expect(client.handle402).toHaveBeenCalledTimes(1);
+  });
+});

--- a/typescript/packages/client-fetch/tsconfig.json
+++ b/typescript/packages/client-fetch/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/typescript/packages/client-fetch/tsup.config.ts
+++ b/typescript/packages/client-fetch/tsup.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "tsup";
+
+// Dual CJS + ESM build with type declarations. `entry` globs every
+// `index.ts` under `src/`; this package currently has just `src/index.ts`,
+// but the glob keeps additions purely additive. The `scripts/postbuild.mjs`
+// step writes `dist/{esm,cjs}/package.json` module-type markers chained
+// from `package.json`'s `build` script.
+const entry = ["src/**/index.ts"];
+
+export default defineConfig([
+  {
+    entry,
+    format: "esm",
+    outDir: "dist/esm",
+    outExtension: () => ({ js: ".js" }),
+    dts: false,
+    sourcemap: true,
+    clean: true,
+    target: "es2020",
+    treeshake: true,
+  },
+  {
+    entry,
+    format: "cjs",
+    outDir: "dist/cjs",
+    outExtension: () => ({ js: ".js" }),
+    dts: true,
+    sourcemap: true,
+    clean: false,
+    target: "es2020",
+    treeshake: true,
+  },
+]);

--- a/typescript/packages/client-fetch/vitest.config.ts
+++ b/typescript/packages/client-fetch/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `@bosonprotocol/x402-client-fetch` workspace package — native-`fetch` adapter for the buyer-side SDK.
- `wrapFetchWithPayment(originalFetch, client)` intercepts `402` responses carrying `scheme: "escrow"`, calls `client.handle402(entry)` for the `X-PAYMENT` header, then re-issues the same URL once (no infinite retry loop). Non-escrow 402s and non-JSON bodies pass through unchanged so other x402 schemes coexist cleanly.
- Re-exports the full `@bosonprotocol/x402-client` public API, so a consumer installing just this package gets `createX402bClient`, the signer adapters, and error classes in one import path.
- Conventions match the sibling packages (dual CJS+ESM tsup build with the same postbuild guard merged via #30).

## Test plan
- [x] `pnpm build` — 5 packages built
- [x] `pnpm test` — 6 wrap tests cover: 200 pass-through · 402-escrow retry-with-X-PAYMENT (correct entry + base64) · retry preserves URL/method/headers/body · 402 without escrow accept entry · 402 with non-JSON body · no infinite retry on second 402
- [x] `pnpm lint` — `eslint --max-warnings 0` clean
- [x] `pnpm format:check` — prettier clean

> Based on \`implement-client-handle402\` (#29); opened as draft. GitHub auto-updates the base as #29 → #28 → main merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new package that provides a fetch wrapper to transparently handle 402 Payment Required responses by retrying with an X-PAYMENT header when applicable.

* **Documentation**
  * Added README describing usage, examples, and license information.
  * Included Apache-2.0 license text.

* **Tests**
  * Added comprehensive tests for wrapper behavior, retry logic, and edge cases.

* **Chores**
  * Package metadata and build/test configs added for distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/31)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->