### PR TITLE
feat(facilitator): scaffold @bosonprotocol/x402-facilitator package

### DIFF
--- a/.changeset/scaffold-x402-facilitator-package.md
+++ b/.changeset/scaffold-x402-facilitator-package.md
@@ -1,0 +1,14 @@
+---
+"@bosonprotocol/x402-facilitator": minor
+---
+
+Initial skeleton for `@bosonprotocol/x402-facilitator`: ships I/O types
+(`FacilitatorVerifyInput/Result`, `FacilitatorSettleInput/Result`,
+`FacilitatorPerformActionInput/Result`), `FacilitatorConfig`, the
+`FacilitatorErrorCode` union, the typed `FacilitatorError` /
+`NotImplementedError` classes with a `toResult()` normalizer, and the
+`FacilitatorChannelAdapter` implementation of
+`@bosonprotocol/x402-actions`'s `ChannelAdapter` for the `facilitator`
+channel. The three library functions (`verify`, `settle`,
+`performAction`) are stubs that throw `NotImplementedError` until the
+real implementations land in follow-up PRs.

--- a/docs/boson-impl-04-state-machine-and-next-actions.md
+++ b/docs/boson-impl-04-state-machine-and-next-actions.md
@@ -153,7 +153,7 @@ A **channel** is a transport for invoking an action. The standard registry:
 | Channel | What it means | Invocation shape |
 |---|---|---|
 | `server` | The seller's HTTP server exposes a convenience endpoint that wraps the on-chain call (and may notify the seller for context). | `POST <endpoints.server>` with action-specific body. |
-| `facilitator` | A third-party facilitator that submits on-chain on the buyer's behalf (gas-paying meta-tx). | `POST <facilitator>/x402B/<action>` per the facilitator's API (see [boson-impl-07-facilitator.md](./boson-impl-07-facilitator.md)). |
+| `facilitator` | A third-party facilitator that submits on-chain on the buyer's behalf (gas-paying meta-tx). | Commit-time actions use `POST <facilitator>/settle`; post-commit actions use `POST <facilitator>/perform-action?action=<action>` per the facilitator's API (see [boson-impl-07-facilitator.md](./boson-impl-07-facilitator.md)). |
 | `onchain` | Direct on-chain submission. The buyer signs and submits the raw tx themselves. | `<facet>.<method>(...)` per `onchainHints`. |
 | `mcp` | The buyer's agent dispatches against the **escrow's** MCP server (the Boson Protocol MCP, currently [`bosonprotocol/agentic-commerce`](https://github.com/bosonprotocol/agentic-commerce)) — one shared server across every Boson seller, not a per-seller endpoint. The seller-specific routing lives in `fallback.mcp` as a Boson-namespaced identifier the BosonMCP resolves. | MCP tool invocation against BosonMCP; identifier from `fallback.mcp`. |
 | `xmtp` | Out-of-band: the buyer messages the seller's XMTP inbox; the seller can act on behalf of the buyer for some actions, or simply acknowledge. | XMTP message to `fallback.xmtp` with structured payload. |

--- a/docs/boson-impl-05-server-sdk.md
+++ b/docs/boson-impl-05-server-sdk.md
@@ -41,7 +41,7 @@ app.get("/datafeed", expressMiddleware(requireEscrow));
 
 ## Endpoints exposed (optional convenience)
 
-- `POST /x402B/commit` — accepts `X-PAYMENT` with `action=boson-createOfferAndCommit`, relays the meta-tx + token-auth to the facilitator (or directly to `MetaTransactionsHandlerFacet.executeMetaTransactionWithTokenTransferAuthorization`), returns 200.
+- `POST /x402B/commit` — accepts `X-PAYMENT` with `action=boson-createOfferAndCommit`, relays the meta-tx + optional token-auth to the facilitator (or directly to the matching `MetaTransactionsHandlerFacet` meta-tx entrypoint), returns 200.
 - `POST /x402B/commit-and-redeem` — same, with `action=boson-createOfferCommitAndRedeem` (atomic on-chain redeem; the actual delivery may be sync or async per `fulfillment.option`).
 - `POST /x402B/redeem` — server-side wrapper for `redeemVoucher`.
 - `POST /x402B/complete` — wrapper for `completeExchange`.

--- a/docs/boson-impl-07-facilitator.md
+++ b/docs/boson-impl-07-facilitator.md
@@ -4,9 +4,9 @@
 
 ## Goals
 
-`@bosonprotocol/x402-facilitator` is the reference verify + settle service for the `escrow` scheme. It:
+`@bosonprotocol/x402-facilitator` is the reference verify + settle + perform-action surface for the `escrow` scheme. It:
 
-1. Exposes `/verify` and `/settle` endpoints compatible with x402's facilitator API.
+1. Exposes `/verify` and `/settle` endpoints compatible with x402's facilitator API, plus `/perform-action` for the `"facilitator"` `nextActions` channel.
 2. Routes `escrow`-scheme payloads to the appropriate Boson on-chain entrypoint.
 3. Submits transactions and pays gas.
 
@@ -23,25 +23,53 @@ POST /settle
   body: { scheme: "escrow", network, payload, requirements }
   -> { ok: true, exchangeId, txHash } | { ok: false, code, reason }
 
-POST /perform-action     // optional, for the "facilitator" channel in nextActions
+POST /perform-action?action=<ActionId>     // optional, for the "facilitator" channel in nextActions
   body: { exchangeId, action, signedPayload }
-  -> { ok: true, txHash } | { ok: false, code, reason }
+  -> { ok: true, txHash, newExchangeState, newDisputeState? } | { ok: false, code, reason }
 ```
+
+`FacilitatorChannelAdapter` stamps `endpoints.facilitator` with:
+
+- `${url}/settle` for commit-time actions (`boson-createOfferAndCommit`, `boson-createOfferCommitAndRedeem`).
+- `${url}/perform-action?action=${action}` for post-commit actions.
 
 ## Settle path
 
-Every `escrow` settle is the same single on-chain call:
+The v0.1 package is a TypeScript surface scaffold: `verify`, `settle`, and
+`performAction` throw `NotImplementedError` until the relayer
+implementation lands. The intended submit path is selected by the buyer's
+`tokenAuthStrategy`.
+
+For `tokenAuthStrategy = "none"`, the facilitator wraps the signed
+meta-transaction with the existing Boson entrypoint:
+
+```
+MetaTransactionsHandlerFacet.executeMetaTransaction(
+  userAddress,
+  functionName,
+  functionSignature,
+  nonce,
+  packedSig
+)
+```
+
+For `tokenAuthStrategy = "erc3009" | "permit" | "permit2"`, the planned
+BPIP-12 path is:
 
 ```
 MetaTransactionsHandlerFacet.executeMetaTransactionWithTokenTransferAuthorization(
   metaTxParams,                  // built from payload.metaTx
   tokenTransferAuthorizations,   // bytes[] queue, one entry encoding payload.tokenAuth
-                                 // (empty array when tokenAuthStrategy = "none")
   r, s, v                        // payload.metaTx.sig
 )
 ```
 
-The inner `metaTxParams.functionName` selects which protocol facet runs:
+That BPIP-12 builder is currently represented by a throwing
+`buildExecuteMetaTransactionWithTokenAuthTx` stub in `@bosonprotocol/x402-evm`.
+Facilitator implementation should map that unsupported path to
+`UNSUPPORTED_TOKEN_AUTH_STRATEGY` until the ABI support ships.
+
+The inner `payload.metaTx.functionName` selects which protocol facet runs:
 
 | `payload.action` | Inner function called by the meta-tx |
 |---|---|

--- a/docs/boson-impl-07-facilitator.md
+++ b/docs/boson-impl-07-facilitator.md
@@ -43,7 +43,7 @@ implementation lands. The intended submit path is selected by the buyer's
 For `tokenAuthStrategy = "none"`, the facilitator wraps the signed
 meta-transaction with the existing Boson entrypoint:
 
-```
+```solidity
 MetaTransactionsHandlerFacet.executeMetaTransaction(
   userAddress,
   functionName,
@@ -56,7 +56,7 @@ MetaTransactionsHandlerFacet.executeMetaTransaction(
 For `tokenAuthStrategy = "erc3009" | "permit" | "permit2"`, the planned
 BPIP-12 path is:
 
-```
+```solidity
 MetaTransactionsHandlerFacet.executeMetaTransactionWithTokenTransferAuthorization(
   metaTxParams,                  // built from payload.metaTx
   tokenTransferAuthorizations,   // bytes[] queue, one entry encoding payload.tokenAuth

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,31 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
 
+  typescript/packages/facilitator:
+    dependencies:
+      '@bosonprotocol/x402-actions':
+        specifier: workspace:^
+        version: link:../actions
+      '@bosonprotocol/x402-core':
+        specifier: workspace:^
+        version: link:../core
+      viem:
+        specifier: ^2.39.3
+        version: 2.48.11(typescript@5.9.3)(zod@3.25.76)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.10
+        version: 20.19.40
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.40)
+
   typescript/packages/fulfillment:
     dependencies:
       '@bosonprotocol/x402-core':

--- a/typescript/packages/facilitator/LICENSE
+++ b/typescript/packages/facilitator/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Boson Protocol
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/typescript/packages/facilitator/README.md
+++ b/typescript/packages/facilitator/README.md
@@ -23,7 +23,7 @@ three library functions (`verify`, `settle`, `performAction`) throw
 Library-shaped facilitator. Three async functions mirror the wire-level
 endpoints described in `docs/boson-impl-07-facilitator.md`:
 
-```
+```text
 verify(input, config)         -> { ok }              | { ok: false, code, reason }
 settle(input, config)         -> { ok, exchangeId, txHash } | { ok: false, code, reason }
 performAction(input, config)  -> { ok, txHash, newExchangeState, newDisputeState? }

--- a/typescript/packages/facilitator/README.md
+++ b/typescript/packages/facilitator/README.md
@@ -1,0 +1,90 @@
+# @bosonprotocol/x402-facilitator
+
+Reference facilitator (verify / settle / perform-action relayer) for the
+Boson Protocol [`escrow`](https://github.com/bosonprotocol/x402-escrow-schema)
+scheme — the off-server gas-paying meta-transaction relayer in the
+[x402B](https://github.com/bosonprotocol/x402B) implementation.
+
+See [`docs/boson-impl-07-facilitator.md`](../../../docs/boson-impl-07-facilitator.md)
+for the spec and [`docs/boson-impl-01-escrow-scheme.md`](../../../docs/boson-impl-01-escrow-scheme.md)
+for the wire format.
+
+## Status
+
+**Skeleton.** This package currently ships only the public TypeScript
+surface — input/result types, `FacilitatorConfig`, the
+`FacilitatorErrorCode` union, and the `FacilitatorChannelAdapter` that
+plugs into `@bosonprotocol/x402-actions`'s `ChannelAdapter` contract. The
+three library functions (`verify`, `settle`, `performAction`) throw
+`NotImplementedError`; real implementations land in follow-up PRs.
+
+## What it does
+
+Library-shaped facilitator. Three async functions mirror the wire-level
+endpoints described in `docs/boson-impl-07-facilitator.md`:
+
+```
+verify(input, config)         -> { ok }              | { ok: false, code, reason }
+settle(input, config)         -> { ok, exchangeId, txHash } | { ok: false, code, reason }
+performAction(input, config)  -> { ok, txHash, newExchangeState, newDisputeState? }
+                              |  { ok: false, code, reason }
+```
+
+The buyer signs the inner action calldata + outer meta-tx envelope on
+the client side (typically via `@bosonprotocol/core-sdk`'s
+`signMetaTxXxx` helpers — see `@bosonprotocol/x402-evm`'s README for the
+client-side pattern). The facilitator never re-builds calldata — it
+accepts `payload.metaTx.functionName` and `payload.metaTx.functionSignature`
+straight from the request and passes them through to
+`@bosonprotocol/x402-evm/envelope`'s `buildExecuteMetaTransactionTx`.
+
+The facilitator's responsibilities are:
+
+1. **Validate** — structural shape, scheme/network/action match, signature
+   recovery, on-chain simulation pre-flight.
+2. **Submit** — wrap the buyer's signed meta-tx in
+   `MetaTransactionsHandlerFacet.executeMetaTransaction(...)`, send via
+   the configured viem `WalletClient`, await the receipt.
+3. **Relay post-commit transitions** — same envelope, same submit path,
+   for `redeem` / `complete` / `cancel` / `revoke` / `raise` / `retract` /
+   `escalate` / `resolve` dispute.
+
+## Install
+
+```sh
+pnpm add @bosonprotocol/x402-facilitator @bosonprotocol/x402-core @bosonprotocol/x402-actions
+```
+
+## API
+
+```ts
+import {
+  verify,
+  settle,
+  performAction,
+  FacilitatorChannelAdapter,
+  type FacilitatorConfig,
+} from "@bosonprotocol/x402-facilitator";
+
+// v0.1: these throw NotImplementedError. Wire-format hints below are
+// stable; the implementation lands in follow-up PRs.
+```
+
+## The `facilitator` channel
+
+`FacilitatorChannelAdapter` implements `@bosonprotocol/x402-actions`'s
+`ChannelAdapter` for the `"facilitator"` channel. Plug it into a server
+SDK's `ChannelRegistry` to stamp `endpoints.facilitator` into every
+`nextActions[]` entry the facilitator can carry.
+
+```ts
+import { FacilitatorChannelAdapter } from "@bosonprotocol/x402-facilitator/channels/facilitator";
+
+const adapter = new FacilitatorChannelAdapter();
+adapter.describe("boson-redeem", { url: "https://facilitator.example" });
+// -> { endpoint: "https://facilitator.example/perform-action?action=boson-redeem" }
+```
+
+## License
+
+Apache-2.0.

--- a/typescript/packages/facilitator/package.json
+++ b/typescript/packages/facilitator/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@bosonprotocol/x402-facilitator",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "description": "Boson Protocol facilitator (verify/settle/perform-action relayer) for the x402 escrow scheme — submits buyer meta-tx via MetaTransactionsHandlerFacet on the Boson Diamond.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bosonprotocol/x402B.git",
+    "directory": "typescript/packages/facilitator"
+  },
+  "homepage": "https://github.com/bosonprotocol/x402B/tree/main/typescript/packages/facilitator",
+  "bugs": {
+    "url": "https://github.com/bosonprotocol/x402B/issues"
+  },
+  "keywords": [
+    "x402",
+    "boson-protocol",
+    "facilitator",
+    "meta-transaction",
+    "relayer",
+    "escrow"
+  ],
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/cjs/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./verify": {
+      "types": "./dist/cjs/verify/index.d.ts",
+      "import": "./dist/esm/verify/index.js",
+      "require": "./dist/cjs/verify/index.js"
+    },
+    "./settle": {
+      "types": "./dist/cjs/settle/index.d.ts",
+      "import": "./dist/esm/settle/index.js",
+      "require": "./dist/cjs/settle/index.js"
+    },
+    "./perform-action": {
+      "types": "./dist/cjs/perform-action/index.d.ts",
+      "import": "./dist/esm/perform-action/index.js",
+      "require": "./dist/cjs/perform-action/index.js"
+    },
+    "./channels/facilitator": {
+      "types": "./dist/cjs/channels/facilitator/index.d.ts",
+      "import": "./dist/esm/channels/facilitator/index.js",
+      "require": "./dist/cjs/channels/facilitator/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup && node scripts/postbuild.mjs",
+    "test": "vitest run --passWithNoTests",
+    "lint": "eslint src --max-warnings 0",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@bosonprotocol/x402-core": "workspace:^",
+    "@bosonprotocol/x402-actions": "workspace:^",
+    "viem": "^2.39.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.10",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/typescript/packages/facilitator/scripts/postbuild.mjs
+++ b/typescript/packages/facilitator/scripts/postbuild.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// Post-build housekeeping after `tsup`:
+//
+// Write `dist/esm/package.json` ({"type":"module"}) and
+// `dist/cjs/package.json` ({"type":"commonjs"}) so Node treats each
+// subtree under the correct module dialect without a
+// MODULE_TYPELESS_PACKAGE_JSON warning at consume time.
+//
+// This package ships no JSON schemas, so unlike core/fulfillment there is
+// no `dist/schemas/` step.
+
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const distRoot = join(here, "..", "dist");
+
+await writeFile(
+  join(distRoot, "esm", "package.json"),
+  JSON.stringify({ type: "module" }, null, 2) + "\n",
+);
+await writeFile(
+  join(distRoot, "cjs", "package.json"),
+  JSON.stringify({ type: "commonjs" }, null, 2) + "\n",
+);
+
+console.log("postbuild: wrote module-type markers in dist/{esm,cjs}/package.json");

--- a/typescript/packages/facilitator/src/channels/facilitator/index.ts
+++ b/typescript/packages/facilitator/src/channels/facilitator/index.ts
@@ -1,0 +1,42 @@
+// `FacilitatorChannelAdapter` — implements `@bosonprotocol/x402-actions`'s
+// `ChannelAdapter` contract for the `"facilitator"` channel.
+//
+// One `nextAction` entry can be invoked through multiple channels. This
+// adapter populates `endpoints.facilitator` with the URL the client
+// should POST to:
+//
+//   - commit-time actions (`boson-createOfferAndCommit`,
+//     `boson-createOfferCommitAndRedeem`) → `${url}/settle`.
+//   - post-commit actions (`boson-redeem`, `boson-completeExchange`,
+//     `boson-cancelVoucher`, `boson-revokeVoucher`,
+//     `boson-raiseDispute`, `boson-retractDispute`,
+//     `boson-escalateDispute`, `boson-resolveDispute`)
+//     → `${url}/perform-action?action=${action}`.
+//
+// Source of truth for the channel id and the adapter shape:
+// `@bosonprotocol/x402-actions/channels`.
+
+import type { ChannelAdapter } from "@bosonprotocol/x402-actions/channels";
+import type { ActionId } from "@bosonprotocol/x402-core/state-machine";
+
+/** Per-server configuration for the facilitator channel adapter. */
+export interface FacilitatorChannelConfig {
+  /** Public URL the facilitator service is reachable at, without a trailing slash. */
+  url: string;
+}
+
+const COMMIT_ACTIONS: ReadonlySet<ActionId> = new Set([
+  "boson-createOfferAndCommit",
+  "boson-createOfferCommitAndRedeem",
+]);
+
+export class FacilitatorChannelAdapter implements ChannelAdapter<FacilitatorChannelConfig> {
+  readonly channel = "facilitator" as const;
+
+  describe(action: ActionId, cfg: FacilitatorChannelConfig): { endpoint: string } | undefined {
+    if (COMMIT_ACTIONS.has(action)) {
+      return { endpoint: `${cfg.url}/settle` };
+    }
+    return { endpoint: `${cfg.url}/perform-action?action=${action}` };
+  }
+}

--- a/typescript/packages/facilitator/src/errors.ts
+++ b/typescript/packages/facilitator/src/errors.ts
@@ -1,0 +1,49 @@
+// Typed errors thrown by `@bosonprotocol/x402-facilitator`.
+
+import type { FacilitatorErrorCode } from "./types.js";
+
+/**
+ * Base class for facilitator errors. Carries a stable `code` and a
+ * human-readable `reason`. Consumers should branch on `code` (or on
+ * `instanceof FacilitatorError` first) rather than parsing `message`.
+ */
+export class FacilitatorError extends Error {
+  readonly code: FacilitatorErrorCode;
+  readonly reason: string;
+
+  constructor(code: FacilitatorErrorCode, reason: string) {
+    super(`${code}: ${reason}`);
+    this.name = "FacilitatorError";
+    this.code = code;
+    this.reason = reason;
+  }
+}
+
+/**
+ * Thrown by every v0.1 stub function. Tests assert on this class so a
+ * future swap to a real implementation is detected by failing assertions.
+ */
+export class NotImplementedError extends FacilitatorError {
+  constructor(feature: string) {
+    super("NOT_IMPLEMENTED", `${feature} is not implemented yet`);
+    this.name = "NotImplementedError";
+  }
+}
+
+/**
+ * Normalize an unknown thrown value into the `{ ok: false, code, reason }`
+ * branch of a facilitator result. Useful at HTTP handler boundaries.
+ *
+ * - `FacilitatorError` preserves its `code` / `reason`.
+ * - Any other `Error` collapses to `INTERNAL_ERROR` with its `message`.
+ * - Non-Error throws collapse to `INTERNAL_ERROR` with `String(err)`.
+ */
+export function toResult(err: unknown): { ok: false; code: FacilitatorErrorCode; reason: string } {
+  if (err instanceof FacilitatorError) {
+    return { ok: false, code: err.code, reason: err.reason };
+  }
+  if (err instanceof Error) {
+    return { ok: false, code: "INTERNAL_ERROR", reason: err.message };
+  }
+  return { ok: false, code: "INTERNAL_ERROR", reason: String(err) };
+}

--- a/typescript/packages/facilitator/src/errors.ts
+++ b/typescript/packages/facilitator/src/errors.ts
@@ -32,11 +32,24 @@ export class NotImplementedError extends FacilitatorError {
 
 /**
  * Normalize an unknown thrown value into the `{ ok: false, code, reason }`
- * branch of a facilitator result. Useful at HTTP handler boundaries.
+ * branch of a facilitator result.
  *
  * - `FacilitatorError` preserves its `code` / `reason`.
  * - Any other `Error` collapses to `INTERNAL_ERROR` with its `message`.
  * - Non-Error throws collapse to `INTERNAL_ERROR` with `String(err)`.
+ *
+ * ⚠️ **Information disclosure note.** For the `INTERNAL_ERROR` branches
+ * (non-`FacilitatorError` `Error` instances and non-`Error` throws) the
+ * `reason` field carries the underlying error's `message` / `String(err)`
+ * verbatim. That message may contain provider URLs, RPC stack frames,
+ * library internals, or other implementation details that are useful for
+ * debugging but should not be exposed to untrusted HTTP clients.
+ *
+ * If you are wrapping these results in an HTTP response, sanitize the
+ * `reason` field on the `code === "INTERNAL_ERROR"` branch before
+ * returning to the client — e.g. replace with a generic
+ * `"internal server error"` and log the verbose message server-side. The
+ * other (typed) error codes are safe to surface as-is.
  */
 export function toResult(err: unknown): { ok: false; code: FacilitatorErrorCode; reason: string } {
   if (err instanceof FacilitatorError) {

--- a/typescript/packages/facilitator/src/index.ts
+++ b/typescript/packages/facilitator/src/index.ts
@@ -1,0 +1,21 @@
+// Public root surface for `@bosonprotocol/x402-facilitator`.
+//
+// Three async library functions mirror the three HTTP endpoints from
+// docs/boson-impl-07-facilitator.md (`verify`, `settle`, `performAction`),
+// plus a `ChannelAdapter` implementation for the `"facilitator"` channel.
+//
+// Prefer the subpath exports (`./verify`, `./settle`, `./perform-action`,
+// `./channels/facilitator`) when tree-shaking matters — this barrel is a
+// convenience superset.
+
+export * from "./types.js";
+export * from "./errors.js";
+
+export { verify } from "./verify/index.js";
+export { settle } from "./settle/index.js";
+export { performAction } from "./perform-action/index.js";
+
+export {
+  FacilitatorChannelAdapter,
+  type FacilitatorChannelConfig,
+} from "./channels/facilitator/index.js";

--- a/typescript/packages/facilitator/src/perform-action/index.ts
+++ b/typescript/packages/facilitator/src/perform-action/index.ts
@@ -1,0 +1,34 @@
+// `performAction` — relay a post-commit transition (redeem / complete /
+// cancel / revoke / raise / retract / escalate / resolve dispute) on
+// behalf of the signer.
+//
+// In v0.1 (this scaffold) this is a stub that throws NotImplementedError.
+//
+// Future implementation wraps the buyer-or-seller's pre-signed meta-tx
+// envelope (`input.signedPayload`) the same way `settle()` does — same
+// `buildExecuteMetaTransactionTx` call, same submit-and-wait flow. The
+// facilitator is signer-agnostic: it recovers the signer to confirm the
+// signature is well-formed but doesn't care about role (buyer vs seller).
+//
+// The signed `functionName` inside the envelope selects which protocol
+// facet runs; `performAction` only needs `input.action` to derive the
+// post-state for the response (see `ACTION_POST_STATE` in
+// `@bosonprotocol/x402-core/state-machine`).
+//
+// This is the back-end behind the `"facilitator"` channel emitted by
+// `FacilitatorChannelAdapter.describe(action, cfg)` for every post-commit
+// action.
+
+import { NotImplementedError } from "../errors.js";
+import type {
+  FacilitatorConfig,
+  FacilitatorPerformActionInput,
+  FacilitatorPerformActionResult,
+} from "../types.js";
+
+export async function performAction(
+  _input: FacilitatorPerformActionInput,
+  _config: FacilitatorConfig,
+): Promise<FacilitatorPerformActionResult> {
+  throw new NotImplementedError("performAction");
+}

--- a/typescript/packages/facilitator/src/settle/index.ts
+++ b/typescript/packages/facilitator/src/settle/index.ts
@@ -1,0 +1,43 @@
+// `settle` — submit the buyer's signed meta-tx to
+// `MetaTransactionsHandlerFacet.executeMetaTransaction` on the Boson
+// Diamond.
+//
+// In v0.1 (this scaffold) this is a stub that throws NotImplementedError.
+//
+// Future implementation funnels every escrow settle through the single
+// on-chain entrypoint described in docs/boson-impl-07-facilitator.md
+// §"Settle path":
+//
+//   MetaTransactionsHandlerFacet.executeMetaTransaction(
+//     userAddress, functionName, functionSignature, nonce, packedSig
+//   )
+//
+// The inner calldata (`payload.metaTx.functionName` and
+// `payload.metaTx.functionSignature`) is passed straight through from the
+// request — the facilitator does not re-build it; the buyer's CoreSDK
+// signs both inner and outer on the client side.
+//
+// Outer envelope construction goes through
+// `@bosonprotocol/x402-evm/envelope`'s `buildExecuteMetaTransactionTx`.
+//
+// On success returns `{ ok: true, exchangeId, txHash }` with `exchangeId`
+// pulled from the receipt's `BuyerCommitted` event.
+//
+// The BPIP-12 `executeMetaTransactionWithTokenTransferAuthorization`
+// path delegates to `buildExecuteMetaTransactionWithTokenAuthTx`, which
+// currently throws `NotYetSupportedError`. We catch and map to
+// `UNSUPPORTED_TOKEN_AUTH_STRATEGY` once implemented.
+
+import { NotImplementedError } from "../errors.js";
+import type {
+  FacilitatorConfig,
+  FacilitatorSettleInput,
+  FacilitatorSettleResult,
+} from "../types.js";
+
+export async function settle(
+  _input: FacilitatorSettleInput,
+  _config: FacilitatorConfig,
+): Promise<FacilitatorSettleResult> {
+  throw new NotImplementedError("settle");
+}

--- a/typescript/packages/facilitator/src/types.ts
+++ b/typescript/packages/facilitator/src/types.ts
@@ -1,0 +1,106 @@
+// Public I/O types for `@bosonprotocol/x402-facilitator`.
+//
+// Source of truth: docs/boson-impl-07-facilitator.md.
+//
+// The three library functions (verify / settle / performAction) mirror
+// the three HTTP endpoints the spec doc describes. HTTP transport itself
+// is out of scope for this package — server authors wrap these functions
+// with their framework of choice (Fastify, Hono, Web Fetch, …) the same
+// way `@bosonprotocol/x402-actions` and `@bosonprotocol/x402-fulfillment`
+// stay framework-neutral.
+
+import type {
+  EscrowPaymentPayload,
+  EscrowPaymentRequirements,
+  EvmNetwork,
+  Hex,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+import type { ActionId } from "@bosonprotocol/x402-core/state-machine";
+import { DisputeState, ExchangeState } from "@bosonprotocol/x402-core/state-machine";
+import type { PublicClient, WalletClient } from "viem";
+
+export { DisputeState, ExchangeState };
+export type { ActionId };
+
+/**
+ * Stable wire-level error codes. Consumers should branch on these rather
+ * than on the human-readable `reason` string — the latter is informational
+ * and may change between releases.
+ *
+ * v0.1 — subject to growth as the facilitator's responsibilities widen.
+ */
+export type FacilitatorErrorCode =
+  | "NOT_IMPLEMENTED"
+  | "INVALID_PAYLOAD"
+  | "SCHEME_MISMATCH"
+  | "NETWORK_MISMATCH"
+  | "BAD_META_TX_SIGNATURE"
+  | "BAD_TOKEN_AUTH_SIGNATURE"
+  | "UNSUPPORTED_ACTION"
+  | "UNSUPPORTED_TOKEN_AUTH_STRATEGY"
+  | "ACTION_NOT_IN_REQUIREMENTS"
+  | "TOKEN_AUTH_NOT_IN_REQUIREMENTS"
+  | "SIMULATION_REVERT"
+  | "INSUFFICIENT_FUNDS_FOR_GAS"
+  | "ONCHAIN_REVERT"
+  | "EVENT_NOT_FOUND"
+  | "INTERNAL_ERROR";
+
+/** Body of `POST /verify` (per spec §"Endpoints"). */
+export interface FacilitatorVerifyInput {
+  scheme: "escrow";
+  network: EvmNetwork;
+  payload: EscrowPaymentPayload;
+  requirements: EscrowPaymentRequirements;
+}
+
+export type FacilitatorVerifyResult =
+  | { ok: true }
+  | { ok: false; code: FacilitatorErrorCode; reason: string };
+
+/** Body of `POST /settle` (per spec §"Endpoints"). */
+export interface FacilitatorSettleInput {
+  scheme: "escrow";
+  network: EvmNetwork;
+  payload: EscrowPaymentPayload;
+  requirements: EscrowPaymentRequirements;
+}
+
+export type FacilitatorSettleResult =
+  | { ok: true; exchangeId: string; txHash: Hex }
+  | { ok: false; code: FacilitatorErrorCode; reason: string };
+
+/** Body of `POST /perform-action` (per spec §"Endpoints"). */
+export interface FacilitatorPerformActionInput {
+  exchangeId: string;
+  action: ActionId;
+  /** Fully signed meta-tx envelope, as a 0x-prefixed hex blob. */
+  signedPayload: Hex;
+}
+
+export type FacilitatorPerformActionResult =
+  | {
+      ok: true;
+      txHash: Hex;
+      newExchangeState: ExchangeState;
+      newDisputeState?: DisputeState;
+    }
+  | { ok: false; code: FacilitatorErrorCode; reason: string };
+
+/**
+ * Runtime configuration passed to each library function.
+ *
+ * The relayer's signing key lives inside `walletClient` (typically a
+ * viem `LocalAccount` HD wallet or a KMS-backed signer). The facilitator
+ * never touches the key directly — the wallet handles signing.
+ */
+export interface FacilitatorConfig {
+  /** Public URL the facilitator service is reachable at — populates `nextActions[].endpoints.facilitator`. */
+  url: string;
+  /** Networks the operator has provisioned a relayer wallet + RPC for. */
+  supportedNetworks: readonly EvmNetwork[];
+  /** viem WalletClient — pays gas on settle / perform-action. Network must be in `supportedNetworks`. */
+  walletClient: WalletClient;
+  /** viem PublicClient — used to await receipts and read protocol state. */
+  publicClient: PublicClient;
+}

--- a/typescript/packages/facilitator/src/verify/index.ts
+++ b/typescript/packages/facilitator/src/verify/index.ts
@@ -1,0 +1,36 @@
+// `verify` — stateless pre-flight check on an EscrowPaymentPayload +
+// EscrowPaymentRequirements pair.
+//
+// In v0.1 (this scaffold) this is a stub that throws NotImplementedError.
+//
+// Future implementation MUST (per docs/boson-impl-07-facilitator.md):
+//   1. Confirm `scheme === "escrow"` and the payload network matches the
+//      requirements.
+//   2. Validate the payload structurally via `parseEscrowPaymentPayload`.
+//   3. Recover and verify the buyer's metaTx signature against the
+//      Diamond's EIP-712 domain.
+//   4. If `tokenAuthStrategy !== "none"`, recover and verify the
+//      tokenAuth signature against the asset's EIP-712 domain
+//      (ERC-3009 / EIP-2612 / Permit2).
+//   5. Cross-check action ∈ `requirements.actions.next[].id` and
+//      tokenAuthStrategy ∈ `requirements.tokenAuthStrategies`.
+//   6. Simulate `executeMetaTransaction(...)` against the public client
+//      to catch protocol-level reverts (duplicate nonce, expired auth,
+//      insufficient allowance, …) before settle() spends gas.
+//   7. Return `{ ok: true }` on success, or `{ ok: false, code, reason }`
+//      on a known failure. Unknown failures surface as
+//      `{ ok: false, code: "INTERNAL_ERROR" }`.
+
+import { NotImplementedError } from "../errors.js";
+import type {
+  FacilitatorConfig,
+  FacilitatorVerifyInput,
+  FacilitatorVerifyResult,
+} from "../types.js";
+
+export async function verify(
+  _input: FacilitatorVerifyInput,
+  _config: FacilitatorConfig,
+): Promise<FacilitatorVerifyResult> {
+  throw new NotImplementedError("verify");
+}

--- a/typescript/packages/facilitator/test/channels.test.ts
+++ b/typescript/packages/facilitator/test/channels.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { FacilitatorChannelAdapter } from "../src/channels/facilitator/index.js";
+
+const URL = "https://facilitator.example";
+
+describe("FacilitatorChannelAdapter", () => {
+  const adapter = new FacilitatorChannelAdapter();
+
+  it("identifies itself as the facilitator channel", () => {
+    expect(adapter.channel).toBe("facilitator");
+  });
+
+  it("routes commit-time actions to /settle", () => {
+    expect(adapter.describe("boson-createOfferAndCommit", { url: URL })).toEqual({
+      endpoint: `${URL}/settle`,
+    });
+    expect(adapter.describe("boson-createOfferCommitAndRedeem", { url: URL })).toEqual({
+      endpoint: `${URL}/settle`,
+    });
+  });
+
+  it("routes post-commit actions to /perform-action with action query param", () => {
+    expect(adapter.describe("boson-redeem", { url: URL })).toEqual({
+      endpoint: `${URL}/perform-action?action=boson-redeem`,
+    });
+    expect(adapter.describe("boson-completeExchange", { url: URL })).toEqual({
+      endpoint: `${URL}/perform-action?action=boson-completeExchange`,
+    });
+    expect(adapter.describe("boson-cancelVoucher", { url: URL })).toEqual({
+      endpoint: `${URL}/perform-action?action=boson-cancelVoucher`,
+    });
+    expect(adapter.describe("boson-revokeVoucher", { url: URL })).toEqual({
+      endpoint: `${URL}/perform-action?action=boson-revokeVoucher`,
+    });
+    expect(adapter.describe("boson-raiseDispute", { url: URL })).toEqual({
+      endpoint: `${URL}/perform-action?action=boson-raiseDispute`,
+    });
+    expect(adapter.describe("boson-retractDispute", { url: URL })).toEqual({
+      endpoint: `${URL}/perform-action?action=boson-retractDispute`,
+    });
+    expect(adapter.describe("boson-escalateDispute", { url: URL })).toEqual({
+      endpoint: `${URL}/perform-action?action=boson-escalateDispute`,
+    });
+    expect(adapter.describe("boson-resolveDispute", { url: URL })).toEqual({
+      endpoint: `${URL}/perform-action?action=boson-resolveDispute`,
+    });
+  });
+
+  it("uses the configured url verbatim — no trailing-slash normalization", () => {
+    const trailing = "https://facilitator.example/";
+    expect(adapter.describe("boson-redeem", { url: trailing })).toEqual({
+      endpoint: `${trailing}/perform-action?action=boson-redeem`,
+    });
+  });
+});

--- a/typescript/packages/facilitator/test/stubs.test.ts
+++ b/typescript/packages/facilitator/test/stubs.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NotImplementedError,
+  performAction,
+  settle,
+  verify,
+  type FacilitatorConfig,
+  type FacilitatorPerformActionInput,
+  type FacilitatorSettleInput,
+  type FacilitatorVerifyInput,
+} from "../src/index.js";
+
+// The v0.1 stubs never read these inputs — they throw immediately. Cast
+// through unknown so the test doesn't drag the full viem WalletClient /
+// PublicClient surface into a contract that's checked elsewhere.
+const dummyConfig = {} as unknown as FacilitatorConfig;
+const dummyVerifyInput = {} as unknown as FacilitatorVerifyInput;
+const dummySettleInput = {} as unknown as FacilitatorSettleInput;
+const dummyPerformActionInput = {} as unknown as FacilitatorPerformActionInput;
+
+describe("v0.1 stubs throw NotImplementedError", () => {
+  it("verify() rejects with NotImplementedError and code NOT_IMPLEMENTED", async () => {
+    const promise = verify(dummyVerifyInput, dummyConfig);
+    await expect(promise).rejects.toBeInstanceOf(NotImplementedError);
+    await expect(promise).rejects.toMatchObject({ code: "NOT_IMPLEMENTED" });
+  });
+
+  it("settle() rejects with NotImplementedError and code NOT_IMPLEMENTED", async () => {
+    const promise = settle(dummySettleInput, dummyConfig);
+    await expect(promise).rejects.toBeInstanceOf(NotImplementedError);
+    await expect(promise).rejects.toMatchObject({ code: "NOT_IMPLEMENTED" });
+  });
+
+  it("performAction() rejects with NotImplementedError and code NOT_IMPLEMENTED", async () => {
+    const promise = performAction(dummyPerformActionInput, dummyConfig);
+    await expect(promise).rejects.toBeInstanceOf(NotImplementedError);
+    await expect(promise).rejects.toMatchObject({ code: "NOT_IMPLEMENTED" });
+  });
+});

--- a/typescript/packages/facilitator/test/types.test.ts
+++ b/typescript/packages/facilitator/test/types.test.ts
@@ -1,0 +1,78 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import {
+  type ActionId,
+  type FacilitatorErrorCode,
+  type FacilitatorPerformActionInput,
+  type FacilitatorPerformActionResult,
+  type FacilitatorSettleResult,
+  type FacilitatorVerifyResult,
+  DisputeState,
+  ExchangeState,
+} from "../src/index.js";
+
+describe("@bosonprotocol/x402-facilitator public types", () => {
+  it("FacilitatorVerifyResult is a discriminated union on `ok`", () => {
+    type Failure = Extract<FacilitatorVerifyResult, { ok: false }>;
+    expectTypeOf<Failure["code"]>().toEqualTypeOf<FacilitatorErrorCode>();
+    expectTypeOf<Failure["reason"]>().toEqualTypeOf<string>();
+
+    type Success = Extract<FacilitatorVerifyResult, { ok: true }>;
+    // Success branch must not expose `code` / `reason` / `txHash`.
+    expectTypeOf<Success>().toEqualTypeOf<{ ok: true }>();
+  });
+
+  it("FacilitatorSettleResult success carries exchangeId + txHash", () => {
+    type Success = Extract<FacilitatorSettleResult, { ok: true }>;
+    expectTypeOf<Success["exchangeId"]>().toEqualTypeOf<string>();
+    expectTypeOf<Success["txHash"]>().toEqualTypeOf<string>();
+  });
+
+  it("FacilitatorPerformActionInput.action is exactly the ActionId union", () => {
+    expectTypeOf<FacilitatorPerformActionInput["action"]>().toEqualTypeOf<ActionId>();
+  });
+
+  it("FacilitatorPerformActionResult success carries the predicted new state", () => {
+    type Success = Extract<FacilitatorPerformActionResult, { ok: true }>;
+    expectTypeOf<Success["newExchangeState"]>().toEqualTypeOf<ExchangeState>();
+    expectTypeOf<Success["newDisputeState"]>().toEqualTypeOf<DisputeState | undefined>();
+  });
+
+  it("FacilitatorErrorCode includes NOT_IMPLEMENTED for v0.1 stubs", () => {
+    // Assignability — string literal type member check.
+    const code: FacilitatorErrorCode = "NOT_IMPLEMENTED";
+    expectTypeOf(code).toEqualTypeOf<FacilitatorErrorCode>();
+  });
+
+  it("exhaustive switch on FacilitatorErrorCode compiles", () => {
+    // The point of this test is that this function is type-checked: if a
+    // new code is added to the union without updating the switch, the
+    // `assertNever` line below stops compiling. Run-time behaviour is
+    // irrelevant — vitest type tests are compiled, not executed.
+    function _assertExhaustive(code: FacilitatorErrorCode): string {
+      switch (code) {
+        case "NOT_IMPLEMENTED":
+        case "INVALID_PAYLOAD":
+        case "SCHEME_MISMATCH":
+        case "NETWORK_MISMATCH":
+        case "BAD_META_TX_SIGNATURE":
+        case "BAD_TOKEN_AUTH_SIGNATURE":
+        case "UNSUPPORTED_ACTION":
+        case "UNSUPPORTED_TOKEN_AUTH_STRATEGY":
+        case "ACTION_NOT_IN_REQUIREMENTS":
+        case "TOKEN_AUTH_NOT_IN_REQUIREMENTS":
+        case "SIMULATION_REVERT":
+        case "INSUFFICIENT_FUNDS_FOR_GAS":
+        case "ONCHAIN_REVERT":
+        case "EVENT_NOT_FOUND":
+        case "INTERNAL_ERROR":
+          return code;
+        default: {
+          const _exhaustive: never = code;
+          return _exhaustive;
+        }
+      }
+    }
+    expectTypeOf(_assertExhaustive).toBeFunction();
+  });
+});

--- a/typescript/packages/facilitator/tsconfig.json
+++ b/typescript/packages/facilitator/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/typescript/packages/facilitator/tsup.config.ts
+++ b/typescript/packages/facilitator/tsup.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "tsup";
+
+// Dual CJS + ESM build with type declarations.
+//
+// `entry` globs every `index.ts` under `src/`, including the root
+// `src/index.ts`, so any subpath under `src/<subdir>/index.ts` builds as
+// `@bosonprotocol/x402-facilitator/<subdir>` without further config changes.
+const entry = ["src/**/index.ts"];
+
+export default defineConfig([
+  {
+    entry,
+    format: "esm",
+    outDir: "dist/esm",
+    outExtension: () => ({ js: ".js" }),
+    dts: false,
+    sourcemap: true,
+    clean: true,
+    target: "es2020",
+    treeshake: true,
+  },
+  {
+    entry,
+    format: "cjs",
+    outDir: "dist/cjs",
+    outExtension: () => ({ js: ".js" }),
+    dts: true,
+    sourcemap: true,
+    clean: false,
+    target: "es2020",
+    treeshake: true,
+  },
+]);

--- a/typescript/packages/facilitator/vitest.config.ts
+++ b/typescript/packages/facilitator/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

Initial skeleton for `@bosonprotocol/x402-facilitator`, the reference verify / settle / perform-action relayer for the x402 `escrow` scheme.

- Public TypeScript surface: input + result types for `verify` / `settle` / `performAction`, `FacilitatorConfig`, the `FacilitatorErrorCode` union, and the `FacilitatorError` / `NotImplementedError` classes with a `toResult()` normalizer.
- `FacilitatorChannelAdapter` is a real implementation of `@bosonprotocol/x402-actions`'s `ChannelAdapter` contract for the `"facilitator"` channel — commit-time actions route to `${url}/settle`, post-commit to `${url}/perform-action?action=<id>`.
- The three library functions (`verify`, `settle`, `performAction`) ship as `NotImplementedError`-throwing stubs in this PR; real bodies land in follow-up PRs.
- Tooling matches `@bosonprotocol/x402-evm`: dual ESM/CJS via `tsup`, per-subdir `src/**/index.ts` entry glob, `dist/{esm,cjs}/package.json` module-type markers from `postbuild.mjs`, vitest with `--passWithNoTests`, and the root flat ESLint config.
- Docs alignment in `boson-impl-04` / `-05` / `-07` to reflect the new package and reconcile the `perform-action` body shape.

Spec: [`docs/boson-impl-07-facilitator.md`](./docs/boson-impl-07-facilitator.md).

## Test plan

- [ ] `pnpm install` resolves the new workspace package + `viem` runtime dep
- [ ] `pnpm build` succeeds across the workspace
- [ ] `pnpm test` — 13 facilitator tests pass (types, stubs, channel adapter); all other packages remain green
- [ ] `pnpm lint` — zero warnings (`--max-warnings 0`)
- [ ] `pnpm format:check` — clean
- [ ] `node -e "console.log(Object.keys(require('@bosonprotocol/x402-facilitator')))"` lists `verify`, `settle`, `performAction`, `FacilitatorChannelAdapter`, error classes
- [ ] `dist/{esm,cjs}/package.json` contains the correct `type` marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added @bosonprotocol/x402-facilitator package as a reference facilitator for verify/settle/perform-action flows.
  * Added POST /perform-action for post-commit actions and routing that sends commit-time actions to settle and others to perform-action.

* **Documentation**
  * Expanded facilitator and SDK docs with endpoint semantics, request/response shapes, and usage examples.
  * Added package README and LICENSE.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/34)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->