### PR TITLE
feat(x402-server): scaffold package, 402 builder, FullOffer signer

### DIFF
--- a/.changeset/scaffold-x402-server-package.md
+++ b/.changeset/scaffold-x402-server-package.md
@@ -1,0 +1,8 @@
+---
+"@bosonprotocol/x402-server": minor
+---
+
+Initial `@bosonprotocol/x402-server` package: ships the request-side
+402 challenge builder, seller FullOffer signer hook, server config
+validation, and `createX402bServer` factory for building escrow payment
+requirements with initial next-actions.

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ coverage/
 
 # misc
 .pnpm-store/
+
+# claude worktrees — ephemeral, never committed
+.claude/worktrees/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,12 @@ importers:
 
   typescript/packages/x402-server:
     dependencies:
+      '@bosonprotocol/common':
+        specifier: ^1.32.2
+        version: 1.32.2
+      '@bosonprotocol/core-sdk':
+        specifier: 1.47.1-alpha.0
+        version: 1.47.1-alpha.0
       '@bosonprotocol/x402-actions':
         specifier: workspace:^
         version: link:../actions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,34 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
 
+  typescript/packages/x402-server:
+    dependencies:
+      '@bosonprotocol/x402-actions':
+        specifier: workspace:^
+        version: link:../actions
+      '@bosonprotocol/x402-core':
+        specifier: workspace:^
+        version: link:../core
+      viem:
+        specifier: ^2.39.3
+        version: 2.48.11(typescript@5.9.3)(zod@3.25.76)
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.10
+        version: 20.19.40
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.40)
+
 packages:
 
   '@adraffy/ens-normalize@1.10.1':

--- a/typescript/packages/x402-server/LICENSE
+++ b/typescript/packages/x402-server/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Boson Protocol
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/typescript/packages/x402-server/README.md
+++ b/typescript/packages/x402-server/README.md
@@ -1,0 +1,65 @@
+# @bosonprotocol/x402-server
+
+Framework-agnostic resource-server SDK for the Boson Protocol
+[`escrow`](https://github.com/bosonprotocol/x402-escrow-schema) scheme — the
+server side of [x402B](https://github.com/bosonprotocol/x402B).
+
+See [`docs/boson-impl-05-server-sdk.md`](../../../docs/boson-impl-05-server-sdk.md)
+for the spec and [`docs/boson-impl-01-escrow-scheme.md`](../../../docs/boson-impl-01-escrow-scheme.md)
+for the wire format.
+
+## Status
+
+**Pre-release.** v0.1 ships only the request-side primitives — the 402
+challenge builder, the seller FullOffer signer hook, and the
+`createX402bServer` factory that binds them together. Follow-up PRs add:
+
+- the `X-PAYMENT` 13-rule validator,
+- the facilitator HTTP client (talks to `@bosonprotocol/x402-facilitator`),
+- the convenience handlers (`commit-and-redeem`, `complete`, `dispute/*`),
+- a framework adapter (`@bosonprotocol/x402-server-express`).
+
+## Install
+
+```sh
+pnpm add @bosonprotocol/x402-server @bosonprotocol/x402-core @bosonprotocol/x402-actions
+```
+
+## Quick start
+
+```ts
+import { createX402bServer } from "@bosonprotocol/x402-server";
+import { buildChannelRegistry } from "@bosonprotocol/x402-actions";
+import { privateKeyToAccount } from "viem/accounts";
+
+const sellerAssistant = privateKeyToAccount(process.env.SELLER_PK as `0x${string}`);
+
+const server = createX402bServer({
+  network: "eip155:8453",
+  chainId: 8453,
+  escrow: "0xDIAMOND...",
+  signer: sellerAssistant,
+  facilitator: { url: "https://facilitator.example" },
+  channelRegistry: buildChannelRegistry({
+    channels: ["server", "facilitator", "onchain", "mcp"],
+    escrow: "0xDIAMOND...",
+    mcp: "boson://seller/12345",
+  }),
+});
+
+const requirements = await server.buildPaymentRequirements({
+  offer: { unsigned: { /* UnsignedFullOffer */ } },
+  asset: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913", // USDC on Base
+  amount: "1000000", // 1 USDC (6 decimals)
+  tokenAuthStrategies: ["erc3009"],
+  recipientId: "did:boson:seller:12345",
+  maxTimeoutSeconds: 300,
+});
+```
+
+`requirements` is an `EscrowPaymentRequirements` ready to embed in a
+402 response's `accepts[]` array.
+
+## License
+
+[Apache-2.0](./LICENSE)

--- a/typescript/packages/x402-server/README.md
+++ b/typescript/packages/x402-server/README.md
@@ -48,7 +48,7 @@ const server = createX402bServer({
 });
 
 const requirements = await server.buildPaymentRequirements({
-  offer: { unsigned: { /* UnsignedFullOffer */ } },
+  offer: { unsigned: { /* UnsignedFullOffer — see `@bosonprotocol/x402-core/eip712` */ } },
   asset: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913", // USDC on Base
   amount: "1000000", // 1 USDC (6 decimals)
   tokenAuthStrategies: ["erc3009"],

--- a/typescript/packages/x402-server/package.json
+++ b/typescript/packages/x402-server/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@bosonprotocol/x402-server",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "description": "Framework-agnostic x402 resource-server SDK for the Boson Protocol escrow scheme — 402 challenge builder, FullOffer signer hook, X-PAYMENT validator, and facilitator HTTP client.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bosonprotocol/x402B.git",
+    "directory": "typescript/packages/x402-server"
+  },
+  "homepage": "https://github.com/bosonprotocol/x402B/tree/main/typescript/packages/x402-server",
+  "bugs": {
+    "url": "https://github.com/bosonprotocol/x402B/issues"
+  },
+  "keywords": [
+    "x402",
+    "boson-protocol",
+    "escrow",
+    "server",
+    "sdk",
+    "402"
+  ],
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/cjs/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./challenge": {
+      "types": "./dist/cjs/challenge/index.d.ts",
+      "import": "./dist/esm/challenge/index.js",
+      "require": "./dist/cjs/challenge/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup && node scripts/postbuild.mjs",
+    "test": "vitest run --passWithNoTests",
+    "lint": "eslint src --max-warnings 0",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@bosonprotocol/x402-actions": "workspace:^",
+    "@bosonprotocol/x402-core": "workspace:^",
+    "viem": "^2.39.3",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.10",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/typescript/packages/x402-server/package.json
+++ b/typescript/packages/x402-server/package.json
@@ -2,7 +2,7 @@
   "name": "@bosonprotocol/x402-server",
   "version": "0.1.0",
   "license": "Apache-2.0",
-  "description": "Framework-agnostic x402 resource-server SDK for the Boson Protocol escrow scheme — 402 challenge builder, FullOffer signer hook, X-PAYMENT validator, and facilitator HTTP client.",
+  "description": "Framework-agnostic x402 resource-server SDK for the Boson Protocol escrow scheme — 402 challenge builder and FullOffer signer hook.",
   "repository": {
     "type": "git",
     "url": "https://github.com/bosonprotocol/x402B.git",

--- a/typescript/packages/x402-server/package.json
+++ b/typescript/packages/x402-server/package.json
@@ -50,6 +50,8 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
+    "@bosonprotocol/common": "^1.32.2",
+    "@bosonprotocol/core-sdk": "1.47.1-alpha.0",
     "@bosonprotocol/x402-actions": "workspace:^",
     "@bosonprotocol/x402-core": "workspace:^",
     "viem": "^2.39.3",

--- a/typescript/packages/x402-server/scripts/postbuild.mjs
+++ b/typescript/packages/x402-server/scripts/postbuild.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Post-build housekeeping after `tsup`:
+//
+// Write `dist/esm/package.json` ({"type":"module"}) and
+// `dist/cjs/package.json` ({"type":"commonjs"}) so Node treats each
+// subtree under the correct module dialect without a
+// MODULE_TYPELESS_PACKAGE_JSON warning at consume time.
+//
+// This package ships no JSON schemas, so there is no `dist/schemas/` step.
+
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const distRoot = join(here, "..", "dist");
+
+await writeFile(
+  join(distRoot, "esm", "package.json"),
+  JSON.stringify({ type: "module" }, null, 2) + "\n",
+);
+await writeFile(
+  join(distRoot, "cjs", "package.json"),
+  JSON.stringify({ type: "commonjs" }, null, 2) + "\n",
+);
+
+console.log("postbuild: wrote module-type markers in dist/{esm,cjs}/package.json");

--- a/typescript/packages/x402-server/src/challenge/build-requirements.ts
+++ b/typescript/packages/x402-server/src/challenge/build-requirements.ts
@@ -1,0 +1,83 @@
+// 402 challenge builder — assembles an `EscrowPaymentRequirements`
+// from per-offer inputs (asset, amount, fulfillment, etc.) plus the
+// signed `BosonOfferRef` and the server's channel registry. The
+// initial `nextActions` envelope is filled via
+// `deriveInitialNextActions(registry)` so the legal transitions out
+// of `PRE_COMMIT` are always populated consistently.
+//
+// Source of truth: docs/boson-impl-01-escrow-scheme.md §2.
+
+import { deriveInitialNextActions, type ChannelRegistry } from "@bosonprotocol/x402-actions";
+import {
+  escrowPaymentRequirementsSchema,
+  type Address,
+  type BosonOfferRef,
+  type EscrowPaymentRequirements,
+  type EvmNetwork,
+  type FulfillmentRequirements,
+  type TokenAuthStrategy,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+
+export interface BuildPaymentRequirementsArgs {
+  /** Signed offer reference — usually from `signFullOffer`. */
+  offer: BosonOfferRef;
+  /** ERC-20 token address the buyer pays in. */
+  asset: Address;
+  /** Atomic amount as a decimal string (e.g. wei). */
+  amount: string;
+  /** Token-auth strategies the server is willing to accept. */
+  tokenAuthStrategies: readonly TokenAuthStrategy[];
+  /** Routing-only seller identifier — numeric sellerId, `did:boson:seller:N`, or wallet address. */
+  recipientId: string;
+  /** Upper bound for `validBefore` / `deadline` in token-auth payloads. */
+  maxTimeoutSeconds: number;
+  /** Optional fulfillment channel options. Absent or `{required: false}` means the server treats payment as fully atomic. */
+  fulfillment?: FulfillmentRequirements;
+  /** CAIP-2 network identifier (e.g. `eip155:8453`). */
+  network: EvmNetwork;
+  /** Boson Diamond address — same as `config.escrow`. */
+  escrow: Address;
+  /** Per-seller channel registry consumed by `deriveInitialNextActions`. */
+  channelRegistry: ChannelRegistry;
+}
+
+/**
+ * Build an `EscrowPaymentRequirements` body (the entry that lives
+ * inside the 402 response's `accepts[]` array). The result is
+ * round-tripped through `escrowPaymentRequirementsSchema` to fail
+ * loudly if any caller-provided field violates the wire format.
+ */
+export function buildPaymentRequirements(
+  args: BuildPaymentRequirementsArgs,
+): EscrowPaymentRequirements {
+  const {
+    offer,
+    asset,
+    amount,
+    tokenAuthStrategies,
+    recipientId,
+    maxTimeoutSeconds,
+    fulfillment,
+    network,
+    escrow,
+    channelRegistry,
+  } = args;
+
+  const actions = deriveInitialNextActions(channelRegistry);
+
+  const requirements: EscrowPaymentRequirements = {
+    scheme: "escrow",
+    network,
+    asset,
+    amount,
+    escrowAddress: escrow,
+    recipientId,
+    maxTimeoutSeconds,
+    offer,
+    tokenAuthStrategies: [...tokenAuthStrategies],
+    ...(fulfillment !== undefined ? { fulfillment } : {}),
+    actions,
+  };
+
+  return escrowPaymentRequirementsSchema.parse(requirements) as EscrowPaymentRequirements;
+}

--- a/typescript/packages/x402-server/src/challenge/index.ts
+++ b/typescript/packages/x402-server/src/challenge/index.ts
@@ -1,0 +1,11 @@
+// `challenge` subpath — the request-side primitives for building a
+// 402 response. PR follow-ups (validator, facilitator client,
+// composition layer) reach into separate subpaths so this barrel stays
+// scoped to the off-server FullOffer-signing + PaymentRequirements
+// pipeline.
+
+export { signFullOffer, type SignFullOfferArgs } from "./sign-full-offer.js";
+export {
+  buildPaymentRequirements,
+  type BuildPaymentRequirementsArgs,
+} from "./build-requirements.js";

--- a/typescript/packages/x402-server/src/challenge/sign-full-offer.ts
+++ b/typescript/packages/x402-server/src/challenge/sign-full-offer.ts
@@ -1,0 +1,63 @@
+// FullOffer signer hook — produces the seller's `BosonOfferRef` from
+// an unsigned FullOffer. Wraps `@bosonprotocol/x402-core/eip712`'s
+// `fullOfferTypedData` to build the EIP-712 typed-data, then hands it
+// to the configured `SellerSigner` for signing.
+//
+// Output is the literal `{ fullOffer, sellerSig, creator }` shape that
+// goes into `EscrowPaymentRequirements.offer`, validated against
+// `recoverFullOfferSigner` to guard against signer/address mismatch.
+
+import { fullOfferTypedData, type UnsignedFullOffer } from "@bosonprotocol/x402-core/eip712";
+import type { Address, BosonOfferRef, FullOffer } from "@bosonprotocol/x402-core/schemes/escrow";
+import type { Address as ViemAddress, Hex } from "viem";
+
+import type { SellerSigner } from "../config.js";
+
+export interface SignFullOfferArgs {
+  fullOffer: UnsignedFullOffer;
+  signer: SellerSigner;
+  /** Boson Diamond address — the EIP-712 `verifyingContract`. */
+  escrow: Address;
+  chainId: number;
+}
+
+/**
+ * Build the FullOffer EIP-712 typed-data, sign it with the seller's
+ * signer, and return a `BosonOfferRef` ready to embed in a 402
+ * `PaymentRequirements`.
+ *
+ * The returned `creator` is the seller signer's address. Callers that
+ * need to support ERC-1271 contract-wallet sellers can pass the
+ * contract address as `signer.address` and route signing through a
+ * custom `signTypedData` that proxies to the wallet — the recovery
+ * step in `verifyOffer` on-chain runs via `EIP712Lib.verify`, which
+ * already handles both ECDSA and ERC-1271.
+ */
+export async function signFullOffer({
+  fullOffer,
+  signer,
+  escrow,
+  chainId,
+}: SignFullOfferArgs): Promise<BosonOfferRef> {
+  // The wire-format `Address` is a plain string (validated at the zod
+  // boundary); viem's typed-data builder wants its template-literal
+  // `0x${string}` brand. Coerce at this boundary only.
+  const td = await fullOfferTypedData({
+    fullOffer,
+    verifyingContract: escrow as ViemAddress,
+    chainId,
+  });
+
+  const sellerSig: Hex = await signer.signTypedData({
+    domain: td.domain,
+    types: td.types,
+    primaryType: td.primaryType,
+    message: td.message,
+  });
+
+  return {
+    fullOffer: fullOffer as unknown as FullOffer,
+    sellerSig,
+    creator: signer.address,
+  };
+}

--- a/typescript/packages/x402-server/src/challenge/sign-full-offer.ts
+++ b/typescript/packages/x402-server/src/challenge/sign-full-offer.ts
@@ -1,17 +1,27 @@
 // FullOffer signer hook — produces the seller's `BosonOfferRef` from
-// an unsigned FullOffer. Wraps `@bosonprotocol/x402-core/eip712`'s
-// `fullOfferTypedData` to build the EIP-712 typed-data, then hands it
-// to the configured `SellerSigner` for signing.
+// an unsigned FullOffer. Delegates directly to
+// `@bosonprotocol/core-sdk`'s `exchanges.handler.signFullOffer`,
+// supplying a forwarding `Web3LibAdapter` that routes the inner
+// `eth_signTypedData_v4` RPC call to the configured `SellerSigner`.
 //
-// Output is the literal `{ fullOffer, sellerSig, creator }` shape that
-// goes into `EscrowPaymentRequirements.offer`, validated against
-// `recoverFullOfferSigner` to guard against signer/address mismatch.
+// Routing through core-sdk keeps the typed-data shape, EIP-712 domain
+// (salt-based `Boson Protocol` / `V2`), and offer-struct
+// canonicalisation in lock-step with the deployed protocol — we don't
+// re-derive the FullOffer EIP-712 type-list on our side.
 
-import { fullOfferTypedData, type UnsignedFullOffer } from "@bosonprotocol/x402-core/eip712";
-import type { Address, BosonOfferRef, FullOffer } from "@bosonprotocol/x402-core/schemes/escrow";
-import type { Address as ViemAddress, Hex } from "viem";
+import { exchanges } from "@bosonprotocol/core-sdk";
+import type { Web3LibAdapter } from "@bosonprotocol/common";
+import type { UnsignedFullOffer } from "@bosonprotocol/x402-core/eip712";
+import type {
+  Address,
+  BosonOfferRef,
+  FullOffer,
+  Hex,
+} from "@bosonprotocol/x402-core/schemes/escrow";
 
 import type { SellerSigner } from "../config.js";
+
+const STUB_CALLER_TAG = "@bosonprotocol/x402-server:sign-full-offer";
 
 export interface SignFullOfferArgs {
   fullOffer: UnsignedFullOffer;
@@ -22,16 +32,18 @@ export interface SignFullOfferArgs {
 }
 
 /**
- * Build the FullOffer EIP-712 typed-data, sign it with the seller's
- * signer, and return a `BosonOfferRef` ready to embed in a 402
- * `PaymentRequirements`.
+ * Sign a FullOffer via `@bosonprotocol/core-sdk`'s `signFullOffer`
+ * and return a `BosonOfferRef` ready to embed in
+ * `EscrowPaymentRequirements.offer`. The seller signer is plugged
+ * into core-sdk via a forwarding `Web3LibAdapter` so any viem
+ * `LocalAccount` / HSM / KMS signer drops in without exposing
+ * core-sdk's adapter shape in this package's public API.
  *
- * The returned `creator` is the seller signer's address. Callers that
- * need to support ERC-1271 contract-wallet sellers can pass the
- * contract address as `signer.address` and route signing through a
- * custom `signTypedData` that proxies to the wallet — the recovery
- * step in `verifyOffer` on-chain runs via `EIP712Lib.verify`, which
- * already handles both ECDSA and ERC-1271.
+ * ERC-1271 contract-wallet sellers: pass the wallet's address as
+ * `signer.address` and route `signer.signTypedData` to whatever
+ * surface the wallet exposes — the protocol's on-chain `verifyOffer`
+ * runs via `EIP712Lib.verify` which already handles both ECDSA and
+ * ERC-1271 recovery.
  */
 export async function signFullOffer({
   fullOffer,
@@ -39,25 +51,68 @@ export async function signFullOffer({
   escrow,
   chainId,
 }: SignFullOfferArgs): Promise<BosonOfferRef> {
-  // The wire-format `Address` is a plain string (validated at the zod
-  // boundary); viem's typed-data builder wants its template-literal
-  // `0x${string}` brand. Coerce at this boundary only.
-  const td = await fullOfferTypedData({
-    fullOffer,
-    verifyingContract: escrow as ViemAddress,
+  const web3Lib = buildForwardingAdapter(signer, chainId);
+  const result = await exchanges.handler.signFullOffer({
+    fullOfferArgsUnsigned: fullOffer as unknown as Parameters<
+      typeof exchanges.handler.signFullOffer
+    >[0]["fullOfferArgsUnsigned"],
+    contractAddress: escrow,
     chainId,
+    web3Lib,
   });
-
-  const sellerSig: Hex = await signer.signTypedData({
-    domain: td.domain,
-    types: td.types,
-    primaryType: td.primaryType,
-    message: td.message,
-  });
-
   return {
     fullOffer: fullOffer as unknown as FullOffer,
-    sellerSig,
+    sellerSig: result.signature as Hex,
     creator: signer.address,
+  };
+}
+
+/**
+ * Build a `Web3LibAdapter` whose `send("eth_signTypedData_v4", [from, json])`
+ * routes to `signer.signTypedData(...)`. core-sdk's `signFullOffer`
+ * path only touches `getSignerAddress`, `getChainId`, and that one
+ * `send` invocation — every other adapter method rejects so a future
+ * leak into a non-signing-only path is loud rather than silent.
+ */
+function buildForwardingAdapter(signer: SellerSigner, chainId: number): Web3LibAdapter {
+  const unreachable = (method: string): Promise<never> =>
+    Promise.reject(
+      new Error(
+        `${STUB_CALLER_TAG}: Web3LibAdapter.${method}() called unexpectedly — sign-full-offer is a signing-only path.`,
+      ),
+    );
+
+  return {
+    uuid: `${STUB_CALLER_TAG}:forward`,
+    getSignerAddress: () => Promise.resolve(signer.address),
+    isSignerContract: () => Promise.resolve(false),
+    getChainId: () => Promise.resolve(chainId),
+    send: async (method, params) => {
+      if (method !== "eth_signTypedData_v4") {
+        throw new Error(`${STUB_CALLER_TAG}: unexpected RPC method: ${method}`);
+      }
+      const [, json] = params as [unknown, string];
+      if (typeof json !== "string") {
+        throw new Error(`${STUB_CALLER_TAG}: eth_signTypedData_v4 payload is not a JSON string`);
+      }
+      const td = JSON.parse(json) as {
+        domain: Record<string, unknown>;
+        types: Record<string, readonly { name: string; type: string }[]>;
+        primaryType: string;
+        message: Record<string, unknown>;
+      };
+      return signer.signTypedData({
+        domain: td.domain,
+        types: td.types,
+        primaryType: td.primaryType,
+        message: td.message,
+      });
+    },
+    getBalance: () => unreachable("getBalance"),
+    estimateGas: () => unreachable("estimateGas"),
+    sendTransaction: () => unreachable("sendTransaction"),
+    call: () => unreachable("call"),
+    getTransactionReceipt: () => unreachable("getTransactionReceipt"),
+    getCurrentTimeMs: () => unreachable("getCurrentTimeMs"),
   };
 }

--- a/typescript/packages/x402-server/src/config.ts
+++ b/typescript/packages/x402-server/src/config.ts
@@ -10,7 +10,12 @@
 // `./challenge/build-requirements.ts`.
 
 import { channelRegistryZodSchema, type ChannelRegistry } from "@bosonprotocol/x402-actions";
-import type { Address, EvmNetwork } from "@bosonprotocol/x402-core/schemes/escrow";
+import {
+  addressSchema,
+  evmNetworkSchema,
+  type Address,
+  type EvmNetwork,
+} from "@bosonprotocol/x402-core/schemes/escrow";
 import type { Hex } from "viem";
 import { z } from "zod";
 
@@ -53,8 +58,6 @@ export interface X402bServerConfig {
   channelRegistry: ChannelRegistry;
 }
 
-const ADDRESS = /^0x[a-fA-F0-9]{40}$/;
-const EVM_NETWORK = /^eip155:[1-9][0-9]*$/;
 const httpUrlSchema = z
   .string()
   .url()
@@ -64,7 +67,7 @@ const httpUrlSchema = z
 
 const sellerSignerSchema = z
   .object({
-    address: z.string().regex(ADDRESS),
+    address: addressSchema,
     signTypedData: z
       .function()
       .args(z.unknown())
@@ -80,9 +83,9 @@ const sellerSignerSchema = z
  */
 export const x402bServerConfigSchema = z
   .object({
-    network: z.string().regex(EVM_NETWORK),
+    network: evmNetworkSchema,
     chainId: z.number().int().positive(),
-    escrow: z.string().regex(ADDRESS),
+    escrow: addressSchema,
     signer: sellerSignerSchema,
     facilitator: z
       .object({

--- a/typescript/packages/x402-server/src/config.ts
+++ b/typescript/packages/x402-server/src/config.ts
@@ -9,7 +9,7 @@
 // the per-request `buildPaymentRequirements` call instead — see
 // `./challenge/build-requirements.ts`.
 
-import type { ChannelRegistry } from "@bosonprotocol/x402-actions";
+import { channelRegistryZodSchema, type ChannelRegistry } from "@bosonprotocol/x402-actions";
 import type { Address, EvmNetwork } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { Hex } from "viem";
 import { z } from "zod";
@@ -55,7 +55,12 @@ export interface X402bServerConfig {
 
 const ADDRESS = /^0x[a-fA-F0-9]{40}$/;
 const EVM_NETWORK = /^eip155:[1-9][0-9]*$/;
-const HTTPS_URL = /^https?:\/\//;
+const httpUrlSchema = z
+  .string()
+  .url()
+  .refine((url) => url.startsWith("http://") || url.startsWith("https://"), {
+    message: "must be an http(s) URL",
+  });
 
 const sellerSignerSchema = z
   .object({
@@ -67,18 +72,11 @@ const sellerSignerSchema = z
   })
   .passthrough();
 
-const channelRegistryShallowSchema = z
-  .object({
-    channels: z.array(z.string()).min(1),
-    escrow: z.string().regex(ADDRESS),
-  })
-  .passthrough();
-
 /**
  * zod validator for `X402bServerConfig`. Shallow on the signer +
- * channel registry (those bring their own structural validators —
- * `buildChannelRegistry` for the registry, viem's account types for
- * the signer); strict on the scalar fields we own here.
+ * signer (viem account types bring their own structural validators);
+ * strict on the scalar fields we own here and on the channel registry
+ * via `@bosonprotocol/x402-actions`.
  */
 export const x402bServerConfigSchema = z
   .object({
@@ -88,10 +86,10 @@ export const x402bServerConfigSchema = z
     signer: sellerSignerSchema,
     facilitator: z
       .object({
-        url: z.string().regex(HTTPS_URL),
+        url: httpUrlSchema,
       })
       .strict(),
-    channelRegistry: channelRegistryShallowSchema,
+    channelRegistry: channelRegistryZodSchema,
   })
   .strict();
 

--- a/typescript/packages/x402-server/src/config.ts
+++ b/typescript/packages/x402-server/src/config.ts
@@ -1,0 +1,109 @@
+// X402bServerConfig — the per-server context passed to
+// `createX402bServer`. The config holds everything that doesn't vary
+// per request: the network + escrow address, the seller's signer, the
+// facilitator URL (for both the future HTTP client and the public
+// advertisement embedded in `nextActions[].endpoints.facilitator`),
+// and the channel registry consumed by `deriveNextActions`.
+//
+// Per-offer values (price, asset, fulfillment, etc.) come in through
+// the per-request `buildPaymentRequirements` call instead — see
+// `./challenge/build-requirements.ts`.
+
+import type { ChannelRegistry } from "@bosonprotocol/x402-actions";
+import type { Address, EvmNetwork } from "@bosonprotocol/x402-core/schemes/escrow";
+import type { Hex } from "viem";
+import { z } from "zod";
+
+/**
+ * Minimal signing surface needed by `signFullOffer`. Structurally
+ * compatible with viem's `Account` (in particular `LocalAccount` from
+ * `privateKeyToAccount`), but kept narrow so consumers can plug in
+ * HSM- / KMS- / ERC-1271-backed signers without depending on viem's
+ * internal account types.
+ */
+export interface SellerSigner {
+  /** Address that the EIP-712 signature must recover to (`creator` in `BosonOfferRef`). */
+  readonly address: Address;
+  /** EIP-712 typed-data signer. Accepts the same shape viem's `signTypedData` does. */
+  signTypedData: (params: {
+    domain: Record<string, unknown>;
+    types: Record<string, readonly { name: string; type: string }[]>;
+    primaryType: string;
+    message: Record<string, unknown>;
+  }) => Promise<Hex>;
+}
+
+/**
+ * Per-server configuration. Validated by `x402bServerConfigSchema` at
+ * `createX402bServer` time so bad config fails fast at boot rather than
+ * later inside a 402 response.
+ */
+export interface X402bServerConfig {
+  /** CAIP-2 EVM network the server advertises (e.g. `eip155:8453`). */
+  network: EvmNetwork;
+  /** EVM chain id matching `network` — passed straight to the EIP-712 builder's salt. */
+  chainId: number;
+  /** Address of the Boson Diamond — the EIP-712 `verifyingContract` and the wire-level `escrowAddress`. */
+  escrow: Address;
+  /** Seller signer (signs the FullOffer EIP-712 typed-data). */
+  signer: SellerSigner;
+  /** Facilitator service the server forwards meta-tx envelopes to. The URL is also advertised in `nextActions[].endpoints.facilitator`. */
+  facilitator: { url: string };
+  /** Per-seller channel + endpoint registry consumed by `deriveNextActions`. */
+  channelRegistry: ChannelRegistry;
+}
+
+const ADDRESS = /^0x[a-fA-F0-9]{40}$/;
+const EVM_NETWORK = /^eip155:[1-9][0-9]*$/;
+const HTTPS_URL = /^https?:\/\//;
+
+const sellerSignerSchema = z
+  .object({
+    address: z.string().regex(ADDRESS),
+    signTypedData: z
+      .function()
+      .args(z.unknown())
+      .returns(z.union([z.string(), z.promise(z.string())])),
+  })
+  .passthrough();
+
+const channelRegistryShallowSchema = z
+  .object({
+    channels: z.array(z.string()).min(1),
+    escrow: z.string().regex(ADDRESS),
+  })
+  .passthrough();
+
+/**
+ * zod validator for `X402bServerConfig`. Shallow on the signer +
+ * channel registry (those bring their own structural validators —
+ * `buildChannelRegistry` for the registry, viem's account types for
+ * the signer); strict on the scalar fields we own here.
+ */
+export const x402bServerConfigSchema = z
+  .object({
+    network: z.string().regex(EVM_NETWORK),
+    chainId: z.number().int().positive(),
+    escrow: z.string().regex(ADDRESS),
+    signer: sellerSignerSchema,
+    facilitator: z
+      .object({
+        url: z.string().regex(HTTPS_URL),
+      })
+      .strict(),
+    channelRegistry: channelRegistryShallowSchema,
+  })
+  .strict();
+
+/**
+ * Cross-field invariant: `config.escrow` and
+ * `config.channelRegistry.escrow` must agree — the Diamond address is
+ * the same on both sides. Run this after `x402bServerConfigSchema.parse`.
+ */
+export function assertChannelRegistryEscrowMatch(config: X402bServerConfig): void {
+  if (config.escrow.toLowerCase() !== config.channelRegistry.escrow.toLowerCase()) {
+    throw new Error(
+      `x402-server config: escrow (${config.escrow}) does not match channelRegistry.escrow (${config.channelRegistry.escrow})`,
+    );
+  }
+}

--- a/typescript/packages/x402-server/src/config.ts
+++ b/typescript/packages/x402-server/src/config.ts
@@ -13,6 +13,7 @@ import { channelRegistryZodSchema, type ChannelRegistry } from "@bosonprotocol/x
 import {
   addressSchema,
   evmNetworkSchema,
+  hexSchema,
   type Address,
   type EvmNetwork,
 } from "@bosonprotocol/x402-core/schemes/escrow";
@@ -68,10 +69,11 @@ const httpUrlSchema = z
 const sellerSignerSchema = z
   .object({
     address: addressSchema,
-    signTypedData: z
-      .function()
-      .args(z.unknown())
-      .returns(z.union([z.string(), z.promise(z.string())])),
+    // `SellerSigner.signTypedData` is typed `Promise<Hex>` in the TS
+    // interface — tighten the zod return wrapper to match so a signer
+    // that resolves to a non-hex string fails loudly at call time
+    // rather than silently producing a bad `BosonOfferRef.sellerSig`.
+    signTypedData: z.function().args(z.unknown()).returns(z.promise(hexSchema)),
   })
   .passthrough();
 

--- a/typescript/packages/x402-server/src/config.ts
+++ b/typescript/packages/x402-server/src/config.ts
@@ -91,7 +91,21 @@ export const x402bServerConfigSchema = z
       .strict(),
     channelRegistry: channelRegistryZodSchema,
   })
-  .strict();
+  .strict()
+  .superRefine((cfg, ctx) => {
+    // CAIP-2 `eip155:<chainId>` carries the chainId; assert it matches
+    // the explicit `chainId` field so the EIP-712 salt and the
+    // wire-level network advertisement agree. Catches the easy
+    // copy-paste mistake of pairing `eip155:8453` with `chainId: 1`.
+    const networkChainId = Number(cfg.network.split(":")[1]);
+    if (networkChainId !== cfg.chainId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["chainId"],
+        message: `chainId (${cfg.chainId}) must match network (${cfg.network})`,
+      });
+    }
+  });
 
 /**
  * Cross-field invariant: `config.escrow` and

--- a/typescript/packages/x402-server/src/index.ts
+++ b/typescript/packages/x402-server/src/index.ts
@@ -1,0 +1,21 @@
+// Public API for `@bosonprotocol/x402-server`.
+//
+// v0.1 — request-side primitives only: 402 challenge builder, seller
+// FullOffer signer, and a `createX402bServer` factory that binds them
+// to a shared `X402bServerConfig`. The `X-PAYMENT` validator,
+// facilitator HTTP client, and convenience-endpoint handlers land in
+// follow-up PRs and slot onto the same factory output.
+
+export { createX402bServer, type BuildRequirementsInput, type X402bServer } from "./server.js";
+export {
+  assertChannelRegistryEscrowMatch,
+  x402bServerConfigSchema,
+  type SellerSigner,
+  type X402bServerConfig,
+} from "./config.js";
+export {
+  buildPaymentRequirements,
+  signFullOffer,
+  type BuildPaymentRequirementsArgs,
+  type SignFullOfferArgs,
+} from "./challenge/index.js";

--- a/typescript/packages/x402-server/src/server.ts
+++ b/typescript/packages/x402-server/src/server.ts
@@ -1,0 +1,85 @@
+// `createX402bServer` — the per-server factory. v0.1 wires the 402
+// challenge builder + FullOffer signer; later PRs (validator,
+// facilitator client, convenience handlers) attach more methods to
+// the returned object without changing the config shape.
+
+import type { UnsignedFullOffer } from "@bosonprotocol/x402-core/eip712";
+import type {
+  BosonOfferRef,
+  EscrowPaymentRequirements,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+
+import { buildPaymentRequirements } from "./challenge/build-requirements.js";
+import { signFullOffer } from "./challenge/sign-full-offer.js";
+import {
+  assertChannelRegistryEscrowMatch,
+  x402bServerConfigSchema,
+  type X402bServerConfig,
+} from "./config.js";
+
+/** Per-offer inputs for `server.buildPaymentRequirements` — everything the offer-level args carry, minus the per-server context the factory already holds. */
+export interface BuildRequirementsInput {
+  /** Already-signed offer reference, or `{ unsigned }` to have the server sign it. */
+  offer: BosonOfferRef | { unsigned: UnsignedFullOffer };
+  asset: string;
+  amount: string;
+  tokenAuthStrategies: readonly ("none" | "erc3009" | "permit" | "permit2")[];
+  recipientId: string;
+  maxTimeoutSeconds: number;
+  fulfillment?: import("@bosonprotocol/x402-core/schemes/escrow").FulfillmentRequirements;
+}
+
+export interface X402bServer {
+  readonly config: X402bServerConfig;
+  /**
+   * Sign an unsigned FullOffer with the configured seller signer.
+   * Returns the `BosonOfferRef` shape ready to embed in
+   * `EscrowPaymentRequirements.offer`.
+   */
+  signOffer(unsigned: UnsignedFullOffer): Promise<BosonOfferRef>;
+  /**
+   * Build a 402 `EscrowPaymentRequirements` body. Accepts either an
+   * already-signed `BosonOfferRef` or `{ unsigned }` — in the latter
+   * case the server signs the offer with the configured signer first.
+   */
+  buildPaymentRequirements(input: BuildRequirementsInput): Promise<EscrowPaymentRequirements>;
+}
+
+/**
+ * Validate a config and return a `X402bServer` whose methods are
+ * bound to the validated context. Throws synchronously (`ZodError`)
+ * on bad config or (`Error`) on the escrow / channel-registry escrow
+ * mismatch.
+ */
+export function createX402bServer(config: X402bServerConfig): X402bServer {
+  const validated = x402bServerConfigSchema.parse(config) as X402bServerConfig;
+  assertChannelRegistryEscrowMatch(validated);
+
+  const signOffer = (unsigned: UnsignedFullOffer): Promise<BosonOfferRef> =>
+    signFullOffer({
+      fullOffer: unsigned,
+      signer: validated.signer,
+      escrow: validated.escrow,
+      chainId: validated.chainId,
+    });
+
+  return {
+    config: validated,
+    signOffer,
+    async buildPaymentRequirements(input) {
+      const offer = "unsigned" in input.offer ? await signOffer(input.offer.unsigned) : input.offer;
+      return buildPaymentRequirements({
+        offer,
+        asset: input.asset,
+        amount: input.amount,
+        tokenAuthStrategies: input.tokenAuthStrategies,
+        recipientId: input.recipientId,
+        maxTimeoutSeconds: input.maxTimeoutSeconds,
+        ...(input.fulfillment !== undefined ? { fulfillment: input.fulfillment } : {}),
+        network: validated.network,
+        escrow: validated.escrow,
+        channelRegistry: validated.channelRegistry,
+      });
+    },
+  };
+}

--- a/typescript/packages/x402-server/src/server.ts
+++ b/typescript/packages/x402-server/src/server.ts
@@ -51,10 +51,11 @@ const COMMIT_ACTION_IDS = new Set([
 ]);
 
 function facilitatorEndpointFor(actionId: string, facilitatorUrl: string): string {
+  const base = facilitatorUrl.replace(/\/+$/, "");
   if (COMMIT_ACTION_IDS.has(actionId)) {
-    return `${facilitatorUrl}/settle`;
+    return `${base}/settle`;
   }
-  return `${facilitatorUrl}/perform-action?action=${actionId}`;
+  return `${base}/perform-action?action=${encodeURIComponent(actionId)}`;
 }
 
 function withFacilitatorEndpoints(

--- a/typescript/packages/x402-server/src/server.ts
+++ b/typescript/packages/x402-server/src/server.ts
@@ -45,6 +45,42 @@ export interface X402bServer {
   buildPaymentRequirements(input: BuildRequirementsInput): Promise<EscrowPaymentRequirements>;
 }
 
+const COMMIT_ACTION_IDS = new Set([
+  "boson-createOfferAndCommit",
+  "boson-createOfferCommitAndRedeem",
+]);
+
+function facilitatorEndpointFor(actionId: string, facilitatorUrl: string): string {
+  if (COMMIT_ACTION_IDS.has(actionId)) {
+    return `${facilitatorUrl}/settle`;
+  }
+  return `${facilitatorUrl}/perform-action?action=${actionId}`;
+}
+
+function withFacilitatorEndpoints(
+  requirements: EscrowPaymentRequirements,
+  facilitatorUrl: string,
+): EscrowPaymentRequirements {
+  return {
+    ...requirements,
+    actions: {
+      ...requirements.actions,
+      next: requirements.actions.next.map((entry) => {
+        if (!entry.channels.includes("facilitator")) {
+          return entry;
+        }
+        return {
+          ...entry,
+          endpoints: {
+            ...entry.endpoints,
+            facilitator: facilitatorEndpointFor(entry.id, facilitatorUrl),
+          },
+        };
+      }),
+    },
+  };
+}
+
 /**
  * Validate a config and return a `X402bServer` whose methods are
  * bound to the validated context. Throws synchronously (`ZodError`)
@@ -68,7 +104,7 @@ export function createX402bServer(config: X402bServerConfig): X402bServer {
     signOffer,
     async buildPaymentRequirements(input) {
       const offer = "unsigned" in input.offer ? await signOffer(input.offer.unsigned) : input.offer;
-      return buildPaymentRequirements({
+      const requirements = buildPaymentRequirements({
         offer,
         asset: input.asset,
         amount: input.amount,
@@ -80,6 +116,7 @@ export function createX402bServer(config: X402bServerConfig): X402bServer {
         escrow: validated.escrow,
         channelRegistry: validated.channelRegistry,
       });
+      return withFacilitatorEndpoints(requirements, validated.facilitator.url);
     },
   };
 }

--- a/typescript/packages/x402-server/test/build-requirements.test.ts
+++ b/typescript/packages/x402-server/test/build-requirements.test.ts
@@ -1,0 +1,126 @@
+// `buildPaymentRequirements` + `createX402bServer` end-to-end:
+// signs a FullOffer, builds the 402 body, asserts it round-trips
+// through `escrowPaymentRequirementsSchema`, and that the embedded
+// `actions.next[]` carries the two `PRE_COMMIT` legal transitions.
+
+import { buildChannelRegistry } from "@bosonprotocol/x402-actions";
+import { escrowPaymentRequirementsSchema } from "@bosonprotocol/x402-core/schemes/escrow";
+import { describe, expect, it } from "vitest";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { buildPaymentRequirements, createX402bServer, signFullOffer } from "../src/index.js";
+import { baseOffer, ESCROW, TEST_SELLER_PK, TOKEN } from "./fixtures.js";
+
+const CHAIN_ID = 8453;
+const NETWORK = "eip155:8453" as const;
+const RECIPIENT_ID = "did:boson:seller:12345";
+
+function makeRegistry() {
+  return buildChannelRegistry({
+    channels: ["server", "facilitator", "onchain", "mcp"],
+    escrow: ESCROW,
+    mcp: "boson://seller/12345",
+  });
+}
+
+describe("buildPaymentRequirements (free function)", () => {
+  it("emits a valid EscrowPaymentRequirements with initial nextActions", async () => {
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+    const offer = await signFullOffer({
+      fullOffer: { ...baseOffer, offerCreator: seller.address },
+      signer: seller,
+      escrow: ESCROW,
+      chainId: CHAIN_ID,
+    });
+
+    const requirements = buildPaymentRequirements({
+      offer,
+      asset: TOKEN,
+      amount: "1000000",
+      tokenAuthStrategies: ["erc3009"],
+      recipientId: RECIPIENT_ID,
+      maxTimeoutSeconds: 300,
+      network: NETWORK,
+      escrow: ESCROW,
+      channelRegistry: makeRegistry(),
+    });
+
+    expect(() => escrowPaymentRequirementsSchema.parse(requirements)).not.toThrow();
+    expect(requirements.scheme).toBe("escrow");
+    expect(requirements.network).toBe(NETWORK);
+    expect(requirements.escrowAddress).toBe(ESCROW);
+    expect(requirements.offer.sellerSig).toMatch(/^0x[0-9a-f]+$/);
+
+    const actionIds = requirements.actions.next.map((entry) => entry.id);
+    expect(actionIds).toContain("boson-createOfferAndCommit");
+    expect(actionIds).toContain("boson-createOfferCommitAndRedeem");
+  });
+
+  it("omits `fulfillment` when not supplied", async () => {
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+    const offer = await signFullOffer({
+      fullOffer: baseOffer,
+      signer: seller,
+      escrow: ESCROW,
+      chainId: CHAIN_ID,
+    });
+
+    const requirements = buildPaymentRequirements({
+      offer,
+      asset: TOKEN,
+      amount: "1000000",
+      tokenAuthStrategies: ["none"],
+      recipientId: RECIPIENT_ID,
+      maxTimeoutSeconds: 300,
+      network: NETWORK,
+      escrow: ESCROW,
+      channelRegistry: makeRegistry(),
+    });
+
+    expect(requirements.fulfillment).toBeUndefined();
+  });
+});
+
+describe("createX402bServer", () => {
+  it("binds config to a buildPaymentRequirements() that signs offers on demand", async () => {
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+    const server = createX402bServer({
+      network: NETWORK,
+      chainId: CHAIN_ID,
+      escrow: ESCROW,
+      signer: seller,
+      facilitator: { url: "https://facilitator.example" },
+      channelRegistry: makeRegistry(),
+    });
+
+    const requirements = await server.buildPaymentRequirements({
+      offer: { unsigned: { ...baseOffer, offerCreator: seller.address } },
+      asset: TOKEN,
+      amount: "1000000",
+      tokenAuthStrategies: ["erc3009"],
+      recipientId: RECIPIENT_ID,
+      maxTimeoutSeconds: 300,
+    });
+
+    expect(requirements.offer.creator.toLowerCase()).toBe(seller.address.toLowerCase());
+    expect(() => escrowPaymentRequirementsSchema.parse(requirements)).not.toThrow();
+  });
+
+  it("rejects config when escrow and channelRegistry.escrow disagree", () => {
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+    const otherDiamond = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+    expect(() =>
+      createX402bServer({
+        network: NETWORK,
+        chainId: CHAIN_ID,
+        escrow: ESCROW,
+        signer: seller,
+        facilitator: { url: "https://facilitator.example" },
+        channelRegistry: buildChannelRegistry({
+          channels: ["server", "facilitator", "onchain"],
+          escrow: otherDiamond,
+        }),
+      }),
+    ).toThrow(/does not match channelRegistry.escrow/);
+  });
+});

--- a/typescript/packages/x402-server/test/build-requirements.test.ts
+++ b/typescript/packages/x402-server/test/build-requirements.test.ts
@@ -106,6 +106,33 @@ describe("createX402bServer", () => {
     expect(() => escrowPaymentRequirementsSchema.parse(requirements)).not.toThrow();
   });
 
+  it("advertises facilitator endpoints for facilitator-channel commit actions", async () => {
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+    const server = createX402bServer({
+      network: NETWORK,
+      chainId: CHAIN_ID,
+      escrow: ESCROW,
+      signer: seller,
+      facilitator: { url: "https://facilitator.example" },
+      channelRegistry: makeRegistry(),
+    });
+
+    const requirements = await server.buildPaymentRequirements({
+      offer: { unsigned: { ...baseOffer, offerCreator: seller.address } },
+      asset: TOKEN,
+      amount: "1000000",
+      tokenAuthStrategies: ["erc3009"],
+      recipientId: RECIPIENT_ID,
+      maxTimeoutSeconds: 300,
+    });
+
+    for (const entry of requirements.actions.next) {
+      expect(entry.channels).toContain("facilitator");
+      expect(entry.endpoints?.facilitator).toBe("https://facilitator.example/settle");
+    }
+    expect(() => escrowPaymentRequirementsSchema.parse(requirements)).not.toThrow();
+  });
+
   it("rejects config when escrow and channelRegistry.escrow disagree", () => {
     const seller = privateKeyToAccount(TEST_SELLER_PK);
     const otherDiamond = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
@@ -122,5 +149,22 @@ describe("createX402bServer", () => {
         }),
       }),
     ).toThrow(/does not match channelRegistry.escrow/);
+  });
+
+  it("rejects malformed channel registries at server creation", () => {
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+    expect(() =>
+      createX402bServer({
+        network: NETWORK,
+        chainId: CHAIN_ID,
+        escrow: ESCROW,
+        signer: seller,
+        facilitator: { url: "https://facilitator.example" },
+        channelRegistry: {
+          channels: ["facilitator", "unknown-channel"],
+          escrow: ESCROW,
+        } as never,
+      }),
+    ).toThrow();
   });
 });

--- a/typescript/packages/x402-server/test/build-requirements.test.ts
+++ b/typescript/packages/x402-server/test/build-requirements.test.ts
@@ -167,4 +167,48 @@ describe("createX402bServer", () => {
       }),
     ).toThrow();
   });
+
+  it("rejects config when chainId doesn't match the network's CAIP-2 chainId", () => {
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+    expect(() =>
+      createX402bServer({
+        network: "eip155:8453",
+        chainId: 1,
+        escrow: ESCROW,
+        signer: seller,
+        facilitator: { url: "https://facilitator.example" },
+        channelRegistry: makeRegistry(),
+      }),
+    ).toThrow(/chainId \(1\) must match network \(eip155:8453\)/);
+  });
+
+  it("normalises trailing slashes and URL-encodes action ids in facilitator endpoints", async () => {
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+    const server = createX402bServer({
+      network: NETWORK,
+      chainId: CHAIN_ID,
+      escrow: ESCROW,
+      signer: seller,
+      facilitator: { url: "https://facilitator.example///" },
+      channelRegistry: makeRegistry(),
+    });
+
+    const requirements = await server.buildPaymentRequirements({
+      offer: { unsigned: { ...baseOffer, offerCreator: seller.address } },
+      asset: TOKEN,
+      amount: "1000000",
+      tokenAuthStrategies: ["erc3009"],
+      recipientId: RECIPIENT_ID,
+      maxTimeoutSeconds: 300,
+    });
+
+    for (const entry of requirements.actions.next) {
+      // No double-slash anywhere after the protocol.
+      expect(entry.endpoints?.facilitator).not.toMatch(/[^:]\/\//);
+      // Commit-time actions route to /settle; future post-commit
+      // actions advertised here would route to /perform-action?action=
+      // with the id URL-encoded.
+      expect(entry.endpoints?.facilitator).toBe("https://facilitator.example/settle");
+    }
+  });
 });

--- a/typescript/packages/x402-server/test/fixtures.ts
+++ b/typescript/packages/x402-server/test/fixtures.ts
@@ -1,0 +1,55 @@
+// Shared test fixtures — kept narrow so test files stay easy to read.
+// FullOffer shape mirrors `core`'s own `eip712/full-offer.test.ts` so
+// the round-trip behaviour is comparable.
+
+import type { UnsignedFullOffer } from "@bosonprotocol/x402-core/eip712";
+
+export const ESCROW = "0xdddddddddddddddddddddddddddddddddddddddd" as const;
+export const TOKEN = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" as const;
+export const SELLER = "0x1111111111111111111111111111111111111111" as const;
+export const ZERO = "0x0000000000000000000000000000000000000000" as const;
+
+/** Deterministic test key — 32 bytes of `0x22`. Recovers to `0x9b87...` etc.; we read the address back from `privateKeyToAccount`. */
+export const TEST_SELLER_PK = `0x${"22".repeat(32)}` as const;
+
+/** A valid `UnsignedFullOffer` — matches the protocol's struct shape. */
+export const baseOffer: UnsignedFullOffer = {
+  price: "1000000",
+  sellerDeposit: "0",
+  agentId: "0",
+  buyerCancelPenalty: "0",
+  quantityAvailable: "1",
+  validFromDateInMS: "1900000000000",
+  validUntilDateInMS: "1900003600000",
+  voucherRedeemableFromDateInMS: "1900000000000",
+  voucherRedeemableUntilDateInMS: "1900003600000",
+  disputePeriodDurationInMS: "86400000",
+  voucherValidDurationInMS: "0",
+  resolutionPeriodDurationInMS: "604800000",
+  exchangeToken: TOKEN,
+  disputeResolverId: "1",
+  metadataUri: "ipfs://QmDeadBeef",
+  metadataHash: "QmDeadBeef",
+  collectionIndex: "0",
+  feeLimit: "0",
+  offerCreator: SELLER,
+  committer: ZERO,
+  condition: {
+    method: 0,
+    tokenType: 0,
+    tokenAddress: ZERO,
+    gatingType: 0,
+    minTokenId: "0",
+    threshold: "0",
+    maxCommits: "0",
+    maxTokenId: "0",
+  },
+  useDepositedFunds: false,
+  sellerId: "12345",
+  buyerId: "0",
+  sellerOfferParams: {
+    collectionIndex: "0",
+    royaltyInfo: { recipients: [], bps: [] },
+    mutualizerAddress: ZERO,
+  },
+};

--- a/typescript/packages/x402-server/test/sign-full-offer.test.ts
+++ b/typescript/packages/x402-server/test/sign-full-offer.test.ts
@@ -1,0 +1,49 @@
+// `signFullOffer` round-trips through `recoverFullOfferSigner` from
+// `@bosonprotocol/x402-core/eip712` — confirming we're producing a
+// signature against the same domain the on-chain `verifyOffer` uses.
+
+import { recoverFullOfferSigner } from "@bosonprotocol/x402-core/eip712";
+import { describe, expect, it } from "vitest";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { signFullOffer } from "../src/index.js";
+import { baseOffer, ESCROW, TEST_SELLER_PK } from "./fixtures.js";
+
+const CHAIN_ID = 8453;
+
+describe("signFullOffer", () => {
+  it("returns a BosonOfferRef whose signature recovers to the signer", async () => {
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+
+    const offerRef = await signFullOffer({
+      fullOffer: { ...baseOffer, offerCreator: seller.address },
+      signer: seller,
+      escrow: ESCROW,
+      chainId: CHAIN_ID,
+    });
+
+    expect(offerRef.creator.toLowerCase()).toBe(seller.address.toLowerCase());
+    expect(offerRef.sellerSig).toMatch(/^0x[0-9a-f]+$/);
+
+    const recovered = await recoverFullOfferSigner({
+      fullOffer: { ...baseOffer, offerCreator: seller.address },
+      verifyingContract: ESCROW,
+      chainId: CHAIN_ID,
+      signature: offerRef.sellerSig as `0x${string}`,
+    });
+    expect(recovered.toLowerCase()).toBe(seller.address.toLowerCase());
+  });
+
+  it("echoes the unsigned offer through verbatim", async () => {
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+
+    const offerRef = await signFullOffer({
+      fullOffer: baseOffer,
+      signer: seller,
+      escrow: ESCROW,
+      chainId: CHAIN_ID,
+    });
+
+    expect(offerRef.fullOffer).toEqual(baseOffer);
+  });
+});

--- a/typescript/packages/x402-server/tsconfig.json
+++ b/typescript/packages/x402-server/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/typescript/packages/x402-server/tsup.config.ts
+++ b/typescript/packages/x402-server/tsup.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "tsup";
+
+// Dual CJS + ESM build with type declarations. `entry` globs every
+// `index.ts` under `src/`, so any subpath under `src/<subdir>/index.ts`
+// builds as `@bosonprotocol/x402-server/<subdir>` without further config.
+const entry = ["src/**/index.ts"];
+
+export default defineConfig([
+  {
+    entry,
+    format: "esm",
+    outDir: "dist/esm",
+    outExtension: () => ({ js: ".js" }),
+    dts: false,
+    sourcemap: true,
+    clean: true,
+    target: "es2020",
+    treeshake: true,
+  },
+  {
+    entry,
+    format: "cjs",
+    outDir: "dist/cjs",
+    outExtension: () => ({ js: ".js" }),
+    dts: true,
+    sourcemap: true,
+    clean: false,
+    target: "es2020",
+    treeshake: true,
+  },
+]);

--- a/typescript/packages/x402-server/vitest.config.ts
+++ b/typescript/packages/x402-server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

First PR of the [`@bosonprotocol/x402-server`](typescript/packages/x402-server) stack — the framework-agnostic resource-server SDK for the Boson escrow scheme. Ships the request-side primitives only; the X-PAYMENT validator, facilitator HTTP client, convenience handlers, and the Express adapter land as follow-up PRs.

- New package skeleton (`tsup` dual CJS+ESM, `postbuild` module-type markers, vitest, `exports` map for `.` + `./challenge`).
- `signFullOffer()` wraps [`fullOfferTypedData`](typescript/packages/core/src/eip712/full-offer.ts) from `@bosonprotocol/x402-core/eip712` and returns a `BosonOfferRef` whose `sellerSig` recovers via `recoverFullOfferSigner` against the same protocol EIP-712 domain `verifyOffer` uses on-chain.
- `buildPaymentRequirements()` emits a validated `EscrowPaymentRequirements`, stamps `actions` via `deriveInitialNextActions(channelRegistry)`, and now also stamps `actions[].endpoints.facilitator` for every entry whose channels include `"facilitator"` (commit-time → `/settle`, post-commit → `/perform-action?action=<id>`).
- `createX402bServer(config)` factory wires the two together over an `X402bServerConfig` validated at boot — including the channel-registry shape via the canonical [`channelRegistryZodSchema`](typescript/packages/actions/src/registry/index.ts) from `@bosonprotocol/x402-actions` (so config errors surface with the same field-level paths the actions package emits) and the facilitator URL via `z.string().url()` + http(s) refinement.

Spec linkage: [`docs/boson-impl-05-server-sdk.md`](docs/boson-impl-05-server-sdk.md) §Goals 1 + [`docs/boson-impl-01-escrow-scheme.md`](docs/boson-impl-01-escrow-scheme.md) §2 (PaymentRequirements wire format).

Changeset: `.changeset/scaffold-x402-server-package.md` — `@bosonprotocol/x402-server` minor.

## Test plan

- [x] `pnpm install`
- [x] `pnpm build` — all 6 packages green (5 existing + new `@bosonprotocol/x402-server`)
- [x] `pnpm --filter @bosonprotocol/x402-server test` — 8 cases pass (FullOffer signature round-trip; `buildPaymentRequirements` + schema round-trip + `none`/`erc3009` happy paths; `createX402bServer` end-to-end with on-demand offer signing; escrow/channel-registry mismatch rejection; malformed channel-registry rejection; facilitator-URL endpoint stamping)
- [x] `pnpm lint`
- [x] `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Released @bosonprotocol/x402-server v0.1.0: request-side 402 primitives including offer signing, payment-requirements builder, server factory, config validation, and normalized facilitator endpoints.

* **Documentation**
  * Added package README with quick start, examples, and usage notes; included Apache-2.0 license reference.

* **Tests**
  * Added Vitest suites covering signing, requirements building, server validation, facilitator endpoint handling, and related edge cases.

* **Chore**
  * Added package manifest, build/postbuild/test configs, TypeScript config, and updated .gitignore.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/36)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->