### PR TITLE
feat(facilitator): implement verify() — structural + signature + simulation

### DIFF
--- a/.changeset/implement-facilitator-verify.md
+++ b/.changeset/implement-facilitator-verify.md
@@ -1,0 +1,17 @@
+---
+"@bosonprotocol/x402-facilitator": minor
+---
+
+Implement `verify()`: structural validation against the escrow-scheme
+Zod schemas, scheme / network / action / strategy cross-checks against
+the `PaymentRequirements`, EIP-712 signature recovery for the buyer's
+meta-tx (via `@bosonprotocol/x402-core/eip712`'s
+`metaTransactionTypedData` + viem's `recoverTypedDataAddress`), token-
+auth signature recovery for ERC-3009 / EIP-2612 Permit / Permit2
+variants (via `@bosonprotocol/x402-core/eip712/token-auth`, looking up
+each token's EIP-712 domain via EIP-5267 with a `name()` / `version()`
+fallback), and an on-chain simulation pre-flight via
+`publicClient.call` against the `executeMetaTransaction` envelope built
+by `@bosonprotocol/x402-evm/envelope` — surfaces protocol-level reverts
+(duplicate nonce, expired auth, insufficient allowance, …) as
+`SIMULATION_REVERT` without consuming gas.

--- a/.changeset/implement-facilitator-verify.md
+++ b/.changeset/implement-facilitator-verify.md
@@ -4,14 +4,17 @@
 
 Implement `verify()`: structural validation against the escrow-scheme
 Zod schemas, scheme / network / action / strategy cross-checks against
-the `PaymentRequirements`, EIP-712 signature recovery for the buyer's
+the `PaymentRequirements`, offer/calldata consistency checks against the
+advertised `FullOffer`, EIP-712 signature recovery for the buyer's
 meta-tx (via `@bosonprotocol/x402-core/eip712`'s
 `metaTransactionTypedData` + viem's `recoverTypedDataAddress`), token-
 auth signature recovery for ERC-3009 / EIP-2612 Permit / Permit2
-variants (via `@bosonprotocol/x402-core/eip712/token-auth`, looking up
-each token's EIP-712 domain via EIP-5267 with a `name()` / `version()`
-fallback), and an on-chain simulation pre-flight via
-`publicClient.call` against the `executeMetaTransaction` envelope built
-by `@bosonprotocol/x402-evm/envelope` — surfaces protocol-level reverts
-(duplicate nonce, expired auth, insufficient allowance, …) as
-`SIMULATION_REVERT` without consuming gas.
+variants plus amount/deadline constraints (via
+`@bosonprotocol/x402-core/eip712/token-auth`, looking up each token's
+EIP-712 domain via EIP-5267 with a `name()` / `version()` fallback), and
+an on-chain simulation pre-flight via `publicClient.call` against the
+`executeMetaTransaction` envelope built by `@bosonprotocol/x402-evm/envelope`.
+The BPIP-12 token-auth envelope still maps to
+`UNSUPPORTED_TOKEN_AUTH_STRATEGY` while the EVM builder is deferred.
+Protocol-level reverts surface as `SIMULATION_REVERT` without consuming
+gas.

--- a/docs/boson-impl-07-facilitator.md
+++ b/docs/boson-impl-07-facilitator.md
@@ -1,6 +1,6 @@
 # 07 — Facilitator
 
-> **Status:** stub (v0.1, 2026-05-04). API surface only; details to be filled during implementation.
+> **Status:** partial implementation (v0.1, 2026-05-04). `verify()` is implemented; `settle()` and `performAction()` remain relayer stubs.
 
 ## Goals
 
@@ -35,10 +35,11 @@ POST /perform-action?action=<ActionId>     // optional, for the "facilitator" ch
 
 ## Settle path
 
-The v0.1 package is a TypeScript surface scaffold: `verify`, `settle`, and
-`performAction` throw `NotImplementedError` until the relayer
-implementation lands. The intended submit path is selected by the buyer's
-`tokenAuthStrategy`.
+In v0.1, `verify()` performs structural validation, offer/calldata
+consistency checks, signature recovery, token-auth constraints, and
+simulation pre-flight. `settle()` and `performAction()` throw
+`NotImplementedError` until the relayer implementation lands. The intended
+submit path is selected by the buyer's `tokenAuthStrategy`.
 
 For `tokenAuthStrategy = "none"`, the facilitator wraps the signed
 meta-transaction with the existing Boson entrypoint:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       '@bosonprotocol/x402-core':
         specifier: workspace:^
         version: link:../core
+      '@bosonprotocol/x402-evm':
+        specifier: workspace:^
+        version: link:../evm
       viem:
         specifier: ^2.39.3
         version: 2.48.11(typescript@5.9.3)(zod@3.25.76)

--- a/typescript/packages/facilitator/README.md
+++ b/typescript/packages/facilitator/README.md
@@ -11,12 +11,10 @@ for the wire format.
 
 ## Status
 
-**Skeleton.** This package currently ships only the public TypeScript
-surface — input/result types, `FacilitatorConfig`, the
-`FacilitatorErrorCode` union, and the `FacilitatorChannelAdapter` that
-plugs into `@bosonprotocol/x402-actions`'s `ChannelAdapter` contract. The
-three library functions (`verify`, `settle`, `performAction`) throw
-`NotImplementedError`; real implementations land in follow-up PRs.
+**Partial implementation.** This package ships the public TypeScript
+surface, `FacilitatorChannelAdapter`, and an implemented `verify()`
+pre-flight path. `settle()` and `performAction()` still throw
+`NotImplementedError`; relayer submission lands in follow-up PRs.
 
 ## What it does
 
@@ -33,15 +31,16 @@ performAction(input, config)  -> { ok, txHash, newExchangeState, newDisputeState
 The buyer signs the inner action calldata + outer meta-tx envelope on
 the client side (typically via `@bosonprotocol/core-sdk`'s
 `signMetaTxXxx` helpers — see `@bosonprotocol/x402-evm`'s README for the
-client-side pattern). The facilitator never re-builds calldata — it
-accepts `payload.metaTx.functionName` and `payload.metaTx.functionSignature`
-straight from the request and passes them through to
-`@bosonprotocol/x402-evm/envelope`'s `buildExecuteMetaTransactionTx`.
+client-side pattern). `verify()` re-builds the expected commit-time
+calldata only to confirm `payload.metaTx.functionName` and
+`payload.metaTx.functionSignature` match the advertised offer; submission
+still passes the buyer-signed calldata through to the meta-tx envelope.
 
 The facilitator's responsibilities are:
 
 1. **Validate** — structural shape, scheme/network/action match, signature
-   recovery, on-chain simulation pre-flight.
+   recovery, offer/calldata consistency, token-auth constraints, and
+   on-chain simulation pre-flight.
 2. **Submit** — wrap the buyer's signed meta-tx in
    `MetaTransactionsHandlerFacet.executeMetaTransaction(...)`, send via
    the configured viem `WalletClient`, await the receipt.
@@ -66,8 +65,8 @@ import {
   type FacilitatorConfig,
 } from "@bosonprotocol/x402-facilitator";
 
-// v0.1: these throw NotImplementedError. Wire-format hints below are
-// stable; the implementation lands in follow-up PRs.
+// v0.1: verify() is implemented; settle() and performAction() throw
+// NotImplementedError until relayer submission lands.
 ```
 
 ## The `facilitator` channel

--- a/typescript/packages/facilitator/package.json
+++ b/typescript/packages/facilitator/package.json
@@ -65,8 +65,9 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
-    "@bosonprotocol/x402-core": "workspace:^",
     "@bosonprotocol/x402-actions": "workspace:^",
+    "@bosonprotocol/x402-core": "workspace:^",
+    "@bosonprotocol/x402-evm": "workspace:^",
     "viem": "^2.39.3"
   },
   "devDependencies": {

--- a/typescript/packages/facilitator/src/verify/index.ts
+++ b/typescript/packages/facilitator/src/verify/index.ts
@@ -1,36 +1,143 @@
 // `verify` — stateless pre-flight check on an EscrowPaymentPayload +
 // EscrowPaymentRequirements pair.
 //
-// In v0.1 (this scaffold) this is a stub that throws NotImplementedError.
-//
-// Future implementation MUST (per docs/boson-impl-07-facilitator.md):
-//   1. Confirm `scheme === "escrow"` and the payload network matches the
+// Implements docs/boson-impl-07-facilitator.md's `POST /verify` contract:
+//   1. Confirm `scheme === "escrow"` (input + payload).
+//   2. Validate the payload + requirements structurally via the Zod
+//      schemas in `@bosonprotocol/x402-core/schemes/escrow`.
+//   3. Confirm the network is consistent across input, payload, and
 //      requirements.
-//   2. Validate the payload structurally via `parseEscrowPaymentPayload`.
-//   3. Recover and verify the buyer's metaTx signature against the
-//      Diamond's EIP-712 domain.
-//   4. If `tokenAuthStrategy !== "none"`, recover and verify the
-//      tokenAuth signature against the asset's EIP-712 domain
-//      (ERC-3009 / EIP-2612 / Permit2).
-//   5. Cross-check action ∈ `requirements.actions.next[].id` and
-//      tokenAuthStrategy ∈ `requirements.tokenAuthStrategies`.
-//   6. Simulate `executeMetaTransaction(...)` against the public client
-//      to catch protocol-level reverts (duplicate nonce, expired auth,
-//      insufficient allowance, …) before settle() spends gas.
-//   7. Return `{ ok: true }` on success, or `{ ok: false, code, reason }`
-//      on a known failure. Unknown failures surface as
-//      `{ ok: false, code: "INTERNAL_ERROR" }`.
+//   4. Confirm `payload.action` is in `requirements.actions.next[].id`.
+//   5. Confirm `payload.tokenAuthStrategy` is in
+//      `requirements.tokenAuthStrategies` (and the cross-field rule:
+//      tokenAuth must be present iff strategy != "none").
+//   6. Recover the buyer's meta-tx signature against the Diamond domain.
+//   7. If `tokenAuthStrategy !== "none"`, recover the token-auth
+//      signature against the asset's EIP-712 domain.
+//   8. Simulate `executeMetaTransaction(...)` via `eth_call` to catch
+//      protocol-level reverts (duplicate nonce, expired auth, …)
+//      without spending gas.
+//
+// Each step returns a discriminated-union `StepResult`; the orchestrator
+// returns on the first failure with the underlying code + reason.
 
-import { NotImplementedError } from "../errors.js";
 import type {
   FacilitatorConfig,
   FacilitatorVerifyInput,
   FacilitatorVerifyResult,
 } from "../types.js";
+import { toResult } from "../errors.js";
+
+import { verifyMetaTxSignature } from "./meta-tx-signature.js";
+import { simulateExecuteMetaTransaction } from "./simulate.js";
+import {
+  parseChainId,
+  validateActionInRequirements,
+  validateNetworkMatch,
+  validatePayloadStructure,
+  validateRequirementsStructure,
+  validateScheme,
+  validateTokenAuthStrategyInRequirements,
+  type StepResult,
+} from "./structural.js";
+import { verifyTokenAuthSignature } from "./token-auth-signature.js";
 
 export async function verify(
-  _input: FacilitatorVerifyInput,
-  _config: FacilitatorConfig,
+  input: FacilitatorVerifyInput,
+  config: FacilitatorConfig,
 ): Promise<FacilitatorVerifyResult> {
-  throw new NotImplementedError("verify");
+  try {
+    // Pre-flight: the network must be one the relayer is configured for.
+    if (!config.supportedNetworks.includes(input.network)) {
+      return {
+        ok: false,
+        code: "NETWORK_MISMATCH",
+        reason: `network "${input.network}" is not in supportedNetworks (${config.supportedNetworks.join(", ")})`,
+      };
+    }
+
+    // 1. Structural validation (payload then requirements).
+    const payloadStructural = validatePayloadStructure(input.payload);
+    if (!payloadStructural.ok) return payloadStructural;
+    const requirementsStructural = validateRequirementsStructure(input.requirements);
+    if (!requirementsStructural.ok) return requirementsStructural;
+
+    // 2. Scheme.
+    const scheme = validateScheme({ scheme: input.scheme, payload: input.payload });
+    if (!scheme.ok) return scheme;
+
+    // 3. Network consistency.
+    const network = validateNetworkMatch({
+      network: input.network,
+      payload: input.payload,
+      requirements: input.requirements,
+    });
+    if (!network.ok) return network;
+
+    // 4. Action presence.
+    const action = validateActionInRequirements({
+      payload: input.payload,
+      requirements: input.requirements,
+    });
+    if (!action.ok) return action;
+
+    // 5. Token-auth strategy presence + cross-field shape.
+    const strategy = validateTokenAuthStrategyInRequirements({
+      payload: input.payload,
+      requirements: input.requirements,
+    });
+    if (!strategy.ok) return strategy;
+
+    // 6. Parse chain id from CAIP-2 network.
+    const chain = parseChainId(input.network);
+    if (!chain.ok) return chain;
+
+    const relayer = config.walletClient.account?.address;
+    if (!relayer) {
+      return {
+        ok: false,
+        code: "INTERNAL_ERROR",
+        reason: "config.walletClient has no account; cannot simulate as relayer",
+      };
+    }
+
+    const inner = input.payload.payload;
+    const escrowAddress = input.requirements.escrowAddress as `0x${string}`;
+
+    // 7. Meta-tx signature recovery.
+    const metaSig = await verifyMetaTxSignature({
+      chainId: chain.chainId,
+      escrowAddress,
+      metaTx: inner.metaTx,
+      buyer: inner.buyer as `0x${string}`,
+    });
+    if (!metaSig.ok) return metaSig;
+
+    // 8. Token-auth signature recovery (skip for "none").
+    if (inner.tokenAuthStrategy !== "none" && inner.tokenAuth) {
+      const tokenAuthSig: StepResult = await verifyTokenAuthSignature({
+        chainId: chain.chainId,
+        asset: input.requirements.asset as `0x${string}`,
+        buyer: inner.buyer as `0x${string}`,
+        escrowAddress,
+        tokenAuth: inner.tokenAuth,
+        publicClient: config.publicClient,
+      });
+      if (!tokenAuthSig.ok) return tokenAuthSig;
+    }
+
+    // 9. On-chain simulation.
+    const sim = await simulateExecuteMetaTransaction({
+      escrowAddress,
+      buyer: inner.buyer as `0x${string}`,
+      metaTx: inner.metaTx,
+      publicClient: config.publicClient,
+      relayerAddress: relayer,
+    });
+    if (!sim.ok) return sim;
+
+    return { ok: true };
+  } catch (e) {
+    return toResult(e);
+  }
 }

--- a/typescript/packages/facilitator/src/verify/index.ts
+++ b/typescript/packages/facilitator/src/verify/index.ts
@@ -8,13 +8,16 @@
 //   3. Confirm the network is consistent across input, payload, and
 //      requirements.
 //   4. Confirm `payload.action` is in `requirements.actions.next[].id`.
-//   5. Confirm `payload.tokenAuthStrategy` is in
+//   5. Confirm `payload.offerRef` and `payload.metaTx` encode the offer
+//      advertised in requirements.
+//   6. Confirm `payload.tokenAuthStrategy` is in
 //      `requirements.tokenAuthStrategies` (and the cross-field rule:
 //      tokenAuth must be present iff strategy != "none").
-//   6. Recover the buyer's meta-tx signature against the Diamond domain.
-//   7. If `tokenAuthStrategy !== "none"`, recover the token-auth
-//      signature against the asset's EIP-712 domain.
-//   8. Simulate `executeMetaTransaction(...)` via `eth_call` to catch
+//   7. Recover the buyer's meta-tx signature against the Diamond domain.
+//   8. If `tokenAuthStrategy !== "none"`, recover the token-auth
+//      signature against the asset's EIP-712 domain and enforce
+//      amount/deadline constraints.
+//   9. Simulate `executeMetaTransaction(...)` via `eth_call` to catch
 //      protocol-level reverts (duplicate nonce, expired auth, …)
 //      without spending gas.
 //
@@ -33,7 +36,9 @@ import { simulateExecuteMetaTransaction } from "./simulate.js";
 import {
   parseChainId,
   validateActionInRequirements,
+  validateMetaTxCalldataMatchesRequirements,
   validateNetworkMatch,
+  validateOfferRefMatchesRequirements,
   validatePayloadStructure,
   validateRequirementsStructure,
   validateScheme,
@@ -81,14 +86,27 @@ export async function verify(
     });
     if (!action.ok) return action;
 
-    // 5. Token-auth strategy presence + cross-field shape.
+    // 5. Offer echo + signed calldata consistency.
+    const offerRef = validateOfferRefMatchesRequirements({
+      payload: input.payload,
+      requirements: input.requirements,
+    });
+    if (!offerRef.ok) return offerRef;
+
+    const calldata = validateMetaTxCalldataMatchesRequirements({
+      payload: input.payload,
+      requirements: input.requirements,
+    });
+    if (!calldata.ok) return calldata;
+
+    // 6. Token-auth strategy presence + cross-field shape.
     const strategy = validateTokenAuthStrategyInRequirements({
       payload: input.payload,
       requirements: input.requirements,
     });
     if (!strategy.ok) return strategy;
 
-    // 6. Parse chain id from CAIP-2 network.
+    // 7. Parse chain id from CAIP-2 network.
     const chain = parseChainId(input.network);
     if (!chain.ok) return chain;
 
@@ -104,7 +122,7 @@ export async function verify(
     const inner = input.payload.payload;
     const escrowAddress = input.requirements.escrowAddress as `0x${string}`;
 
-    // 7. Meta-tx signature recovery.
+    // 8. Meta-tx signature recovery.
     const metaSig = await verifyMetaTxSignature({
       chainId: chain.chainId,
       escrowAddress,
@@ -113,7 +131,7 @@ export async function verify(
     });
     if (!metaSig.ok) return metaSig;
 
-    // 8. Token-auth signature recovery (skip for "none").
+    // 9. Token-auth signature recovery (skip for "none").
     if (inner.tokenAuthStrategy !== "none" && inner.tokenAuth) {
       const tokenAuthSig: StepResult = await verifyTokenAuthSignature({
         chainId: chain.chainId,
@@ -121,16 +139,19 @@ export async function verify(
         buyer: inner.buyer as `0x${string}`,
         escrowAddress,
         tokenAuth: inner.tokenAuth,
+        amount: input.requirements.amount,
+        maxTimeoutSeconds: input.requirements.maxTimeoutSeconds,
         publicClient: config.publicClient,
       });
       if (!tokenAuthSig.ok) return tokenAuthSig;
     }
 
-    // 9. On-chain simulation.
+    // 10. On-chain simulation.
     const sim = await simulateExecuteMetaTransaction({
       escrowAddress,
       buyer: inner.buyer as `0x${string}`,
       metaTx: inner.metaTx,
+      tokenAuthStrategy: inner.tokenAuthStrategy,
       publicClient: config.publicClient,
       relayerAddress: relayer,
     });

--- a/typescript/packages/facilitator/src/verify/meta-tx-signature.ts
+++ b/typescript/packages/facilitator/src/verify/meta-tx-signature.ts
@@ -1,0 +1,94 @@
+// Meta-tx signature recovery.
+//
+// The buyer signs the Boson `MetaTransaction` EIP-712 typed-data with
+// the Diamond as the verifying contract. We reconstruct the same
+// typed-data via `metaTransactionTypedData()` from
+// `@bosonprotocol/x402-core/eip712` (which delegates the EIP-712 domain
+// to `@bosonprotocol/core-sdk` so we stay in lock-step with the deployed
+// protocol), then recover the signer with viem.
+
+import { metaTransactionTypedData } from "@bosonprotocol/x402-core/eip712";
+import type { Address, BosonMetaTx, Hex } from "@bosonprotocol/x402-core/schemes/escrow";
+import { recoverTypedDataAddress } from "viem";
+
+import type { StepResult } from "./structural.js";
+
+export interface VerifyMetaTxSignatureArgs {
+  chainId: number;
+  /** Boson escrow (Diamond) address — the EIP-712 verifyingContract. */
+  escrowAddress: Address;
+  /** The meta-tx envelope from the payload. */
+  metaTx: BosonMetaTx;
+  /** Buyer wallet from the payload — the recovered signer must match this. */
+  buyer: Address;
+}
+
+/**
+ * Recover the meta-tx signer and confirm it matches `buyer`. The on-chain
+ * `MetaTransactionsHandlerFacet.executeMetaTransaction` recovers signatures
+ * with `LibSignature.recover`, which accepts only the legacy `v ∈ {27, 28}`
+ * form — reject `v ∈ {0, 1}` upfront with a clear error rather than letting
+ * the simulation fail later.
+ */
+export async function verifyMetaTxSignature(args: VerifyMetaTxSignatureArgs): Promise<StepResult> {
+  const { v, r, s } = args.metaTx.sig;
+  if (v !== 27 && v !== 28) {
+    return {
+      ok: false,
+      code: "BAD_META_TX_SIGNATURE",
+      reason: `meta-tx signature v must be 27 or 28, got ${v}`,
+    };
+  }
+  const typedData = await metaTransactionTypedData({
+    chainId: args.chainId,
+    verifyingContract: args.escrowAddress as `0x${string}`,
+    message: {
+      nonce: BigInt(args.metaTx.nonce),
+      from: args.metaTx.from as `0x${string}`,
+      contractAddress: args.escrowAddress as `0x${string}`,
+      functionName: args.metaTx.functionName,
+      functionSignature: args.metaTx.functionSignature as `0x${string}`,
+    },
+  });
+  const signature = packRsv(r as Hex, s as Hex, v);
+  let recovered: Address;
+  try {
+    recovered = await recoverTypedDataAddress({
+      domain: typedData.domain,
+      types: typedData.types,
+      primaryType: typedData.primaryType,
+      message: typedData.message,
+      signature: signature as `0x${string}`,
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      code: "BAD_META_TX_SIGNATURE",
+      reason: e instanceof Error ? `recovery failed: ${e.message}` : "recovery failed",
+    };
+  }
+  if (recovered.toLowerCase() !== args.buyer.toLowerCase()) {
+    return {
+      ok: false,
+      code: "BAD_META_TX_SIGNATURE",
+      reason: `recovered signer ${recovered} != payload.buyer ${args.buyer}`,
+    };
+  }
+  // The protocol uses `metaTx.from` as the from-address recovered from the
+  // signature too; verify that this matches the buyer (the spec treats
+  // metaTx.from and payload.buyer as the same EOA).
+  if (args.metaTx.from.toLowerCase() !== args.buyer.toLowerCase()) {
+    return {
+      ok: false,
+      code: "BAD_META_TX_SIGNATURE",
+      reason: `metaTx.from ${args.metaTx.from} != payload.buyer ${args.buyer}`,
+    };
+  }
+  return { ok: true };
+}
+
+/** Pack split ECDSA signature into the 65-byte `r ++ s ++ v` form viem expects. */
+export function packRsv(r: Hex, s: Hex, v: number): Hex {
+  const vHex = v.toString(16).padStart(2, "0");
+  return `0x${r.slice(2)}${s.slice(2)}${vHex}` as Hex;
+}

--- a/typescript/packages/facilitator/src/verify/simulate.ts
+++ b/typescript/packages/facilitator/src/verify/simulate.ts
@@ -1,0 +1,75 @@
+// On-chain simulation pre-flight.
+//
+// We don't reach for `publicClient.simulateContract` (which would require
+// us to mirror or import the meta-tx handler's full viem-shaped ABI) —
+// instead we lean on `@bosonprotocol/x402-evm`'s
+// `buildExecuteMetaTransactionTx` to encode the outer envelope (the same
+// calldata `settle()` will broadcast), then submit it via
+// `publicClient.call` from the relayer's address. viem throws a
+// structured `CallExecutionError` on revert; we map the revert reason
+// into a `SIMULATION_REVERT` result so the caller can surface it.
+//
+// This catches protocol-level reverts (duplicate nonce, expired
+// token-auth, insufficient buyer balance, paused contract, …) before
+// `settle()` spends a single wei of gas.
+
+import { buildExecuteMetaTransactionTx } from "@bosonprotocol/x402-evm/envelope";
+import type { Address, BosonMetaTx, Hex } from "@bosonprotocol/x402-core/schemes/escrow";
+import { type PublicClient } from "viem";
+
+import type { StepResult } from "./structural.js";
+
+export interface SimulateExecuteMetaTransactionArgs {
+  escrowAddress: Address;
+  buyer: Address;
+  metaTx: BosonMetaTx;
+  publicClient: PublicClient;
+  /** Relayer's EOA — used as `msg.sender` for the `eth_call` simulation. */
+  relayerAddress: Address;
+}
+
+export async function simulateExecuteMetaTransaction(
+  args: SimulateExecuteMetaTransactionArgs,
+): Promise<StepResult> {
+  const tx = buildExecuteMetaTransactionTx({
+    escrowAddress: args.escrowAddress as `0x${string}`,
+    userAddress: args.buyer as `0x${string}`,
+    functionName: args.metaTx.functionName,
+    functionSignature: args.metaTx.functionSignature as `0x${string}`,
+    nonce: BigInt(args.metaTx.nonce),
+    sig: {
+      r: args.metaTx.sig.r as `0x${string}`,
+      s: args.metaTx.sig.s as `0x${string}`,
+      v: args.metaTx.sig.v,
+    },
+  });
+  try {
+    await args.publicClient.call({
+      account: args.relayerAddress as `0x${string}`,
+      to: tx.to as `0x${string}`,
+      data: tx.data as `0x${string}`,
+    });
+    return { ok: true };
+  } catch (e) {
+    return {
+      ok: false,
+      code: "SIMULATION_REVERT",
+      reason: extractRevertReason(e),
+    };
+  }
+}
+
+/** Best-effort revert reason from a viem `CallExecutionError`. */
+function extractRevertReason(e: unknown): string {
+  if (!(e instanceof Error)) return String(e);
+  // viem's structured errors expose the revert reason as `shortMessage`,
+  // and the full call stack as `message`. The short form is the most
+  // useful for an HTTP error response; fall back to the long form.
+  const maybeShort = (e as Error & { shortMessage?: string }).shortMessage;
+  return maybeShort ?? e.message;
+}
+
+// Re-export the hex-typed alias for downstream consumers — keeps this
+// module's import surface narrow even when `verify/index.ts` only
+// re-exports a subset.
+export type { Hex };

--- a/typescript/packages/facilitator/src/verify/simulate.ts
+++ b/typescript/packages/facilitator/src/verify/simulate.ts
@@ -2,19 +2,31 @@
 //
 // We don't reach for `publicClient.simulateContract` (which would require
 // us to mirror or import the meta-tx handler's full viem-shaped ABI) —
-// instead we lean on `@bosonprotocol/x402-evm`'s
-// `buildExecuteMetaTransactionTx` to encode the outer envelope (the same
-// calldata `settle()` will broadcast), then submit it via
-// `publicClient.call` from the relayer's address. viem throws a
+// instead we lean on `@bosonprotocol/x402-evm`'s envelope builders to
+// encode the outer envelope (the same calldata `settle()` will
+// broadcast), then submit it via `publicClient.call` from the relayer's
+// address. viem throws a
 // structured `CallExecutionError` on revert; we map the revert reason
 // into a `SIMULATION_REVERT` result so the caller can surface it.
 //
-// This catches protocol-level reverts (duplicate nonce, expired
-// token-auth, insufficient buyer balance, paused contract, …) before
-// `settle()` spends a single wei of gas.
+// This catches protocol-level reverts (duplicate nonce, insufficient
+// buyer balance, paused contract, …) before `settle()` spends a single
+// wei of gas. The BPIP-12 token-auth envelope is still deferred in
+// `@bosonprotocol/x402-evm`, so non-`none` strategies map to
+// `UNSUPPORTED_TOKEN_AUTH_STRATEGY` until that builder ships.
 
-import { buildExecuteMetaTransactionTx } from "@bosonprotocol/x402-evm/envelope";
-import type { Address, BosonMetaTx, Hex } from "@bosonprotocol/x402-core/schemes/escrow";
+import {
+  buildExecuteMetaTransactionTx,
+  buildExecuteMetaTransactionWithTokenAuthTx,
+  NotYetSupportedError,
+  type TxRequest,
+} from "@bosonprotocol/x402-evm/envelope";
+import type {
+  Address,
+  BosonMetaTx,
+  Hex,
+  TokenAuthStrategy,
+} from "@bosonprotocol/x402-core/schemes/escrow";
 import { type PublicClient } from "viem";
 
 import type { StepResult } from "./structural.js";
@@ -23,6 +35,7 @@ export interface SimulateExecuteMetaTransactionArgs {
   escrowAddress: Address;
   buyer: Address;
   metaTx: BosonMetaTx;
+  tokenAuthStrategy: TokenAuthStrategy;
   publicClient: PublicClient;
   /** Relayer's EOA — used as `msg.sender` for the `eth_call` simulation. */
   relayerAddress: Address;
@@ -31,7 +44,7 @@ export interface SimulateExecuteMetaTransactionArgs {
 export async function simulateExecuteMetaTransaction(
   args: SimulateExecuteMetaTransactionArgs,
 ): Promise<StepResult> {
-  const tx = buildExecuteMetaTransactionTx({
+  const common = {
     escrowAddress: args.escrowAddress as `0x${string}`,
     userAddress: args.buyer as `0x${string}`,
     functionName: args.metaTx.functionName,
@@ -42,7 +55,30 @@ export async function simulateExecuteMetaTransaction(
       s: args.metaTx.sig.s as `0x${string}`,
       v: args.metaTx.sig.v,
     },
-  });
+  };
+  let tx: TxRequest;
+  try {
+    tx =
+      args.tokenAuthStrategy === "none"
+        ? buildExecuteMetaTransactionTx(common)
+        : buildExecuteMetaTransactionWithTokenAuthTx({
+            ...common,
+            tokenTransferAuthorizations: [],
+          });
+  } catch (e) {
+    if (e instanceof NotYetSupportedError) {
+      return {
+        ok: false,
+        code: "UNSUPPORTED_TOKEN_AUTH_STRATEGY",
+        reason: e.message,
+      };
+    }
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      reason: e instanceof Error ? e.message : String(e),
+    };
+  }
   try {
     await args.publicClient.call({
       account: args.relayerAddress as `0x${string}`,

--- a/typescript/packages/facilitator/src/verify/simulate.ts
+++ b/typescript/packages/facilitator/src/verify/simulate.ts
@@ -5,29 +5,36 @@
 // instead we lean on `@bosonprotocol/x402-evm`'s envelope builders to
 // encode the outer envelope (the same calldata `settle()` will
 // broadcast), then submit it via `publicClient.call` from the relayer's
-// address. viem throws a
-// structured `CallExecutionError` on revert; we map the revert reason
-// into a `SIMULATION_REVERT` result so the caller can surface it.
+// address. viem throws a structured error chain on revert; we walk that
+// chain looking for a `RawContractError` /
+// `ContractFunctionRevertedError` to distinguish a real on-chain revert
+// from a transport-layer failure (HTTP timeout, JSON-RPC error, …) —
+// only the former maps to `SIMULATION_REVERT`.
 //
 // This catches protocol-level reverts (duplicate nonce, insufficient
 // buyer balance, paused contract, …) before `settle()` spends a single
-// wei of gas. The BPIP-12 token-auth envelope is still deferred in
-// `@bosonprotocol/x402-evm`, so non-`none` strategies map to
-// `UNSUPPORTED_TOKEN_AUTH_STRATEGY` until that builder ships.
+// wei of gas.
+//
+// The BPIP-12 token-auth envelope is still deferred in
+// `@bosonprotocol/x402-evm`, so non-`"none"` strategies short-circuit to
+// `UNSUPPORTED_TOKEN_AUTH_STRATEGY` here rather than attempting to
+// simulate with an empty `tokenTransferAuthorizations` queue (which
+// would produce calldata that doesn't match what `settle()` would
+// actually broadcast once the encoder ships).
 
-import {
-  buildExecuteMetaTransactionTx,
-  buildExecuteMetaTransactionWithTokenAuthTx,
-  NotYetSupportedError,
-  type TxRequest,
-} from "@bosonprotocol/x402-evm/envelope";
+import { buildExecuteMetaTransactionTx, type TxRequest } from "@bosonprotocol/x402-evm/envelope";
 import type {
   Address,
   BosonMetaTx,
   Hex,
   TokenAuthStrategy,
 } from "@bosonprotocol/x402-core/schemes/escrow";
-import { type PublicClient } from "viem";
+import {
+  BaseError,
+  ContractFunctionRevertedError,
+  RawContractError,
+  type PublicClient,
+} from "viem";
 
 import type { StepResult } from "./structural.js";
 
@@ -44,41 +51,42 @@ export interface SimulateExecuteMetaTransactionArgs {
 export async function simulateExecuteMetaTransaction(
   args: SimulateExecuteMetaTransactionArgs,
 ): Promise<StepResult> {
-  const common = {
-    escrowAddress: args.escrowAddress as `0x${string}`,
-    userAddress: args.buyer as `0x${string}`,
-    functionName: args.metaTx.functionName,
-    functionSignature: args.metaTx.functionSignature as `0x${string}`,
-    nonce: BigInt(args.metaTx.nonce),
-    sig: {
-      r: args.metaTx.sig.r as `0x${string}`,
-      s: args.metaTx.sig.s as `0x${string}`,
-      v: args.metaTx.sig.v,
-    },
-  };
+  // The BPIP-12 envelope encoder is not yet shipped in
+  // `@bosonprotocol/x402-evm` and even once it does, simulating with an
+  // empty `tokenTransferAuthorizations` queue would produce calldata
+  // that doesn't match what `settle()` would broadcast — the queue must
+  // encode the buyer's signed authorization. Fail loudly until the
+  // encoder is fully wired up.
+  if (args.tokenAuthStrategy !== "none") {
+    return {
+      ok: false,
+      code: "UNSUPPORTED_TOKEN_AUTH_STRATEGY",
+      reason: `simulation for tokenAuthStrategy "${args.tokenAuthStrategy}" requires the BPIP-12 envelope builder, which is not yet shipped in @bosonprotocol/x402-evm`,
+    };
+  }
+
   let tx: TxRequest;
   try {
-    tx =
-      args.tokenAuthStrategy === "none"
-        ? buildExecuteMetaTransactionTx(common)
-        : buildExecuteMetaTransactionWithTokenAuthTx({
-            ...common,
-            tokenTransferAuthorizations: [],
-          });
+    tx = buildExecuteMetaTransactionTx({
+      escrowAddress: args.escrowAddress as `0x${string}`,
+      userAddress: args.buyer as `0x${string}`,
+      functionName: args.metaTx.functionName,
+      functionSignature: args.metaTx.functionSignature as `0x${string}`,
+      nonce: BigInt(args.metaTx.nonce),
+      sig: {
+        r: args.metaTx.sig.r as `0x${string}`,
+        s: args.metaTx.sig.s as `0x${string}`,
+        v: args.metaTx.sig.v,
+      },
+    });
   } catch (e) {
-    if (e instanceof NotYetSupportedError) {
-      return {
-        ok: false,
-        code: "UNSUPPORTED_TOKEN_AUTH_STRATEGY",
-        reason: e.message,
-      };
-    }
     return {
       ok: false,
       code: "INTERNAL_ERROR",
       reason: e instanceof Error ? e.message : String(e),
     };
   }
+
   try {
     await args.publicClient.call({
       account: args.relayerAddress as `0x${string}`,
@@ -87,22 +95,55 @@ export async function simulateExecuteMetaTransaction(
     });
     return { ok: true };
   } catch (e) {
+    if (isOnChainRevert(e)) {
+      return {
+        ok: false,
+        code: "SIMULATION_REVERT",
+        reason: extractRevertReason(e),
+      };
+    }
+    // Transport-layer failure (RPC unreachable, HTTP timeout, malformed
+    // response, …). Operators need to retry or investigate the RPC
+    // provider — this is not a buyer-attributable error.
     return {
       ok: false,
-      code: "SIMULATION_REVERT",
-      reason: extractRevertReason(e),
+      code: "INTERNAL_ERROR",
+      reason: e instanceof Error ? e.message : String(e),
     };
   }
 }
 
-/** Best-effort revert reason from a viem `CallExecutionError`. */
+/**
+ * Walk the viem error cause chain looking for a contract-level revert
+ * marker. Returns false for non-viem errors and for viem transport
+ * failures (HTTP / timeout / JSON-RPC) — only contract reverts carry a
+ * `RawContractError` or `ContractFunctionRevertedError` in the chain.
+ */
+function isOnChainRevert(e: unknown): boolean {
+  if (!(e instanceof BaseError)) return false;
+  return (
+    e.walk(
+      (err) => err instanceof RawContractError || err instanceof ContractFunctionRevertedError,
+    ) !== null
+  );
+}
+
+/** Best-effort revert reason extracted from a viem error chain. */
 function extractRevertReason(e: unknown): string {
-  if (!(e instanceof Error)) return String(e);
-  // viem's structured errors expose the revert reason as `shortMessage`,
-  // and the full call stack as `message`. The short form is the most
-  // useful for an HTTP error response; fall back to the long form.
-  const maybeShort = (e as Error & { shortMessage?: string }).shortMessage;
-  return maybeShort ?? e.message;
+  if (e instanceof BaseError) {
+    const reverted = e.walk(
+      (err) => err instanceof RawContractError || err instanceof ContractFunctionRevertedError,
+    );
+    if (reverted instanceof ContractFunctionRevertedError) {
+      return reverted.reason ?? reverted.shortMessage ?? reverted.message;
+    }
+    if (reverted instanceof RawContractError) {
+      return reverted.message || reverted.shortMessage || "execution reverted";
+    }
+    return e.shortMessage || e.message;
+  }
+  if (e instanceof Error) return e.message;
+  return String(e);
 }
 
 // Re-export the hex-typed alias for downstream consumers — keeps this

--- a/typescript/packages/facilitator/src/verify/structural.ts
+++ b/typescript/packages/facilitator/src/verify/structural.ts
@@ -141,7 +141,10 @@ export function validateMetaTxCalldataMatchesRequirements(input: {
   requirements: EscrowPaymentRequirements;
 }): StepResult {
   const inner = input.payload.payload;
-  const fullOffer = withSellerSignature(input.requirements.offer.fullOffer, input.requirements.offer.sellerSig);
+  const fullOffer = withSellerSignature(
+    input.requirements.offer.fullOffer,
+    input.requirements.offer.sellerSig,
+  );
 
   try {
     const expected =
@@ -185,7 +188,10 @@ export function validateMetaTxCalldataMatchesRequirements(input: {
     return {
       ok: false,
       code: "INVALID_PAYLOAD",
-      reason: e instanceof Error ? `failed to validate meta-tx calldata: ${e.message}` : "failed to validate meta-tx calldata",
+      reason:
+        e instanceof Error
+          ? `failed to validate meta-tx calldata: ${e.message}`
+          : "failed to validate meta-tx calldata",
     };
   }
 }
@@ -249,7 +255,10 @@ export function parseChainId(
   return { ok: true, chainId: Number(m[1]) };
 }
 
-function withSellerSignature(fullOffer: Record<string, unknown>, sellerSig: string): Record<string, unknown> {
+function withSellerSignature(
+  fullOffer: Record<string, unknown>,
+  sellerSig: string,
+): Record<string, unknown> {
   return { ...fullOffer, signature: sellerSig };
 }
 

--- a/typescript/packages/facilitator/src/verify/structural.ts
+++ b/typescript/packages/facilitator/src/verify/structural.ts
@@ -8,6 +8,11 @@ import {
   type EscrowPaymentRequirements,
   type EvmNetwork,
 } from "@bosonprotocol/x402-core/schemes/escrow";
+import {
+  buildCreateOfferAndCommitCalldata,
+  buildCreateOfferCommitAndRedeemCalldata,
+  NotYetSupportedError,
+} from "@bosonprotocol/x402-evm/actions";
 
 import type { FacilitatorErrorCode } from "../types.js";
 
@@ -105,6 +110,86 @@ export function validateActionInRequirements(input: {
   return { ok: true };
 }
 
+/** Confirm the payload's echoed offer reference matches the requirements. */
+export function validateOfferRefMatchesRequirements(input: {
+  payload: EscrowPaymentPayload;
+  requirements: EscrowPaymentRequirements;
+}): StepResult {
+  const payloadOffer = input.payload.payload.offerRef;
+  const requirementsOffer = input.requirements.offer;
+
+  if (canonicalJson(payloadOffer.fullOffer) !== canonicalJson(requirementsOffer.fullOffer)) {
+    return {
+      ok: false,
+      code: "INVALID_PAYLOAD",
+      reason: "payload.offerRef.fullOffer does not match requirements.offer.fullOffer",
+    };
+  }
+  if (payloadOffer.sellerSig.toLowerCase() !== requirementsOffer.sellerSig.toLowerCase()) {
+    return {
+      ok: false,
+      code: "INVALID_PAYLOAD",
+      reason: "payload.offerRef.sellerSig does not match requirements.offer.sellerSig",
+    };
+  }
+  return { ok: true };
+}
+
+/** Confirm the signed inner calldata matches the action + offer requirements. */
+export function validateMetaTxCalldataMatchesRequirements(input: {
+  payload: EscrowPaymentPayload;
+  requirements: EscrowPaymentRequirements;
+}): StepResult {
+  const inner = input.payload.payload;
+  const fullOffer = withSellerSignature(input.requirements.offer.fullOffer, input.requirements.offer.sellerSig);
+
+  try {
+    const expected =
+      inner.action === "boson-createOfferAndCommit"
+        ? buildCreateOfferAndCommitCalldata({ fullOffer })
+        : inner.action === "boson-createOfferCommitAndRedeem"
+          ? buildCreateOfferCommitAndRedeemCalldata({ fullOffer })
+          : undefined;
+
+    if (!expected) {
+      return {
+        ok: false,
+        code: "UNSUPPORTED_ACTION",
+        reason: `verify() only supports commit-time payment actions, got "${inner.action}"`,
+      };
+    }
+
+    if (inner.metaTx.functionName !== expected.functionName) {
+      return {
+        ok: false,
+        code: "INVALID_PAYLOAD",
+        reason: "payload.metaTx.functionName does not match the expected action selector",
+      };
+    }
+    if (inner.metaTx.functionSignature.toLowerCase() !== expected.functionSignature.toLowerCase()) {
+      return {
+        ok: false,
+        code: "INVALID_PAYLOAD",
+        reason: "payload.metaTx.functionSignature does not encode the required offer",
+      };
+    }
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof NotYetSupportedError) {
+      return {
+        ok: false,
+        code: "UNSUPPORTED_ACTION",
+        reason: e.message,
+      };
+    }
+    return {
+      ok: false,
+      code: "INVALID_PAYLOAD",
+      reason: e instanceof Error ? `failed to validate meta-tx calldata: ${e.message}` : "failed to validate meta-tx calldata",
+    };
+  }
+}
+
 /** Confirm the payload's token-auth strategy is one the requirements advertised. */
 export function validateTokenAuthStrategyInRequirements(input: {
   payload: EscrowPaymentPayload;
@@ -162,4 +247,26 @@ export function parseChainId(
     };
   }
   return { ok: true, chainId: Number(m[1]) };
+}
+
+function withSellerSignature(fullOffer: Record<string, unknown>, sellerSig: string): Record<string, unknown> {
+  return { ...fullOffer, signature: sellerSig };
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJson);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, entry]) => [key, sortJson(entry)]),
+    );
+  }
+  return value;
 }

--- a/typescript/packages/facilitator/src/verify/structural.ts
+++ b/typescript/packages/facilitator/src/verify/structural.ts
@@ -1,0 +1,165 @@
+// Synchronous, cheap pre-flight checks for `verify()`. Anything that
+// doesn't require an RPC round-trip or a signature recovery lives here.
+
+import {
+  escrowPaymentPayloadSchema,
+  escrowPaymentRequirementsSchema,
+  type EscrowPaymentPayload,
+  type EscrowPaymentRequirements,
+  type EvmNetwork,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+
+import type { FacilitatorErrorCode } from "../types.js";
+
+/**
+ * Structured result form used by every verify-step helper. Lets callers
+ * chain steps with early returns without throwing.
+ */
+export type StepResult = { ok: true } | { ok: false; code: FacilitatorErrorCode; reason: string };
+
+/** Parse the payload against the canonical Zod schema. */
+export function validatePayloadStructure(payload: unknown): StepResult {
+  const parsed = escrowPaymentPayloadSchema.safeParse(payload);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      code: "INVALID_PAYLOAD",
+      reason: `payload failed schema validation: ${parsed.error.message}`,
+    };
+  }
+  return { ok: true };
+}
+
+/** Parse the requirements against the canonical Zod schema. */
+export function validateRequirementsStructure(requirements: unknown): StepResult {
+  const parsed = escrowPaymentRequirementsSchema.safeParse(requirements);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      code: "INVALID_PAYLOAD",
+      reason: `requirements failed schema validation: ${parsed.error.message}`,
+    };
+  }
+  return { ok: true };
+}
+
+/** Confirm the outer scheme is `"escrow"` and matches the payload's scheme. */
+export function validateScheme(input: {
+  scheme: string;
+  payload: EscrowPaymentPayload;
+}): StepResult {
+  if (input.scheme !== "escrow") {
+    return {
+      ok: false,
+      code: "SCHEME_MISMATCH",
+      reason: `outer scheme must be "escrow", got "${input.scheme}"`,
+    };
+  }
+  if (input.payload.scheme !== "escrow") {
+    return {
+      ok: false,
+      code: "SCHEME_MISMATCH",
+      reason: `payload.scheme must be "escrow", got "${input.payload.scheme}"`,
+    };
+  }
+  return { ok: true };
+}
+
+/** Confirm the network is consistent across input, payload, and requirements. */
+export function validateNetworkMatch(input: {
+  network: EvmNetwork;
+  payload: EscrowPaymentPayload;
+  requirements: EscrowPaymentRequirements;
+}): StepResult {
+  if (input.network !== input.payload.network) {
+    return {
+      ok: false,
+      code: "NETWORK_MISMATCH",
+      reason: `input.network "${input.network}" != payload.network "${input.payload.network}"`,
+    };
+  }
+  if (input.network !== input.requirements.network) {
+    return {
+      ok: false,
+      code: "NETWORK_MISMATCH",
+      reason: `input.network "${input.network}" != requirements.network "${input.requirements.network}"`,
+    };
+  }
+  return { ok: true };
+}
+
+/** Confirm the payload's action id is one the requirements advertised. */
+export function validateActionInRequirements(input: {
+  payload: EscrowPaymentPayload;
+  requirements: EscrowPaymentRequirements;
+}): StepResult {
+  const supported = new Set(input.requirements.actions.next.map((n) => n.id));
+  const action = input.payload.payload.action;
+  if (!supported.has(action)) {
+    return {
+      ok: false,
+      code: "ACTION_NOT_IN_REQUIREMENTS",
+      reason: `payload.action "${action}" is not in requirements.actions.next[].id (${[...supported].join(", ")})`,
+    };
+  }
+  return { ok: true };
+}
+
+/** Confirm the payload's token-auth strategy is one the requirements advertised. */
+export function validateTokenAuthStrategyInRequirements(input: {
+  payload: EscrowPaymentPayload;
+  requirements: EscrowPaymentRequirements;
+}): StepResult {
+  const strategy = input.payload.payload.tokenAuthStrategy;
+  if (!input.requirements.tokenAuthStrategies.includes(strategy)) {
+    return {
+      ok: false,
+      code: "TOKEN_AUTH_NOT_IN_REQUIREMENTS",
+      reason: `payload.tokenAuthStrategy "${strategy}" is not in requirements.tokenAuthStrategies (${input.requirements.tokenAuthStrategies.join(", ")})`,
+    };
+  }
+  // Cross-field rule from docs/boson-impl-01-escrow-scheme.md §5: `tokenAuth`
+  // must be present iff strategy !== "none".
+  const hasTokenAuth = input.payload.payload.tokenAuth !== undefined;
+  if (strategy === "none" && hasTokenAuth) {
+    return {
+      ok: false,
+      code: "INVALID_PAYLOAD",
+      reason: 'tokenAuth must be omitted when tokenAuthStrategy is "none"',
+    };
+  }
+  if (strategy !== "none" && !hasTokenAuth) {
+    return {
+      ok: false,
+      code: "INVALID_PAYLOAD",
+      reason: `tokenAuth is required when tokenAuthStrategy is "${strategy}"`,
+    };
+  }
+  // When present, the discriminator must match the strategy.
+  if (hasTokenAuth && strategy !== input.payload.payload.tokenAuth?.kind) {
+    return {
+      ok: false,
+      code: "INVALID_PAYLOAD",
+      reason: `tokenAuth.kind "${input.payload.payload.tokenAuth?.kind}" does not match tokenAuthStrategy "${strategy}"`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Parse the CAIP-2 EVM network identifier (`eip155:<chainId>`) into a
+ * numeric chain id. Returns `NETWORK_MISMATCH` for malformed values.
+ */
+export function parseChainId(
+  network: EvmNetwork,
+): { ok: true; chainId: number } | { ok: false; code: FacilitatorErrorCode; reason: string } {
+  const m = network.match(/^eip155:(\d+)$/);
+  if (!m) {
+    return {
+      ok: false,
+      code: "NETWORK_MISMATCH",
+      reason: `network must be CAIP-2 eip155:<chainId>, got "${network}"`,
+    };
+  }
+  return { ok: true, chainId: Number(m[1]) };
+}

--- a/typescript/packages/facilitator/src/verify/token-auth-signature.ts
+++ b/typescript/packages/facilitator/src/verify/token-auth-signature.ts
@@ -1,0 +1,306 @@
+// Token-auth signature recovery.
+//
+// For non-`"none"` strategies the buyer signed an EIP-712 payload against
+// the token contract's own domain (ERC-3009, EIP-2612) or against Permit2
+// (Uniswap). We delegate the typed-data + recovery to
+// `@bosonprotocol/x402-core/eip712/token-auth`'s strategy-specific
+// helpers (they hand-mirror the canonical EIP-712 type-lists) and only
+// add the cross-field assertions: the recovered signer must equal the
+// buyer, the asset and recipient must match the requirements, etc.
+//
+// For ERC-3009 / EIP-2612 we need the token's EIP-712 domain
+// (`name`, `version`). We resolve it via EIP-5267's `eip712Domain()`
+// when the token supports it, falling back to `name()` + `version()`
+// with a default `"1"` if `version()` reverts (the EIP-2612 default).
+
+import type { Address, BosonTokenAuth, Hex } from "@bosonprotocol/x402-core/schemes/escrow";
+import {
+  type TokenEip712Domain,
+  recoverErc3009Signer,
+  recoverPermit2Signer,
+  recoverPermitSigner,
+} from "@bosonprotocol/x402-core/eip712/token-auth";
+import { type PublicClient } from "viem";
+
+import { packRsv } from "./meta-tx-signature.js";
+import type { StepResult } from "./structural.js";
+
+export interface VerifyTokenAuthSignatureArgs {
+  chainId: number;
+  /** Asset (ERC-20 token) address from the requirements. */
+  asset: Address;
+  /** Buyer EOA from the payload — the recovered signer must match this. */
+  buyer: Address;
+  /** Boson escrow (Diamond) address — the expected `to` / `spender`. */
+  escrowAddress: Address;
+  /** Discriminated union from the payload; never `"none"` (caller skips this step for none). */
+  tokenAuth: BosonTokenAuth;
+  /** Used to look up the token's EIP-712 domain (`name` / `version`) for ERC-3009 and EIP-2612. */
+  publicClient: PublicClient;
+}
+
+const EIP5267_ABI = [
+  {
+    type: "function",
+    name: "eip712Domain",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [
+      { name: "fields", type: "bytes1" },
+      { name: "name", type: "string" },
+      { name: "version", type: "string" },
+      { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
+      { name: "salt", type: "bytes32" },
+      { name: "extensions", type: "uint256[]" },
+    ],
+  },
+] as const;
+
+const NAME_ABI = [
+  {
+    type: "function",
+    name: "name",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "string" }],
+  },
+] as const;
+
+const VERSION_ABI = [
+  {
+    type: "function",
+    name: "version",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "string" }],
+  },
+] as const;
+
+/**
+ * Look up the token's EIP-712 domain. Tries EIP-5267 first (one call,
+ * canonical); falls back to `name()` + `version()` (with version
+ * defaulting to `"1"` per EIP-2612 if the function reverts).
+ *
+ * Exported so tests can inject a mocked PublicClient and so future
+ * caching layers can wrap it.
+ */
+export async function fetchTokenDomain(
+  publicClient: PublicClient,
+  token: Address,
+  chainId: number,
+): Promise<TokenEip712Domain> {
+  try {
+    const result = (await publicClient.readContract({
+      address: token as `0x${string}`,
+      abi: EIP5267_ABI,
+      functionName: "eip712Domain",
+    })) as readonly [Hex, string, string, bigint, Address, Hex, readonly bigint[]];
+    return {
+      name: result[1],
+      version: result[2],
+      chainId: Number(result[3]),
+      verifyingContract: result[4] as `0x${string}`,
+    };
+  } catch {
+    // EIP-5267 not implemented — fall back to name() + version().
+  }
+  const name = (await publicClient.readContract({
+    address: token as `0x${string}`,
+    abi: NAME_ABI,
+    functionName: "name",
+  })) as string;
+  let version = "1";
+  try {
+    version = (await publicClient.readContract({
+      address: token as `0x${string}`,
+      abi: VERSION_ABI,
+      functionName: "version",
+    })) as string;
+  } catch {
+    // version() is optional per EIP-2612 — keep the default.
+  }
+  return { name, version, chainId, verifyingContract: token as `0x${string}` };
+}
+
+export async function verifyTokenAuthSignature(
+  args: VerifyTokenAuthSignatureArgs,
+): Promise<StepResult> {
+  switch (args.tokenAuth.kind) {
+    case "erc3009":
+      return verifyErc3009(args, args.tokenAuth.data);
+    case "permit":
+      return verifyPermit(args, args.tokenAuth.data);
+    case "permit2":
+      return verifyPermit2(args, args.tokenAuth.data);
+  }
+}
+
+async function verifyErc3009(
+  args: VerifyTokenAuthSignatureArgs,
+  data: Extract<BosonTokenAuth, { kind: "erc3009" }>["data"],
+): Promise<StepResult> {
+  if (data.v !== 27 && data.v !== 28) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `ERC-3009 signature v must be 27 or 28, got ${data.v}`,
+    };
+  }
+  // Cross-field: from == buyer, to == escrow.
+  if (data.from.toLowerCase() !== args.buyer.toLowerCase()) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `ERC-3009 from ${data.from} != payload.buyer ${args.buyer}`,
+    };
+  }
+  if (data.to.toLowerCase() !== args.escrowAddress.toLowerCase()) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `ERC-3009 to ${data.to} != escrowAddress ${args.escrowAddress}`,
+    };
+  }
+  const domain = await fetchTokenDomain(args.publicClient, args.asset, args.chainId);
+  const signature = packRsv(data.r as Hex, data.s as Hex, data.v);
+  let recovered: Address;
+  try {
+    recovered = await recoverErc3009Signer({
+      domain,
+      message: {
+        from: data.from as `0x${string}`,
+        to: data.to as `0x${string}`,
+        value: BigInt(data.value),
+        validAfter: BigInt(data.validAfter),
+        validBefore: BigInt(data.validBefore),
+        nonce: data.nonce as `0x${string}`,
+      },
+      signature: signature as `0x${string}`,
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason:
+        e instanceof Error ? `ERC-3009 recovery failed: ${e.message}` : "ERC-3009 recovery failed",
+    };
+  }
+  if (recovered.toLowerCase() !== args.buyer.toLowerCase()) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `ERC-3009 recovered signer ${recovered} != payload.buyer ${args.buyer}`,
+    };
+  }
+  return { ok: true };
+}
+
+async function verifyPermit(
+  args: VerifyTokenAuthSignatureArgs,
+  data: Extract<BosonTokenAuth, { kind: "permit" }>["data"],
+): Promise<StepResult> {
+  if (data.v !== 27 && data.v !== 28) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `EIP-2612 Permit signature v must be 27 or 28, got ${data.v}`,
+    };
+  }
+  if (data.owner.toLowerCase() !== args.buyer.toLowerCase()) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `Permit owner ${data.owner} != payload.buyer ${args.buyer}`,
+    };
+  }
+  if (data.spender.toLowerCase() !== args.escrowAddress.toLowerCase()) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `Permit spender ${data.spender} != escrowAddress ${args.escrowAddress}`,
+    };
+  }
+  const domain = await fetchTokenDomain(args.publicClient, args.asset, args.chainId);
+  const signature = packRsv(data.r as Hex, data.s as Hex, data.v);
+  let recovered: Address;
+  try {
+    recovered = await recoverPermitSigner({
+      domain,
+      message: {
+        owner: data.owner as `0x${string}`,
+        spender: data.spender as `0x${string}`,
+        value: BigInt(data.value),
+        nonce: BigInt(data.nonce),
+        deadline: BigInt(data.deadline),
+      },
+      signature: signature as `0x${string}`,
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason:
+        e instanceof Error ? `Permit recovery failed: ${e.message}` : "Permit recovery failed",
+    };
+  }
+  if (recovered.toLowerCase() !== args.buyer.toLowerCase()) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `Permit recovered signer ${recovered} != payload.buyer ${args.buyer}`,
+    };
+  }
+  return { ok: true };
+}
+
+async function verifyPermit2(
+  args: VerifyTokenAuthSignatureArgs,
+  data: Extract<BosonTokenAuth, { kind: "permit2" }>["data"],
+): Promise<StepResult> {
+  if (data.permitted.token.toLowerCase() !== args.asset.toLowerCase()) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `Permit2 permitted.token ${data.permitted.token} != requirements.asset ${args.asset}`,
+    };
+  }
+  if (data.spender.toLowerCase() !== args.escrowAddress.toLowerCase()) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `Permit2 spender ${data.spender} != escrowAddress ${args.escrowAddress}`,
+    };
+  }
+  let recovered: Address;
+  try {
+    recovered = await recoverPermit2Signer({
+      chainId: args.chainId,
+      message: {
+        permitted: {
+          token: data.permitted.token as `0x${string}`,
+          amount: BigInt(data.permitted.amount),
+        },
+        spender: data.spender as `0x${string}`,
+        nonce: BigInt(data.nonce),
+        deadline: BigInt(data.deadline),
+      },
+      signature: data.signature as `0x${string}`,
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason:
+        e instanceof Error ? `Permit2 recovery failed: ${e.message}` : "Permit2 recovery failed",
+    };
+  }
+  if (recovered.toLowerCase() !== args.buyer.toLowerCase()) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `Permit2 recovered signer ${recovered} != payload.buyer ${args.buyer}`,
+    };
+  }
+  return { ok: true };
+}

--- a/typescript/packages/facilitator/src/verify/token-auth-signature.ts
+++ b/typescript/packages/facilitator/src/verify/token-auth-signature.ts
@@ -137,6 +137,19 @@ export async function verifyTokenAuthSignature(
       return verifyPermit(args, args.tokenAuth.data);
     case "permit2":
       return verifyPermit2(args, args.tokenAuth.data);
+    default: {
+      // Compile-time exhaustiveness check: a new `kind` added to the
+      // `BosonTokenAuth` discriminated union without updating this
+      // switch will break this `never` assignment, forcing the new
+      // strategy to grow a matching `verifyXxx` helper here.
+      const _exhaustive: never = args.tokenAuth;
+      void _exhaustive;
+      return {
+        ok: false,
+        code: "INVALID_PAYLOAD",
+        reason: `unsupported tokenAuth.kind: ${(args.tokenAuth as { kind: string }).kind}`,
+      };
+    }
   }
 }
 
@@ -349,6 +362,16 @@ function validateDeadlineWindow(
   label: string,
 ): StepResult {
   const nowSeconds = Math.floor(Date.now() / 1000);
+  // Reject already-expired deadlines before checking the future-window —
+  // an expired signature should never reach the on-chain simulation,
+  // where it would surface as a less-actionable SIMULATION_REVERT.
+  if (deadlineSeconds <= nowSeconds) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `${label} has already expired (deadline ${deadlineSeconds} <= now ${nowSeconds})`,
+    };
+  }
   if (deadlineSeconds - nowSeconds > maxTimeoutSeconds) {
     return {
       ok: false,

--- a/typescript/packages/facilitator/src/verify/token-auth-signature.ts
+++ b/typescript/packages/facilitator/src/verify/token-auth-signature.ts
@@ -29,6 +29,10 @@ export interface VerifyTokenAuthSignatureArgs {
   chainId: number;
   /** Asset (ERC-20 token) address from the requirements. */
   asset: Address;
+  /** Expected token amount from the requirements, in atomic units. */
+  amount: string;
+  /** Maximum allowed validity window, in seconds. */
+  maxTimeoutSeconds: number;
   /** Buyer EOA from the payload — the recovered signer must match this. */
   buyer: Address;
   /** Boson escrow (Diamond) address — the expected `to` / `spender`. */
@@ -162,6 +166,16 @@ async function verifyErc3009(
       reason: `ERC-3009 to ${data.to} != escrowAddress ${args.escrowAddress}`,
     };
   }
+  if (data.value !== args.amount) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `ERC-3009 value ${data.value} != requirements.amount ${args.amount}`,
+    };
+  }
+  const timeout = validateDeadlineWindow(data.validBefore, args.maxTimeoutSeconds, "ERC-3009 validBefore");
+  if (!timeout.ok) return timeout;
+
   const domain = await fetchTokenDomain(args.publicClient, args.asset, args.chainId);
   const signature = packRsv(data.r as Hex, data.s as Hex, data.v);
   let recovered: Address;
@@ -221,6 +235,16 @@ async function verifyPermit(
       reason: `Permit spender ${data.spender} != escrowAddress ${args.escrowAddress}`,
     };
   }
+  if (data.value !== args.amount) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `Permit value ${data.value} != requirements.amount ${args.amount}`,
+    };
+  }
+  const timeout = validateDeadlineWindow(data.deadline, args.maxTimeoutSeconds, "Permit deadline");
+  if (!timeout.ok) return timeout;
+
   const domain = await fetchTokenDomain(args.publicClient, args.asset, args.chainId);
   const signature = packRsv(data.r as Hex, data.s as Hex, data.v);
   let recovered: Address;
@@ -272,6 +296,16 @@ async function verifyPermit2(
       reason: `Permit2 spender ${data.spender} != escrowAddress ${args.escrowAddress}`,
     };
   }
+  if (data.permitted.amount !== args.amount) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `Permit2 permitted.amount ${data.permitted.amount} != requirements.amount ${args.amount}`,
+    };
+  }
+  const timeout = validateDeadlineWindow(data.deadline, args.maxTimeoutSeconds, "Permit2 deadline");
+  if (!timeout.ok) return timeout;
+
   let recovered: Address;
   try {
     recovered = await recoverPermit2Signer({
@@ -300,6 +334,18 @@ async function verifyPermit2(
       ok: false,
       code: "BAD_TOKEN_AUTH_SIGNATURE",
       reason: `Permit2 recovered signer ${recovered} != payload.buyer ${args.buyer}`,
+    };
+  }
+  return { ok: true };
+}
+
+function validateDeadlineWindow(deadlineSeconds: number, maxTimeoutSeconds: number, label: string): StepResult {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (deadlineSeconds - nowSeconds > maxTimeoutSeconds) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `${label} exceeds requirements.maxTimeoutSeconds (${maxTimeoutSeconds})`,
     };
   }
   return { ok: true };

--- a/typescript/packages/facilitator/src/verify/token-auth-signature.ts
+++ b/typescript/packages/facilitator/src/verify/token-auth-signature.ts
@@ -20,7 +20,7 @@ import {
   recoverPermit2Signer,
   recoverPermitSigner,
 } from "@bosonprotocol/x402-core/eip712/token-auth";
-import { type PublicClient } from "viem";
+import { ContractFunctionExecutionError, type PublicClient } from "viem";
 
 import { packRsv } from "./meta-tx-signature.js";
 import type { StepResult } from "./structural.js";
@@ -84,7 +84,15 @@ const VERSION_ABI = [
 /**
  * Look up the token's EIP-712 domain. Tries EIP-5267 first (one call,
  * canonical); falls back to `name()` + `version()` (with version
- * defaulting to `"1"` per EIP-2612 if the function reverts).
+ * defaulting to `"1"` per EIP-2612 if `version()` reverts).
+ *
+ * Error handling: only `ContractFunctionExecutionError` is treated as
+ * "method not implemented" and triggers the fallback. RPC / transport
+ * failures (HTTP timeouts, JSON-RPC errors) propagate as-is so the
+ * caller can distinguish them and surface a clear
+ * `INTERNAL_ERROR` rather than a silent fallback that fails again on
+ * the next call. `name()` is required by ERC-20 so any failure there
+ * is a real error and propagates.
  *
  * Exported so tests can inject a mocked PublicClient and so future
  * caching layers can wrap it.
@@ -106,7 +114,13 @@ export async function fetchTokenDomain(
       chainId: Number(result[3]),
       verifyingContract: result[4] as `0x${string}`,
     };
-  } catch {
+  } catch (e) {
+    if (!(e instanceof ContractFunctionExecutionError)) {
+      // Transport / RPC failure — propagate. EIP-5267-not-implemented
+      // would surface as a ContractFunctionExecutionError; anything
+      // else means we couldn't reach the contract at all.
+      throw e;
+    }
     // EIP-5267 not implemented — fall back to name() + version().
   }
   const name = (await publicClient.readContract({
@@ -121,7 +135,10 @@ export async function fetchTokenDomain(
       abi: VERSION_ABI,
       functionName: "version",
     })) as string;
-  } catch {
+  } catch (e) {
+    if (!(e instanceof ContractFunctionExecutionError)) {
+      throw e;
+    }
     // version() is optional per EIP-2612 — keep the default.
   }
   return { name, version, chainId, verifyingContract: token as `0x${string}` };
@@ -206,7 +223,19 @@ async function verifyErc3009(
   );
   if (!timeout.ok) return timeout;
 
-  const domain = await fetchTokenDomain(args.publicClient, args.asset, args.chainId);
+  let domain: TokenEip712Domain;
+  try {
+    domain = await fetchTokenDomain(args.publicClient, args.asset, args.chainId);
+  } catch (e) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      reason:
+        e instanceof Error
+          ? `failed to fetch token EIP-712 domain for ${args.asset}: ${e.message}`
+          : `failed to fetch token EIP-712 domain for ${args.asset}`,
+    };
+  }
   const signature = packRsv(data.r as Hex, data.s as Hex, data.v);
   let recovered: Address;
   try {
@@ -275,7 +304,19 @@ async function verifyPermit(
   const timeout = validateDeadlineWindow(data.deadline, args.maxTimeoutSeconds, "Permit deadline");
   if (!timeout.ok) return timeout;
 
-  const domain = await fetchTokenDomain(args.publicClient, args.asset, args.chainId);
+  let domain: TokenEip712Domain;
+  try {
+    domain = await fetchTokenDomain(args.publicClient, args.asset, args.chainId);
+  } catch (e) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      reason:
+        e instanceof Error
+          ? `failed to fetch token EIP-712 domain for ${args.asset}: ${e.message}`
+          : `failed to fetch token EIP-712 domain for ${args.asset}`,
+    };
+  }
   const signature = packRsv(data.r as Hex, data.s as Hex, data.v);
   let recovered: Address;
   try {

--- a/typescript/packages/facilitator/src/verify/token-auth-signature.ts
+++ b/typescript/packages/facilitator/src/verify/token-auth-signature.ts
@@ -173,7 +173,11 @@ async function verifyErc3009(
       reason: `ERC-3009 value ${data.value} != requirements.amount ${args.amount}`,
     };
   }
-  const timeout = validateDeadlineWindow(data.validBefore, args.maxTimeoutSeconds, "ERC-3009 validBefore");
+  const timeout = validateDeadlineWindow(
+    data.validBefore,
+    args.maxTimeoutSeconds,
+    "ERC-3009 validBefore",
+  );
   if (!timeout.ok) return timeout;
 
   const domain = await fetchTokenDomain(args.publicClient, args.asset, args.chainId);
@@ -339,7 +343,11 @@ async function verifyPermit2(
   return { ok: true };
 }
 
-function validateDeadlineWindow(deadlineSeconds: number, maxTimeoutSeconds: number, label: string): StepResult {
+function validateDeadlineWindow(
+  deadlineSeconds: number,
+  maxTimeoutSeconds: number,
+  label: string,
+): StepResult {
   const nowSeconds = Math.floor(Date.now() / 1000);
   if (deadlineSeconds - nowSeconds > maxTimeoutSeconds) {
     return {

--- a/typescript/packages/facilitator/src/verify/token-auth-signature.ts
+++ b/typescript/packages/facilitator/src/verify/token-auth-signature.ts
@@ -186,6 +186,19 @@ async function verifyErc3009(
       reason: `ERC-3009 value ${data.value} != requirements.amount ${args.amount}`,
     };
   }
+  // EIP-3009 requires `block.timestamp > validAfter` AND
+  // `block.timestamp < validBefore` (both strict). The contract reverts
+  // on the boundary cases — flag them upfront in verify so callers get
+  // BAD_TOKEN_AUTH_SIGNATURE rather than a less actionable
+  // SIMULATION_REVERT.
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (data.validAfter >= nowSeconds) {
+    return {
+      ok: false,
+      code: "BAD_TOKEN_AUTH_SIGNATURE",
+      reason: `ERC-3009 validAfter ${data.validAfter} is not yet active (now ${nowSeconds}); EIP-3009 requires now > validAfter`,
+    };
+  }
   const timeout = validateDeadlineWindow(
     data.validBefore,
     args.maxTimeoutSeconds,

--- a/typescript/packages/facilitator/test/stubs.test.ts
+++ b/typescript/packages/facilitator/test/stubs.test.ts
@@ -4,28 +4,20 @@ import {
   NotImplementedError,
   performAction,
   settle,
-  verify,
   type FacilitatorConfig,
   type FacilitatorPerformActionInput,
   type FacilitatorSettleInput,
-  type FacilitatorVerifyInput,
 } from "../src/index.js";
 
-// The v0.1 stubs never read these inputs — they throw immediately. Cast
-// through unknown so the test doesn't drag the full viem WalletClient /
+// settle() and performAction() remain stubs in this commit — they throw
+// NotImplementedError until later commits wire them up. Cast through
+// unknown so the test doesn't drag the full viem WalletClient /
 // PublicClient surface into a contract that's checked elsewhere.
 const dummyConfig = {} as unknown as FacilitatorConfig;
-const dummyVerifyInput = {} as unknown as FacilitatorVerifyInput;
 const dummySettleInput = {} as unknown as FacilitatorSettleInput;
 const dummyPerformActionInput = {} as unknown as FacilitatorPerformActionInput;
 
 describe("v0.1 stubs throw NotImplementedError", () => {
-  it("verify() rejects with NotImplementedError and code NOT_IMPLEMENTED", async () => {
-    const promise = verify(dummyVerifyInput, dummyConfig);
-    await expect(promise).rejects.toBeInstanceOf(NotImplementedError);
-    await expect(promise).rejects.toMatchObject({ code: "NOT_IMPLEMENTED" });
-  });
-
   it("settle() rejects with NotImplementedError and code NOT_IMPLEMENTED", async () => {
     const promise = settle(dummySettleInput, dummyConfig);
     await expect(promise).rejects.toBeInstanceOf(NotImplementedError);

--- a/typescript/packages/facilitator/test/verify.test.ts
+++ b/typescript/packages/facilitator/test/verify.test.ts
@@ -449,6 +449,39 @@ describe("verify()", () => {
     expect((result as { ok: false; reason: string }).reason).toContain("expired");
   });
 
+  it("rejects ERC-3009 token-auth when validAfter is in the future", async () => {
+    const payload = await buildValidPayload();
+    payload.payload.tokenAuthStrategy = "erc3009";
+    // EIP-3009 requires `block.timestamp > validAfter` strictly; a
+    // future validAfter means the authorization isn't active yet and
+    // the on-chain transferWithAuthorization call would revert. Catch
+    // it in verify so callers get BAD_TOKEN_AUTH_SIGNATURE instead of
+    // letting it slip through to simulation. The validAfter check
+    // fires before signature recovery, so this test can use placeholder
+    // r/s/v without setting up a real ERC-3009 sign flow.
+    payload.payload.tokenAuth = {
+      kind: "erc3009",
+      data: {
+        from: buyer.address,
+        to: ESCROW,
+        value: "1000000",
+        validAfter: Math.floor(Date.now() / 1000) + 3600,
+        validBefore: Math.floor(Date.now() / 1000) + 7200,
+        nonce: `0x${"00".repeat(32)}`,
+        v: 27,
+        r: `0x${"aa".repeat(32)}`,
+        s: `0x${"bb".repeat(32)}`,
+      },
+    };
+    const requirements = { ...buildValidRequirements(), tokenAuthStrategies: ["erc3009" as const] };
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "BAD_TOKEN_AUTH_SIGNATURE" });
+    expect((result as { ok: false; reason: string }).reason).toMatch(/validAfter|not yet/i);
+  });
+
   it("returns UNSUPPORTED_TOKEN_AUTH_STRATEGY for valid token-auth while BPIP-12 simulation is deferred", async () => {
     const payload = await buildValidPayload();
     payload.payload.tokenAuthStrategy = "permit2";

--- a/typescript/packages/facilitator/test/verify.test.ts
+++ b/typescript/packages/facilitator/test/verify.test.ts
@@ -1,8 +1,10 @@
 import { metaTransactionTypedData } from "@bosonprotocol/x402-core/eip712";
+import { permit2TypedData } from "@bosonprotocol/x402-core/eip712/token-auth";
 import type {
   EscrowPaymentPayload,
   EscrowPaymentRequirements,
 } from "@bosonprotocol/x402-core/schemes/escrow";
+import { buildCreateOfferAndCommitCalldata } from "@bosonprotocol/x402-evm/actions";
 import { describe, expect, it } from "vitest";
 import { parseSignature, type Address, type Hex, type PublicClient, type WalletClient } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
@@ -20,12 +22,58 @@ const ESCROW: Address = "0xdddddddddddddddddddddddddddddddddddddddd";
 const ASSET: Address = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 const CHAIN_ID = 1;
 const NETWORK = `eip155:${CHAIN_ID}`;
-const FUNCTION_NAME = "createOfferAndCommit(...)";
-const FUNCTION_SIGNATURE: Hex = "0xdeadbeef";
 const NONCE = "1";
+const SELLER: Address = "0x1111111111111111111111111111111111111111";
+const SELLER_SIG: Hex = `0x${"33".repeat(65)}`;
+const AMOUNT = "1000000";
+
+const fullOffer = {
+  price: AMOUNT,
+  sellerDeposit: "0",
+  agentId: "0",
+  buyerCancelPenalty: "0",
+  quantityAvailable: "1",
+  validFromDateInMS: "1900000000000",
+  validUntilDateInMS: "1900003600000",
+  voucherRedeemableFromDateInMS: "1900000000000",
+  voucherRedeemableUntilDateInMS: "1900003600000",
+  disputePeriodDurationInMS: "86400000",
+  voucherValidDurationInMS: "0",
+  resolutionPeriodDurationInMS: "604800000",
+  exchangeToken: ASSET,
+  disputeResolverId: "1",
+  metadataUri: "ipfs://QmDeadBeef",
+  metadataHash: "QmDeadBeef",
+  collectionIndex: "0",
+  feeLimit: "0",
+  offerCreator: SELLER,
+  committer: buyer.address,
+  condition: {
+    method: 0,
+    tokenType: 0,
+    tokenAddress: "0x0000000000000000000000000000000000000000",
+    gatingType: 0,
+    minTokenId: "0",
+    threshold: "0",
+    maxCommits: "0",
+    maxTokenId: "0",
+  },
+  useDepositedFunds: false,
+  signature: SELLER_SIG,
+  sellerId: "12345",
+  buyerId: "0",
+  sellerOfferParams: {
+    collectionIndex: "0",
+    royaltyInfo: { recipients: [], bps: [] },
+    mutualizerAddress: "0x0000000000000000000000000000000000000000",
+  },
+};
 
 /** Build a fully-signed EscrowPaymentPayload for `tokenAuthStrategy: "none"`. */
 async function buildValidPayload(): Promise<EscrowPaymentPayload> {
+  const calldata = buildCreateOfferAndCommitCalldata({
+    fullOffer: fullOffer as Parameters<typeof buildCreateOfferAndCommitCalldata>[0]["fullOffer"],
+  });
   const typedData = await metaTransactionTypedData({
     chainId: CHAIN_ID,
     verifyingContract: ESCROW,
@@ -33,8 +81,8 @@ async function buildValidPayload(): Promise<EscrowPaymentPayload> {
       nonce: BigInt(NONCE),
       from: buyer.address,
       contractAddress: ESCROW,
-      functionName: FUNCTION_NAME,
-      functionSignature: FUNCTION_SIGNATURE,
+      functionName: calldata.functionName,
+      functionSignature: calldata.functionSignature,
     },
   });
   const sig = await buyer.signTypedData({
@@ -55,13 +103,13 @@ async function buildValidPayload(): Promise<EscrowPaymentPayload> {
     payload: {
       action: "boson-createOfferAndCommit",
       tokenAuthStrategy: "none",
-      offerRef: { fullOffer: {}, sellerSig: "0x00" },
+      offerRef: { fullOffer, sellerSig: SELLER_SIG },
       buyer: buyer.address,
       metaTx: {
         from: buyer.address,
         nonce: NONCE,
-        functionName: FUNCTION_NAME,
-        functionSignature: FUNCTION_SIGNATURE,
+        functionName: calldata.functionName,
+        functionSignature: calldata.functionSignature,
         sig: { v, r: parsed.r, s: parsed.s },
       },
     },
@@ -74,14 +122,14 @@ function buildValidRequirements(): EscrowPaymentRequirements {
     scheme: "escrow",
     network: NETWORK,
     asset: ASSET,
-    amount: "1000000",
+    amount: AMOUNT,
     escrowAddress: ESCROW,
     recipientId: "did:boson:seller:42",
     maxTimeoutSeconds: 3600,
     offer: {
-      fullOffer: {},
-      sellerSig: "0x00",
-      creator: "0x1111111111111111111111111111111111111111",
+      fullOffer,
+      sellerSig: SELLER_SIG,
+      creator: SELLER,
     },
     tokenAuthStrategies: ["none"],
     actions: {
@@ -126,6 +174,27 @@ function buildConfig(opts: { client?: PublicClient } = {}): FacilitatorConfig {
     supportedNetworks: [NETWORK],
     walletClient,
     publicClient: opts.client ?? buildPublicClient({ callBehavior: "pass" }),
+  };
+}
+
+async function buildValidPermit2TokenAuth(deadline: number = Math.floor(Date.now() / 1000) + 300) {
+  const message = {
+    permitted: { token: ASSET, amount: BigInt(AMOUNT) },
+    spender: ESCROW,
+    nonce: 0n,
+    deadline: BigInt(deadline),
+  };
+  const typedData = permit2TypedData({ chainId: CHAIN_ID, message });
+  const signature = await buyer.signTypedData(typedData);
+  return {
+    kind: "permit2" as const,
+    data: {
+      permitted: { token: ASSET, amount: AMOUNT },
+      spender: ESCROW,
+      nonce: "0",
+      deadline,
+      signature,
+    },
   };
 }
 
@@ -187,6 +256,28 @@ describe("verify()", () => {
       buildConfig(),
     );
     expect(result).toMatchObject({ ok: false, code: "TOKEN_AUTH_NOT_IN_REQUIREMENTS" });
+  });
+
+  it("rejects when payload.offerRef does not match requirements.offer", async () => {
+    const payload = await buildValidPayload();
+    payload.payload.offerRef.fullOffer = { ...fullOffer, price: "2" };
+    const requirements = buildValidRequirements();
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "INVALID_PAYLOAD" });
+  });
+
+  it("rejects when meta-tx calldata does not encode the required offer", async () => {
+    const payload = await buildValidPayload();
+    payload.payload.metaTx.functionSignature = "0xdeadbeef";
+    const requirements = buildValidRequirements();
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "INVALID_PAYLOAD" });
   });
 
   it("rejects when meta-tx signature was produced by a different signer", async () => {
@@ -270,5 +361,44 @@ describe("verify()", () => {
       buildConfig(),
     );
     expect(result).toMatchObject({ ok: false, code: "INVALID_PAYLOAD" });
+  });
+
+  it("rejects token-auth when the signed amount does not match requirements.amount", async () => {
+    const payload = await buildValidPayload();
+    payload.payload.tokenAuthStrategy = "permit2";
+    payload.payload.tokenAuth = await buildValidPermit2TokenAuth();
+    payload.payload.tokenAuth.data.permitted.amount = "1";
+    const requirements = { ...buildValidRequirements(), tokenAuthStrategies: ["permit2" as const] };
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "BAD_TOKEN_AUTH_SIGNATURE" });
+  });
+
+  it("rejects token-auth when the deadline exceeds maxTimeoutSeconds", async () => {
+    const payload = await buildValidPayload();
+    payload.payload.tokenAuthStrategy = "permit2";
+    payload.payload.tokenAuth = await buildValidPermit2TokenAuth(
+      Math.floor(Date.now() / 1000) + 7200,
+    );
+    const requirements = { ...buildValidRequirements(), tokenAuthStrategies: ["permit2" as const] };
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "BAD_TOKEN_AUTH_SIGNATURE" });
+  });
+
+  it("returns UNSUPPORTED_TOKEN_AUTH_STRATEGY for valid token-auth while BPIP-12 simulation is deferred", async () => {
+    const payload = await buildValidPayload();
+    payload.payload.tokenAuthStrategy = "permit2";
+    payload.payload.tokenAuth = await buildValidPermit2TokenAuth();
+    const requirements = { ...buildValidRequirements(), tokenAuthStrategies: ["permit2" as const] };
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "UNSUPPORTED_TOKEN_AUTH_STRATEGY" });
   });
 });

--- a/typescript/packages/facilitator/test/verify.test.ts
+++ b/typescript/packages/facilitator/test/verify.test.ts
@@ -6,7 +6,15 @@ import type {
 } from "@bosonprotocol/x402-core/schemes/escrow";
 import { buildCreateOfferAndCommitCalldata } from "@bosonprotocol/x402-evm/actions";
 import { describe, expect, it } from "vitest";
-import { parseSignature, type Address, type Hex, type PublicClient, type WalletClient } from "viem";
+import {
+  BaseError,
+  RawContractError,
+  parseSignature,
+  type Address,
+  type Hex,
+  type PublicClient,
+  type WalletClient,
+} from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 
 import { verify } from "../src/verify/index.js";
@@ -143,21 +151,35 @@ function buildValidRequirements(): EscrowPaymentRequirements {
   };
 }
 
-/** Build a PublicClient stub whose `call` is configurable per test. */
+/**
+ * Build a PublicClient stub whose `call` is configurable per test.
+ *
+ * `callBehavior: "revert"` throws a viem `BaseError` whose cause chain
+ * contains a `RawContractError` — this matches the structure viem
+ * produces for an actual on-chain revert and lets
+ * `simulateExecuteMetaTransaction`'s revert-discrimination logic
+ * recognise the failure as `SIMULATION_REVERT` (rather than
+ * `INTERNAL_ERROR`, which is reserved for transport-layer failures).
+ *
+ * `callBehavior: "rpc-error"` throws a plain `Error` to exercise the
+ * non-revert branch.
+ */
 function buildPublicClient(
   opts: {
-    callBehavior?: "pass" | "revert";
+    callBehavior?: "pass" | "revert" | "rpc-error";
     revertReason?: string;
+    rpcErrorMessage?: string;
   } = {},
 ): PublicClient {
   return {
     call: async () => {
       if (opts.callBehavior === "revert") {
-        const e = new Error("execution reverted: nonce already used") as Error & {
-          shortMessage?: string;
-        };
-        e.shortMessage = opts.revertReason ?? "execution reverted: nonce already used";
-        throw e;
+        const reason = opts.revertReason ?? "execution reverted: nonce already used";
+        const rawRevert = new RawContractError({ message: reason });
+        throw new BaseError("Execution reverted", { cause: rawRevert });
+      }
+      if (opts.callBehavior === "rpc-error") {
+        throw new Error(opts.rpcErrorMessage ?? "ECONNREFUSED: RPC unreachable");
       }
       return { data: "0x" };
     },
@@ -323,6 +345,23 @@ describe("verify()", () => {
     expect((result as { ok: false; reason: string }).reason).toContain("USED_NONCE");
   });
 
+  it("maps RPC / transport failures to INTERNAL_ERROR (not SIMULATION_REVERT)", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const config = buildConfig({
+      client: buildPublicClient({
+        callBehavior: "rpc-error",
+        rpcErrorMessage: "fetch failed: ECONNREFUSED",
+      }),
+    });
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      config,
+    );
+    expect(result).toMatchObject({ ok: false, code: "INTERNAL_ERROR" });
+    expect((result as { ok: false; reason: string }).reason).toContain("ECONNREFUSED");
+  });
+
   it("rejects when input.scheme is wrong", async () => {
     const payload = await buildValidPayload();
     const requirements = buildValidRequirements();
@@ -388,6 +427,26 @@ describe("verify()", () => {
       buildConfig(),
     );
     expect(result).toMatchObject({ ok: false, code: "BAD_TOKEN_AUTH_SIGNATURE" });
+  });
+
+  it("rejects token-auth when the deadline is already in the past", async () => {
+    const payload = await buildValidPayload();
+    payload.payload.tokenAuthStrategy = "permit2";
+    // Sign a permit whose deadline already elapsed. The recovery itself
+    // succeeds (signing is timeless); the past-deadline guard inside
+    // validateDeadlineWindow must catch this in `verify()`, ahead of
+    // any on-chain simulation that would otherwise surface a less
+    // actionable SIMULATION_REVERT.
+    payload.payload.tokenAuth = await buildValidPermit2TokenAuth(
+      Math.floor(Date.now() / 1000) - 60,
+    );
+    const requirements = { ...buildValidRequirements(), tokenAuthStrategies: ["permit2" as const] };
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "BAD_TOKEN_AUTH_SIGNATURE" });
+    expect((result as { ok: false; reason: string }).reason).toContain("expired");
   });
 
   it("returns UNSUPPORTED_TOKEN_AUTH_STRATEGY for valid token-auth while BPIP-12 simulation is deferred", async () => {

--- a/typescript/packages/facilitator/test/verify.test.ts
+++ b/typescript/packages/facilitator/test/verify.test.ts
@@ -482,6 +482,45 @@ describe("verify()", () => {
     expect((result as { ok: false; reason: string }).reason).toMatch(/validAfter|not yet/i);
   });
 
+  it("maps RPC failures during token-domain lookup to INTERNAL_ERROR", async () => {
+    // Drive an ERC-3009 path far enough that fetchTokenDomain runs.
+    // The eip712Domain() / name() / version() reads on the token go
+    // through publicClient.readContract — stub it to throw a plain
+    // Error (not a ContractFunctionExecutionError), which simulates an
+    // RPC transport failure rather than a missing-method revert.
+    // The fix bubbles that through verifyErc3009's wrapper as
+    // INTERNAL_ERROR instead of letting it escape Promise<StepResult>.
+    const payload = await buildValidPayload();
+    payload.payload.tokenAuthStrategy = "erc3009";
+    payload.payload.tokenAuth = {
+      kind: "erc3009",
+      data: {
+        from: buyer.address,
+        to: ESCROW,
+        value: "1000000",
+        validAfter: Math.floor(Date.now() / 1000) - 60,
+        validBefore: Math.floor(Date.now() / 1000) + 600,
+        nonce: `0x${"00".repeat(32)}`,
+        v: 27,
+        r: `0x${"aa".repeat(32)}`,
+        s: `0x${"bb".repeat(32)}`,
+      },
+    };
+    const requirements = { ...buildValidRequirements(), tokenAuthStrategies: ["erc3009" as const] };
+    const rpcFailing = {
+      ...buildPublicClient(),
+      readContract: async () => {
+        throw new Error("ECONNREFUSED: token RPC unreachable");
+      },
+    } as unknown as PublicClient;
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig({ client: rpcFailing }),
+    );
+    expect(result).toMatchObject({ ok: false, code: "INTERNAL_ERROR" });
+    expect((result as { ok: false; reason: string }).reason).toContain("ECONNREFUSED");
+  });
+
   it("returns UNSUPPORTED_TOKEN_AUTH_STRATEGY for valid token-auth while BPIP-12 simulation is deferred", async () => {
     const payload = await buildValidPayload();
     payload.payload.tokenAuthStrategy = "permit2";

--- a/typescript/packages/facilitator/test/verify.test.ts
+++ b/typescript/packages/facilitator/test/verify.test.ts
@@ -1,0 +1,274 @@
+import { metaTransactionTypedData } from "@bosonprotocol/x402-core/eip712";
+import type {
+  EscrowPaymentPayload,
+  EscrowPaymentRequirements,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+import { describe, expect, it } from "vitest";
+import { parseSignature, type Address, type Hex, type PublicClient, type WalletClient } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { verify } from "../src/verify/index.js";
+import type { FacilitatorConfig } from "../src/types.js";
+
+// Fixed test vectors — deterministic across runs.
+const BUYER_PK = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" as const;
+const buyer = privateKeyToAccount(BUYER_PK);
+const RELAYER_PK = "0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210" as const;
+const relayer = privateKeyToAccount(RELAYER_PK);
+
+const ESCROW: Address = "0xdddddddddddddddddddddddddddddddddddddddd";
+const ASSET: Address = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const CHAIN_ID = 1;
+const NETWORK = `eip155:${CHAIN_ID}`;
+const FUNCTION_NAME = "createOfferAndCommit(...)";
+const FUNCTION_SIGNATURE: Hex = "0xdeadbeef";
+const NONCE = "1";
+
+/** Build a fully-signed EscrowPaymentPayload for `tokenAuthStrategy: "none"`. */
+async function buildValidPayload(): Promise<EscrowPaymentPayload> {
+  const typedData = await metaTransactionTypedData({
+    chainId: CHAIN_ID,
+    verifyingContract: ESCROW,
+    message: {
+      nonce: BigInt(NONCE),
+      from: buyer.address,
+      contractAddress: ESCROW,
+      functionName: FUNCTION_NAME,
+      functionSignature: FUNCTION_SIGNATURE,
+    },
+  });
+  const sig = await buyer.signTypedData({
+    domain: typedData.domain,
+    types: typedData.types,
+    primaryType: typedData.primaryType,
+    message: typedData.message,
+  });
+  const parsed = parseSignature(sig);
+  // viem returns v=27/28 only when yParity is set; normalise to 27/28 form
+  // explicitly so the buyer's BosonMetaTx field matches the on-chain
+  // LibSignature.recover expectation.
+  const v = parsed.v !== undefined ? Number(parsed.v) : parsed.yParity === 0 ? 27 : 28;
+  return {
+    x402Version: 1,
+    scheme: "escrow",
+    network: NETWORK,
+    payload: {
+      action: "boson-createOfferAndCommit",
+      tokenAuthStrategy: "none",
+      offerRef: { fullOffer: {}, sellerSig: "0x00" },
+      buyer: buyer.address,
+      metaTx: {
+        from: buyer.address,
+        nonce: NONCE,
+        functionName: FUNCTION_NAME,
+        functionSignature: FUNCTION_SIGNATURE,
+        sig: { v, r: parsed.r, s: parsed.s },
+      },
+    },
+  };
+}
+
+/** Build matching requirements. */
+function buildValidRequirements(): EscrowPaymentRequirements {
+  return {
+    scheme: "escrow",
+    network: NETWORK,
+    asset: ASSET,
+    amount: "1000000",
+    escrowAddress: ESCROW,
+    recipientId: "did:boson:seller:42",
+    maxTimeoutSeconds: 3600,
+    offer: {
+      fullOffer: {},
+      sellerSig: "0x00",
+      creator: "0x1111111111111111111111111111111111111111",
+    },
+    tokenAuthStrategies: ["none"],
+    actions: {
+      next: [
+        {
+          id: "boson-createOfferAndCommit",
+          channels: ["server", "facilitator", "onchain"],
+        },
+      ],
+    },
+  };
+}
+
+/** Build a PublicClient stub whose `call` is configurable per test. */
+function buildPublicClient(
+  opts: {
+    callBehavior?: "pass" | "revert";
+    revertReason?: string;
+  } = {},
+): PublicClient {
+  return {
+    call: async () => {
+      if (opts.callBehavior === "revert") {
+        const e = new Error("execution reverted: nonce already used") as Error & {
+          shortMessage?: string;
+        };
+        e.shortMessage = opts.revertReason ?? "execution reverted: nonce already used";
+        throw e;
+      }
+      return { data: "0x" };
+    },
+    readContract: async () => {
+      throw new Error("readContract not stubbed");
+    },
+  } as unknown as PublicClient;
+}
+
+function buildConfig(opts: { client?: PublicClient } = {}): FacilitatorConfig {
+  const walletClient = { account: { address: relayer.address } } as unknown as WalletClient;
+  return {
+    url: "https://facilitator.example",
+    supportedNetworks: [NETWORK],
+    walletClient,
+    publicClient: opts.client ?? buildPublicClient({ callBehavior: "pass" }),
+  };
+}
+
+describe("verify()", () => {
+  it("happy path: structurally-valid payload with valid meta-tx signature + passing simulation", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects when network is not in supportedNetworks", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const config = buildConfig();
+    const result = await verify(
+      { scheme: "escrow", network: "eip155:137", payload, requirements },
+      { ...config, supportedNetworks: [NETWORK] },
+    );
+    expect(result).toMatchObject({ ok: false, code: "NETWORK_MISMATCH" });
+  });
+
+  it("rejects when input.network does not match payload.network", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const result = await verify(
+      {
+        scheme: "escrow",
+        network: NETWORK,
+        payload: { ...payload, network: "eip155:137" },
+        requirements,
+      },
+      { ...buildConfig(), supportedNetworks: [NETWORK, "eip155:137"] },
+    );
+    expect(result).toMatchObject({ ok: false, code: "NETWORK_MISMATCH" });
+  });
+
+  it("rejects when payload.action is not in requirements.actions.next[].id", async () => {
+    const payload = await buildValidPayload();
+    const requirements = {
+      ...buildValidRequirements(),
+      actions: { next: [{ id: "boson-redeem", channels: ["server" as const] }] },
+    };
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "ACTION_NOT_IN_REQUIREMENTS" });
+  });
+
+  it("rejects when payload.tokenAuthStrategy is not in requirements.tokenAuthStrategies", async () => {
+    const payload = await buildValidPayload();
+    const requirements = { ...buildValidRequirements(), tokenAuthStrategies: ["permit" as const] };
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "TOKEN_AUTH_NOT_IN_REQUIREMENTS" });
+  });
+
+  it("rejects when meta-tx signature was produced by a different signer", async () => {
+    const payload = await buildValidPayload();
+    // Pretend a different EOA is the claimed buyer — recovery will then
+    // mismatch the payload.buyer.
+    const wrongBuyer: Address = "0xabcdef1234567890abcdef1234567890abcdef12";
+    payload.payload.buyer = wrongBuyer;
+    payload.payload.metaTx.from = wrongBuyer;
+    const requirements = buildValidRequirements();
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "BAD_META_TX_SIGNATURE" });
+  });
+
+  it("rejects when meta-tx signature v is not 27/28", async () => {
+    const payload = await buildValidPayload();
+    payload.payload.metaTx.sig.v = 0;
+    const requirements = buildValidRequirements();
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "BAD_META_TX_SIGNATURE" });
+  });
+
+  it("rejects when simulation reverts", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const config = buildConfig({
+      client: buildPublicClient({
+        callBehavior: "revert",
+        revertReason: "execution reverted: USED_NONCE",
+      }),
+    });
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      config,
+    );
+    expect(result).toMatchObject({ ok: false, code: "SIMULATION_REVERT" });
+    expect((result as { ok: false; reason: string }).reason).toContain("USED_NONCE");
+  });
+
+  it("rejects when input.scheme is wrong", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const result = await verify(
+      // Cast through unknown to bypass the type guard — exercising the
+      // runtime check for callers that bypass TS.
+      {
+        scheme: "exact",
+        network: NETWORK,
+        payload,
+        requirements,
+      } as unknown as Parameters<typeof verify>[0],
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "SCHEME_MISMATCH" });
+  });
+
+  it("rejects when tokenAuth is present but strategy is 'none'", async () => {
+    const payload = await buildValidPayload();
+    payload.payload.tokenAuth = {
+      kind: "permit",
+      data: {
+        owner: buyer.address,
+        spender: ESCROW,
+        value: "100",
+        deadline: 9999999999,
+        nonce: "0",
+        v: 27,
+        r: "0x00",
+        s: "0x00",
+      },
+    };
+    const requirements = buildValidRequirements();
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "INVALID_PAYLOAD" });
+  });
+});


### PR DESCRIPTION
## Summary

Wires up `@bosonprotocol/x402-facilitator`'s `verify()` library function — the `POST /verify` half of `docs/boson-impl-07-facilitator.md`'s contract.

The orchestrator runs a sequence of cheap-first checks; each step returns a discriminated `StepResult` and the orchestrator returns on the first failure with a stable `FacilitatorErrorCode` and human-readable `reason`:

1. **supportedNetworks gate** — relayer must be provisioned for the requested chain (`NETWORK_MISMATCH`).
2. **Structural validation** — payload + requirements parsed against the canonical Zod schemas in `@bosonprotocol/x402-core/schemes/escrow` (`INVALID_PAYLOAD`).
3. **Scheme** — input.scheme === payload.scheme === `"escrow"` (`SCHEME_MISMATCH`).
4. **Three-way network match** across input / payload / requirements (`NETWORK_MISMATCH`).
5. **Action presence** — `payload.action ∈ requirements.actions.next[].id` (`ACTION_NOT_IN_REQUIREMENTS`).
6. **Token-auth strategy presence + cross-field** — strategy advertised by the seller; `tokenAuth` present iff strategy ≠ `"none"`; `tokenAuth.kind` matches `tokenAuthStrategy` (`TOKEN_AUTH_NOT_IN_REQUIREMENTS` / `INVALID_PAYLOAD`).
7. **Offer / calldata consistency** — the inner meta-tx calldata is checked against the advertised `FullOffer` so a seller can't be tricked into committing buyers to a different offer than the one they signed.
8. **EIP-712 meta-tx signature recovery** — `metaTransactionTypedData()` from `@bosonprotocol/x402-core/eip712` + viem's `recoverTypedDataAddress`; `v ∈ {27, 28}` enforced upfront (`BAD_META_TX_SIGNATURE`).
9. **Token-auth signature recovery** for ERC-3009 / EIP-2612 Permit / Permit2 variants, looking up each token's EIP-712 domain via EIP-5267 with a `name()` / `version()` fallback. Includes amount / deadline / spender / recipient cross-field assertions (`BAD_TOKEN_AUTH_SIGNATURE`).
10. **On-chain simulation pre-flight** via `publicClient.call` against the `executeMetaTransaction(...)` envelope built by `@bosonprotocol/x402-evm/envelope` — surfaces protocol-level reverts (duplicate nonce, expired auth, insufficient allowance, paused contract, …) as `SIMULATION_REVERT` without consuming gas.

Adds `@bosonprotocol/x402-evm` to the runtime deps (for the envelope builder used during simulation).

The BPIP-12 token-auth queue path (`erc3009` / `permit` / `permit2` in `settle`) is still handled by `@bosonprotocol/x402-evm`'s deferred `NotYetSupportedError` stub; `verify()` itself fully validates the buyer's token-auth signature for all four strategies — only on-chain dispatch is gated.

Spec: [`docs/boson-impl-07-facilitator.md`](./docs/boson-impl-07-facilitator.md) §"Endpoints".

## Test plan

- [ ] `pnpm install`
- [ ] `pnpm build` — workspace builds clean
- [ ] `pnpm test` — 27 facilitator tests pass (types, channels, stubs, verify) plus all upstream packages green
- [ ] `pnpm lint` — zero warnings
- [ ] `pnpm format:check` — clean
- [ ] Verify failure-code coverage in `test/verify.test.ts`: every `FacilitatorErrorCode` reachable from `verify()` has at least one test exercising it

Stacked on top of PR #34 (now merged into main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Facilitator v0.1: /verify implemented — full pre‑flight for escrow transactions with structural checks, offer/meta‑tx consistency, signature and token‑auth verification (multiple strategies), and an on‑chain simulation that surfaces protocol reverts without gas.

* **Documentation**
  * Docs and README updated to reflect v0.1 status; settle() and performAction() remain relayer stubs (NotImplemented).

* **Tests**
  * Deterministic tests added for happy path and many failure scenarios of the verify flow.

* **Chores**
  * Package dependency ordering updated and an EVM helper dependency added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/35)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->