### PR TITLE
feat(facilitator): implement settle() — submit + extract exchangeId

### DIFF
--- a/.changeset/implement-facilitator-settle.md
+++ b/.changeset/implement-facilitator-settle.md
@@ -1,0 +1,14 @@
+---
+"@bosonprotocol/x402-facilitator": minor
+---
+
+Implement `settle()`: runs `verify()`, builds the outer
+`executeMetaTransaction` envelope via `@bosonprotocol/x402-evm`,
+submits via the configured viem `WalletClient`, awaits the receipt,
+and extracts `exchangeId` from the `BuyerCommitted` event using
+`@bosonprotocol/common`'s `IBosonExchangeHandlerABI`. Functional for
+`tokenAuthStrategy: "none"`; the BPIP-12 token-auth queue path
+surfaces as `UNSUPPORTED_TOKEN_AUTH_STRATEGY` until
+`@bosonprotocol/x402-evm` ships the encoder. Receipt-level reverts
+surface as `ONCHAIN_REVERT`; receipts without `BuyerCommitted` surface
+as `EVENT_NOT_FOUND`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
 
   typescript/packages/facilitator:
     dependencies:
+      '@bosonprotocol/common':
+        specifier: ^1.32.2
+        version: 1.32.2
       '@bosonprotocol/x402-actions':
         specifier: workspace:^
         version: link:../actions

--- a/typescript/packages/facilitator/package.json
+++ b/typescript/packages/facilitator/package.json
@@ -65,6 +65,7 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
+    "@bosonprotocol/common": "^1.32.2",
     "@bosonprotocol/x402-actions": "workspace:^",
     "@bosonprotocol/x402-core": "workspace:^",
     "@bosonprotocol/x402-evm": "workspace:^",

--- a/typescript/packages/facilitator/src/settle/build-envelope.ts
+++ b/typescript/packages/facilitator/src/settle/build-envelope.ts
@@ -5,17 +5,14 @@
 // which encodes the existing
 // `MetaTransactionsHandlerFacet.executeMetaTransaction(...)` entrypoint.
 //
-// For ERC-3009 / EIP-2612 Permit / Permit2 strategies we delegate to
-// `buildExecuteMetaTransactionWithTokenAuthTx`, which currently throws
-// `NotYetSupportedError` until BPIP-12 ships in `core-sdk`. We catch the
-// throw and surface it to the caller as
-// `UNSUPPORTED_TOKEN_AUTH_STRATEGY` so HTTP consumers get a structured
-// 4xx instead of a 5xx.
+// ERC-3009 / EIP-2612 Permit / Permit2 strategies require the BPIP-12
+// token-auth envelope. That encoder is not wired through here yet because
+// it also needs the buyer's tokenAuth payload, so return a structured
+// `UNSUPPORTED_TOKEN_AUTH_STRATEGY` instead of ever building incomplete
+// calldata.
 
 import {
-  NotYetSupportedError,
   buildExecuteMetaTransactionTx,
-  buildExecuteMetaTransactionWithTokenAuthTx,
   type TxRequest,
 } from "@bosonprotocol/x402-evm/envelope";
 import type {
@@ -55,23 +52,9 @@ export function buildSettleEnvelope(args: BuildSettleEnvelopeArgs): BuildSettleE
     return { ok: true, tx: buildExecuteMetaTransactionTx(common) };
   }
 
-  try {
-    const tx = buildExecuteMetaTransactionWithTokenAuthTx({
-      ...common,
-      // The actual byte layout of `tokenTransferAuthorizations[i]` is
-      // gated on BPIP-12; for now pass an empty queue. When BPIP-12
-      // lands the caller will encode the buyer's tokenAuth payload here.
-      tokenTransferAuthorizations: [],
-    });
-    return { ok: true, tx };
-  } catch (e) {
-    if (e instanceof NotYetSupportedError) {
-      return {
-        ok: false,
-        code: "UNSUPPORTED_TOKEN_AUTH_STRATEGY",
-        reason: `tokenAuthStrategy "${args.strategy}" is not yet supported by @bosonprotocol/x402-evm: ${e.message}`,
-      };
-    }
-    throw e;
-  }
+  return {
+    ok: false,
+    code: "UNSUPPORTED_TOKEN_AUTH_STRATEGY",
+    reason: `tokenAuthStrategy "${args.strategy}" requires the BPIP-12 token-auth envelope, which is not yet wired in settle()`,
+  };
 }

--- a/typescript/packages/facilitator/src/settle/build-envelope.ts
+++ b/typescript/packages/facilitator/src/settle/build-envelope.ts
@@ -11,10 +11,7 @@
 // `UNSUPPORTED_TOKEN_AUTH_STRATEGY` instead of ever building incomplete
 // calldata.
 
-import {
-  buildExecuteMetaTransactionTx,
-  type TxRequest,
-} from "@bosonprotocol/x402-evm/envelope";
+import { buildExecuteMetaTransactionTx, type TxRequest } from "@bosonprotocol/x402-evm/envelope";
 import type {
   Address,
   BosonMetaTx,

--- a/typescript/packages/facilitator/src/settle/build-envelope.ts
+++ b/typescript/packages/facilitator/src/settle/build-envelope.ts
@@ -1,0 +1,77 @@
+// Build the outer meta-tx envelope `settle()` will broadcast.
+//
+// For `tokenAuthStrategy: "none"` we route through
+// `@bosonprotocol/x402-evm/envelope`'s `buildExecuteMetaTransactionTx`,
+// which encodes the existing
+// `MetaTransactionsHandlerFacet.executeMetaTransaction(...)` entrypoint.
+//
+// For ERC-3009 / EIP-2612 Permit / Permit2 strategies we delegate to
+// `buildExecuteMetaTransactionWithTokenAuthTx`, which currently throws
+// `NotYetSupportedError` until BPIP-12 ships in `core-sdk`. We catch the
+// throw and surface it to the caller as
+// `UNSUPPORTED_TOKEN_AUTH_STRATEGY` so HTTP consumers get a structured
+// 4xx instead of a 5xx.
+
+import {
+  NotYetSupportedError,
+  buildExecuteMetaTransactionTx,
+  buildExecuteMetaTransactionWithTokenAuthTx,
+  type TxRequest,
+} from "@bosonprotocol/x402-evm/envelope";
+import type {
+  Address,
+  BosonMetaTx,
+  TokenAuthStrategy,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+
+import type { FacilitatorErrorCode } from "../types.js";
+
+export interface BuildSettleEnvelopeArgs {
+  escrowAddress: Address;
+  buyer: Address;
+  metaTx: BosonMetaTx;
+  strategy: TokenAuthStrategy;
+}
+
+export type BuildSettleEnvelopeResult =
+  | { ok: true; tx: TxRequest }
+  | { ok: false; code: FacilitatorErrorCode; reason: string };
+
+export function buildSettleEnvelope(args: BuildSettleEnvelopeArgs): BuildSettleEnvelopeResult {
+  const common = {
+    escrowAddress: args.escrowAddress as `0x${string}`,
+    userAddress: args.buyer as `0x${string}`,
+    functionName: args.metaTx.functionName,
+    functionSignature: args.metaTx.functionSignature as `0x${string}`,
+    nonce: BigInt(args.metaTx.nonce),
+    sig: {
+      r: args.metaTx.sig.r as `0x${string}`,
+      s: args.metaTx.sig.s as `0x${string}`,
+      v: args.metaTx.sig.v,
+    },
+  };
+
+  if (args.strategy === "none") {
+    return { ok: true, tx: buildExecuteMetaTransactionTx(common) };
+  }
+
+  try {
+    const tx = buildExecuteMetaTransactionWithTokenAuthTx({
+      ...common,
+      // The actual byte layout of `tokenTransferAuthorizations[i]` is
+      // gated on BPIP-12; for now pass an empty queue. When BPIP-12
+      // lands the caller will encode the buyer's tokenAuth payload here.
+      tokenTransferAuthorizations: [],
+    });
+    return { ok: true, tx };
+  } catch (e) {
+    if (e instanceof NotYetSupportedError) {
+      return {
+        ok: false,
+        code: "UNSUPPORTED_TOKEN_AUTH_STRATEGY",
+        reason: `tokenAuthStrategy "${args.strategy}" is not yet supported by @bosonprotocol/x402-evm: ${e.message}`,
+      };
+    }
+    throw e;
+  }
+}

--- a/typescript/packages/facilitator/src/settle/extract-exchange-id.ts
+++ b/typescript/packages/facilitator/src/settle/extract-exchange-id.ts
@@ -1,0 +1,54 @@
+// Extract the on-chain `exchangeId` from a successful commit receipt.
+//
+// Boson's commit path (`createOfferAndCommit` /
+// `createOfferCommitAndRedeem`) emits `BuyerCommitted(uint256 offerId,
+// uint256 buyerId, uint256 exchangeId, BosonTypes.Exchange exchange,
+// BosonTypes.Voucher voucher, address executedBy)` — the canonical ABI
+// lives in `@bosonprotocol/common`'s `IBosonExchangeHandlerABI`. We
+// parse the receipt's logs against that ABI to pull the indexed
+// `exchangeId`.
+
+import { abis } from "@bosonprotocol/common";
+import { parseEventLogs, type TransactionReceipt } from "viem";
+
+import type { FacilitatorErrorCode } from "../types.js";
+
+const EXCHANGE_HANDLER_ABI = abis.IBosonExchangeHandlerABI as readonly unknown[];
+
+export interface ExtractExchangeIdResult {
+  ok: true;
+  exchangeId: string;
+}
+
+export type ExtractExchangeIdReturn =
+  | ExtractExchangeIdResult
+  | { ok: false; code: FacilitatorErrorCode; reason: string };
+
+export function extractExchangeId(receipt: TransactionReceipt): ExtractExchangeIdReturn {
+  const events = parseEventLogs({
+    abi: EXCHANGE_HANDLER_ABI,
+    eventName: "BuyerCommitted",
+    logs: receipt.logs,
+  });
+  const first = events[0];
+  if (!first) {
+    return {
+      ok: false,
+      code: "EVENT_NOT_FOUND",
+      reason: `no BuyerCommitted event in receipt ${receipt.transactionHash}`,
+    };
+  }
+  // viem types the parsed event as `{ args: ... }`. The `args.exchangeId`
+  // is a bigint per the ABI's `uint256`; serialise as a decimal string to
+  // match the wire format every other Boson identifier uses.
+  const args = (first as { args: { exchangeId?: bigint } }).args;
+  const exchangeId = args.exchangeId;
+  if (typeof exchangeId !== "bigint") {
+    return {
+      ok: false,
+      code: "EVENT_NOT_FOUND",
+      reason: "BuyerCommitted event present but exchangeId arg is missing or malformed",
+    };
+  }
+  return { ok: true, exchangeId: exchangeId.toString() };
+}

--- a/typescript/packages/facilitator/src/settle/index.ts
+++ b/typescript/packages/facilitator/src/settle/index.ts
@@ -1,43 +1,71 @@
-// `settle` — submit the buyer's signed meta-tx to
-// `MetaTransactionsHandlerFacet.executeMetaTransaction` on the Boson
-// Diamond.
+// `settle` — submit the buyer's signed meta-tx to the Boson Diamond.
 //
-// In v0.1 (this scaffold) this is a stub that throws NotImplementedError.
+// Pipeline:
+//   1. Run `verify()` first — bail on any failure.
+//   2. Build the outer envelope via @bosonprotocol/x402-evm, dispatching
+//      on payload.tokenAuthStrategy. The `"none"` path is functional;
+//      the BPIP-12 token-auth queue path surfaces as
+//      UNSUPPORTED_TOKEN_AUTH_STRATEGY until x402-evm ships the encoder.
+//   3. Submit via the configured WalletClient (relayer pays gas).
+//   4. Await the receipt; an on-chain revert surfaces as ONCHAIN_REVERT.
+//   5. Parse `BuyerCommitted` from the receipt to extract `exchangeId`.
 //
-// Future implementation funnels every escrow settle through the single
-// on-chain entrypoint described in docs/boson-impl-07-facilitator.md
-// §"Settle path":
-//
-//   MetaTransactionsHandlerFacet.executeMetaTransaction(
-//     userAddress, functionName, functionSignature, nonce, packedSig
-//   )
-//
-// The inner calldata (`payload.metaTx.functionName` and
-// `payload.metaTx.functionSignature`) is passed straight through from the
-// request — the facilitator does not re-build it; the buyer's CoreSDK
-// signs both inner and outer on the client side.
-//
-// Outer envelope construction goes through
-// `@bosonprotocol/x402-evm/envelope`'s `buildExecuteMetaTransactionTx`.
-//
-// On success returns `{ ok: true, exchangeId, txHash }` with `exchangeId`
-// pulled from the receipt's `BuyerCommitted` event.
-//
-// The BPIP-12 `executeMetaTransactionWithTokenTransferAuthorization`
-// path delegates to `buildExecuteMetaTransactionWithTokenAuthTx`, which
-// currently throws `NotYetSupportedError`. We catch and map to
-// `UNSUPPORTED_TOKEN_AUTH_STRATEGY` once implemented.
+// All steps return discriminated-union results — no thrown errors leak
+// to the caller unless the underlying transport itself fails (those map
+// to INTERNAL_ERROR via toResult()).
 
-import { NotImplementedError } from "../errors.js";
 import type {
   FacilitatorConfig,
   FacilitatorSettleInput,
   FacilitatorSettleResult,
 } from "../types.js";
+import { toResult } from "../errors.js";
+import { verify } from "../verify/index.js";
+
+import { buildSettleEnvelope } from "./build-envelope.js";
+import { extractExchangeId } from "./extract-exchange-id.js";
+import { submit } from "./submit.js";
 
 export async function settle(
-  _input: FacilitatorSettleInput,
-  _config: FacilitatorConfig,
+  input: FacilitatorSettleInput,
+  config: FacilitatorConfig,
 ): Promise<FacilitatorSettleResult> {
-  throw new NotImplementedError("settle");
+  try {
+    // 1. Verify first. The verify() result type doesn't carry a success
+    //    payload, so we can re-emit failures as-is and proceed on ok.
+    const v = await verify(input, config);
+    if (!v.ok) return v;
+
+    const inner = input.payload.payload;
+    const escrowAddress = input.requirements.escrowAddress as `0x${string}`;
+
+    // 2. Build outer envelope.
+    const envelope = buildSettleEnvelope({
+      escrowAddress,
+      buyer: inner.buyer as `0x${string}`,
+      metaTx: inner.metaTx,
+      strategy: inner.tokenAuthStrategy,
+    });
+    if (!envelope.ok) return envelope;
+
+    // 3 + 4. Submit and wait for receipt.
+    const submitted = await submit({
+      tx: envelope.tx,
+      walletClient: config.walletClient,
+      publicClient: config.publicClient,
+    });
+    if (!submitted.ok) return submitted;
+
+    // 5. Extract exchangeId from BuyerCommitted.
+    const extracted = extractExchangeId(submitted.receipt);
+    if (!extracted.ok) return extracted;
+
+    return {
+      ok: true,
+      exchangeId: extracted.exchangeId,
+      txHash: submitted.txHash,
+    };
+  } catch (e) {
+    return toResult(e);
+  }
 }

--- a/typescript/packages/facilitator/src/settle/submit.ts
+++ b/typescript/packages/facilitator/src/settle/submit.ts
@@ -60,9 +60,29 @@ export async function submit(args: SubmitArgs): Promise<SubmitResult> {
   } catch (e) {
     return classifySendError(e);
   }
-  const receipt = await args.publicClient.waitForTransactionReceipt({
-    hash: txHash as `0x${string}`,
-  });
+  // `waitForTransactionReceipt` polls the RPC and can reject with a
+  // viem-typed error (`WaitForTransactionReceiptTimeoutError`,
+  // `TransactionNotFoundError`, `TransactionReceiptNotFoundError`) or
+  // any wrapped transport failure. None of those are buyer-attributable
+  // — surface them as INTERNAL_ERROR so operators can retry or inspect
+  // the provider rather than treating them like an on-chain revert.
+  // Genuine reverts land in the `receipt.status !== "success"` branch
+  // below.
+  let receipt: TransactionReceipt;
+  try {
+    receipt = await args.publicClient.waitForTransactionReceipt({
+      hash: txHash as `0x${string}`,
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      reason:
+        e instanceof Error
+          ? `waitForTransactionReceipt failed: ${e.message}`
+          : "waitForTransactionReceipt failed",
+    };
+  }
   if (receipt.status !== "success") {
     return {
       ok: false,

--- a/typescript/packages/facilitator/src/settle/submit.ts
+++ b/typescript/packages/facilitator/src/settle/submit.ts
@@ -3,8 +3,9 @@
 // Submission uses the configured viem `WalletClient` (the relayer pays
 // gas); we then call `waitForTransactionReceipt` on the `PublicClient`
 // to confirm the transaction mined. A receipt with `status !== "success"`
-// is an on-chain revert — surfaced as `ONCHAIN_REVERT` so callers can
-// distinguish from network errors.
+// is an on-chain revert — surfaced as `ONCHAIN_REVERT`. Pre-broadcast
+// operator/provider failures remain distinguishable as INTERNAL_ERROR,
+// except relayer balance failures which map to INSUFFICIENT_FUNDS_FOR_GAS.
 //
 // Note: `walletClient.sendTransaction` here goes through whatever
 // account/transport the operator configured. We don't fetch a fresh
@@ -14,7 +15,16 @@
 
 import type { Hex } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { TxRequest } from "@bosonprotocol/x402-evm/envelope";
-import type { PublicClient, TransactionReceipt, WalletClient } from "viem";
+import {
+  BaseError,
+  ContractFunctionRevertedError,
+  ExecutionRevertedError,
+  InsufficientFundsError,
+  RawContractError,
+  type PublicClient,
+  type TransactionReceipt,
+  type WalletClient,
+} from "viem";
 
 import type { FacilitatorErrorCode } from "../types.js";
 
@@ -48,12 +58,7 @@ export async function submit(args: SubmitArgs): Promise<SubmitResult> {
       value: args.tx.value ?? 0n,
     });
   } catch (e) {
-    return {
-      ok: false,
-      code: "ONCHAIN_REVERT",
-      reason:
-        e instanceof Error ? `sendTransaction failed: ${e.message}` : "sendTransaction failed",
-    };
+    return classifySendError(e);
   }
   const receipt = await args.publicClient.waitForTransactionReceipt({
     hash: txHash as `0x${string}`,
@@ -66,4 +71,29 @@ export async function submit(args: SubmitArgs): Promise<SubmitResult> {
     };
   }
   return { ok: true, txHash, receipt };
+}
+
+function classifySendError(e: unknown): Exclude<SubmitResult, { ok: true }> {
+  const reason = e instanceof Error ? `sendTransaction failed: ${e.message}` : "sendTransaction failed";
+
+  if (hasViemCause(e, InsufficientFundsError)) {
+    return { ok: false, code: "INSUFFICIENT_FUNDS_FOR_GAS", reason };
+  }
+  if (
+    hasViemCause(e, ExecutionRevertedError) ||
+    hasViemCause(e, ContractFunctionRevertedError) ||
+    hasViemCause(e, RawContractError)
+  ) {
+    return { ok: false, code: "ONCHAIN_REVERT", reason };
+  }
+  return { ok: false, code: "INTERNAL_ERROR", reason };
+}
+
+function hasViemCause<T extends abstract new (...args: never[]) => Error>(
+  e: unknown,
+  ctor: T,
+): boolean {
+  if (e instanceof ctor) return true;
+  if (!(e instanceof BaseError)) return false;
+  return e.walk((err) => err instanceof ctor) !== null;
 }

--- a/typescript/packages/facilitator/src/settle/submit.ts
+++ b/typescript/packages/facilitator/src/settle/submit.ts
@@ -1,0 +1,69 @@
+// Broadcast the envelope and await the receipt.
+//
+// Submission uses the configured viem `WalletClient` (the relayer pays
+// gas); we then call `waitForTransactionReceipt` on the `PublicClient`
+// to confirm the transaction mined. A receipt with `status !== "success"`
+// is an on-chain revert — surfaced as `ONCHAIN_REVERT` so callers can
+// distinguish from network errors.
+//
+// Note: `walletClient.sendTransaction` here goes through whatever
+// account/transport the operator configured. We don't fetch a fresh
+// nonce or set gas price — that's the wallet client's responsibility,
+// kept out of this package per the v0.1 scope of
+// docs/boson-impl-07-facilitator.md.
+
+import type { Hex } from "@bosonprotocol/x402-core/schemes/escrow";
+import type { TxRequest } from "@bosonprotocol/x402-evm/envelope";
+import type { PublicClient, TransactionReceipt, WalletClient } from "viem";
+
+import type { FacilitatorErrorCode } from "../types.js";
+
+export interface SubmitArgs {
+  tx: TxRequest;
+  walletClient: WalletClient;
+  publicClient: PublicClient;
+}
+
+export type SubmitResult =
+  | { ok: true; txHash: Hex; receipt: TransactionReceipt }
+  | { ok: false; code: FacilitatorErrorCode; reason: string };
+
+export async function submit(args: SubmitArgs): Promise<SubmitResult> {
+  const account = args.walletClient.account;
+  if (!account) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      reason: "walletClient has no account; cannot send transaction",
+    };
+  }
+  const chain = args.walletClient.chain ?? null;
+  let txHash: Hex;
+  try {
+    txHash = await args.walletClient.sendTransaction({
+      account,
+      chain,
+      to: args.tx.to as `0x${string}`,
+      data: args.tx.data as `0x${string}`,
+      value: args.tx.value ?? 0n,
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      code: "ONCHAIN_REVERT",
+      reason:
+        e instanceof Error ? `sendTransaction failed: ${e.message}` : "sendTransaction failed",
+    };
+  }
+  const receipt = await args.publicClient.waitForTransactionReceipt({
+    hash: txHash as `0x${string}`,
+  });
+  if (receipt.status !== "success") {
+    return {
+      ok: false,
+      code: "ONCHAIN_REVERT",
+      reason: `transaction ${txHash} reverted on-chain`,
+    };
+  }
+  return { ok: true, txHash, receipt };
+}

--- a/typescript/packages/facilitator/src/settle/submit.ts
+++ b/typescript/packages/facilitator/src/settle/submit.ts
@@ -74,7 +74,8 @@ export async function submit(args: SubmitArgs): Promise<SubmitResult> {
 }
 
 function classifySendError(e: unknown): Exclude<SubmitResult, { ok: true }> {
-  const reason = e instanceof Error ? `sendTransaction failed: ${e.message}` : "sendTransaction failed";
+  const reason =
+    e instanceof Error ? `sendTransaction failed: ${e.message}` : "sendTransaction failed";
 
   if (hasViemCause(e, InsufficientFundsError)) {
     return { ok: false, code: "INSUFFICIENT_FUNDS_FOR_GAS", reason };

--- a/typescript/packages/facilitator/test/fixtures.ts
+++ b/typescript/packages/facilitator/test/fixtures.ts
@@ -1,0 +1,169 @@
+// Shared test fixtures for the facilitator package.
+//
+// Centralises the scalar constants, signer accounts, and the `fullOffer`
+// shape used by both `verify.test.ts` and `settle.test.ts` (and any
+// future test file that drives the full verify/settle pipeline). When
+// the Boson calldata shape changes, this is the only place to update.
+//
+// Each consumer keeps its own client / mock builders local — they
+// differ in interesting ways (verify needs `publicClient.call`,
+// settle additionally needs `waitForTransactionReceipt` +
+// `walletClient.sendTransaction`, etc.) and the differences are part
+// of each test's intent.
+
+import { metaTransactionTypedData } from "@bosonprotocol/x402-core/eip712";
+import type {
+  EscrowPaymentPayload,
+  EscrowPaymentRequirements,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+import { buildCreateOfferAndCommitCalldata } from "@bosonprotocol/x402-evm/actions";
+import { parseSignature, type Address, type Hex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Fixed test vectors — deterministic across runs. Re-used between
+// verify and settle test suites so the typed-data the buyer signs in
+// one is bit-for-bit identical to what the other expects.
+export const BUYER_PK =
+  "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" as const;
+export const buyer = privateKeyToAccount(BUYER_PK);
+export const RELAYER_PK =
+  "0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210" as const;
+export const relayer = privateKeyToAccount(RELAYER_PK);
+
+export const ESCROW: Address = "0xdddddddddddddddddddddddddddddddddddddddd";
+export const ASSET: Address = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+export const CHAIN_ID = 1;
+export const NETWORK = `eip155:${CHAIN_ID}`;
+export const NONCE = "1";
+export const SELLER: Address = "0x1111111111111111111111111111111111111111";
+export const SELLER_SIG: Hex = `0x${"33".repeat(65)}`;
+export const AMOUNT = "1000000";
+
+/**
+ * Canonical `fullOffer` literal used to build a real meta-tx calldata
+ * via `buildCreateOfferAndCommitCalldata`. Both verify and settle
+ * require the on-chain calldata embedded in `payload.metaTx` to match
+ * what `requirements.offer.fullOffer` advertises — duplicating this
+ * literal across test files would silently drift the moment the Boson
+ * `FullOffer` struct changes.
+ */
+export const fullOffer = {
+  price: AMOUNT,
+  sellerDeposit: "0",
+  agentId: "0",
+  buyerCancelPenalty: "0",
+  quantityAvailable: "1",
+  validFromDateInMS: "1900000000000",
+  validUntilDateInMS: "1900003600000",
+  voucherRedeemableFromDateInMS: "1900000000000",
+  voucherRedeemableUntilDateInMS: "1900003600000",
+  disputePeriodDurationInMS: "86400000",
+  voucherValidDurationInMS: "0",
+  resolutionPeriodDurationInMS: "604800000",
+  exchangeToken: ASSET,
+  disputeResolverId: "1",
+  metadataUri: "ipfs://QmDeadBeef",
+  metadataHash: "QmDeadBeef",
+  collectionIndex: "0",
+  feeLimit: "0",
+  offerCreator: SELLER,
+  committer: buyer.address,
+  condition: {
+    method: 0,
+    tokenType: 0,
+    tokenAddress: "0x0000000000000000000000000000000000000000",
+    gatingType: 0,
+    minTokenId: "0",
+    threshold: "0",
+    maxCommits: "0",
+    maxTokenId: "0",
+  },
+  useDepositedFunds: false,
+  signature: SELLER_SIG,
+  sellerId: "12345",
+  buyerId: "0",
+  sellerOfferParams: {
+    collectionIndex: "0",
+    royaltyInfo: { recipients: [], bps: [] },
+    mutualizerAddress: "0x0000000000000000000000000000000000000000",
+  },
+};
+
+/**
+ * Build a fully-signed `EscrowPaymentPayload` for
+ * `tokenAuthStrategy: "none"`, using the shared `fullOffer` so the
+ * resulting calldata is consistent with what `buildValidRequirements`
+ * advertises.
+ */
+export async function buildValidPayload(): Promise<EscrowPaymentPayload> {
+  const calldata = buildCreateOfferAndCommitCalldata({
+    fullOffer: fullOffer as Parameters<typeof buildCreateOfferAndCommitCalldata>[0]["fullOffer"],
+  });
+  const typedData = await metaTransactionTypedData({
+    chainId: CHAIN_ID,
+    verifyingContract: ESCROW,
+    message: {
+      nonce: BigInt(NONCE),
+      from: buyer.address,
+      contractAddress: ESCROW,
+      functionName: calldata.functionName,
+      functionSignature: calldata.functionSignature,
+    },
+  });
+  const sig = await buyer.signTypedData({
+    domain: typedData.domain,
+    types: typedData.types,
+    primaryType: typedData.primaryType,
+    message: typedData.message,
+  });
+  const parsed = parseSignature(sig);
+  // viem returns v=27/28 only when yParity is set; normalise to 27/28
+  // explicitly so the buyer's BosonMetaTx field matches the on-chain
+  // LibSignature.recover expectation.
+  const v = parsed.v !== undefined ? Number(parsed.v) : parsed.yParity === 0 ? 27 : 28;
+  return {
+    x402Version: 1,
+    scheme: "escrow",
+    network: NETWORK,
+    payload: {
+      action: "boson-createOfferAndCommit",
+      tokenAuthStrategy: "none",
+      offerRef: { fullOffer, sellerSig: SELLER_SIG },
+      buyer: buyer.address,
+      metaTx: {
+        from: buyer.address,
+        nonce: NONCE,
+        functionName: calldata.functionName,
+        functionSignature: calldata.functionSignature,
+        sig: { v, r: parsed.r, s: parsed.s },
+      },
+    },
+  };
+}
+
+/** Build matching `EscrowPaymentRequirements`. */
+export function buildValidRequirements(): EscrowPaymentRequirements {
+  return {
+    scheme: "escrow",
+    network: NETWORK,
+    asset: ASSET,
+    amount: AMOUNT,
+    escrowAddress: ESCROW,
+    recipientId: "did:boson:seller:42",
+    maxTimeoutSeconds: 3600,
+    offer: {
+      fullOffer,
+      sellerSig: SELLER_SIG,
+      creator: SELLER,
+    },
+    tokenAuthStrategies: ["none"],
+    actions: {
+      next: [
+        {
+          id: "boson-createOfferAndCommit",
+          channels: ["server", "facilitator", "onchain"],
+        },
+      ],
+    },
+  };
+}

--- a/typescript/packages/facilitator/test/settle.test.ts
+++ b/typescript/packages/facilitator/test/settle.test.ts
@@ -8,6 +8,7 @@ import { buildCreateOfferAndCommitCalldata } from "@bosonprotocol/x402-evm/actio
 import { describe, expect, it } from "vitest";
 import {
   BaseError,
+  InsufficientFundsError,
   RawContractError,
   encodeAbiParameters,
   encodeEventTopics,
@@ -266,7 +267,9 @@ function buildPublicClient(
   } as unknown as PublicClient;
 }
 
-function buildWalletClient(opts: { sendBehavior?: "pass" | "fail" } = {}): WalletClient {
+function buildWalletClient(
+  opts: { sendBehavior?: "pass" | "fail" | "insufficient-funds" } = {},
+): WalletClient {
   return {
     account: { address: relayer.address, type: "json-rpc" },
     chain: {
@@ -277,6 +280,7 @@ function buildWalletClient(opts: { sendBehavior?: "pass" | "fail" } = {}): Walle
     },
     sendTransaction: async () => {
       if (opts.sendBehavior === "fail") throw new Error("RPC unreachable");
+      if (opts.sendBehavior === "insufficient-funds") throw new InsufficientFundsError();
       return TX_HASH;
     },
   } as unknown as WalletClient;
@@ -369,7 +373,7 @@ describe("settle()", () => {
     expect(result).toMatchObject({ ok: false, code: "EVENT_NOT_FOUND" });
   });
 
-  it("returns ONCHAIN_REVERT when sendTransaction itself fails", async () => {
+  it("returns INTERNAL_ERROR when sendTransaction fails before broadcast", async () => {
     const payload = await buildValidPayload();
     const requirements = buildValidRequirements();
     const config = buildConfig({ walletClient: buildWalletClient({ sendBehavior: "fail" }) });
@@ -377,7 +381,20 @@ describe("settle()", () => {
       { scheme: "escrow", network: NETWORK, payload, requirements },
       config,
     );
-    expect(result).toMatchObject({ ok: false, code: "ONCHAIN_REVERT" });
+    expect(result).toMatchObject({ ok: false, code: "INTERNAL_ERROR" });
+  });
+
+  it("returns INSUFFICIENT_FUNDS_FOR_GAS when the relayer cannot fund gas", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const config = buildConfig({
+      walletClient: buildWalletClient({ sendBehavior: "insufficient-funds" }),
+    });
+    const result = await settle(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      config,
+    );
+    expect(result).toMatchObject({ ok: false, code: "INSUFFICIENT_FUNDS_FOR_GAS" });
   });
 });
 

--- a/typescript/packages/facilitator/test/settle.test.ts
+++ b/typescript/packages/facilitator/test/settle.test.ts
@@ -4,8 +4,11 @@ import type {
   EscrowPaymentPayload,
   EscrowPaymentRequirements,
 } from "@bosonprotocol/x402-core/schemes/escrow";
+import { buildCreateOfferAndCommitCalldata } from "@bosonprotocol/x402-evm/actions";
 import { describe, expect, it } from "vitest";
 import {
+  BaseError,
+  RawContractError,
   encodeAbiParameters,
   encodeEventTopics,
   keccak256,
@@ -31,13 +34,62 @@ const ESCROW: Address = "0xdddddddddddddddddddddddddddddddddddddddd";
 const ASSET: Address = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 const CHAIN_ID = 1;
 const NETWORK = `eip155:${CHAIN_ID}`;
-const FUNCTION_NAME = "createOfferAndCommit(...)";
-const FUNCTION_SIGNATURE: Hex = "0xdeadbeef";
 const NONCE = "1";
+const SELLER: Address = "0x1111111111111111111111111111111111111111";
+const SELLER_SIG: Hex = `0x${"33".repeat(65)}`;
+const AMOUNT = "1000000";
 const TX_HASH: Hex = `0x${"ab".repeat(32)}`;
 const EXPECTED_EXCHANGE_ID = 42n;
 
+// Mirrors verify.test.ts's fullOffer shape so the verify step inside
+// settle()'s pipeline accepts the calldata as consistent with the
+// advertised offer.
+const fullOffer = {
+  price: AMOUNT,
+  sellerDeposit: "0",
+  agentId: "0",
+  buyerCancelPenalty: "0",
+  quantityAvailable: "1",
+  validFromDateInMS: "1900000000000",
+  validUntilDateInMS: "1900003600000",
+  voucherRedeemableFromDateInMS: "1900000000000",
+  voucherRedeemableUntilDateInMS: "1900003600000",
+  disputePeriodDurationInMS: "86400000",
+  voucherValidDurationInMS: "0",
+  resolutionPeriodDurationInMS: "604800000",
+  exchangeToken: ASSET,
+  disputeResolverId: "1",
+  metadataUri: "ipfs://QmDeadBeef",
+  metadataHash: "QmDeadBeef",
+  collectionIndex: "0",
+  feeLimit: "0",
+  offerCreator: SELLER,
+  committer: buyer.address,
+  condition: {
+    method: 0,
+    tokenType: 0,
+    tokenAddress: "0x0000000000000000000000000000000000000000",
+    gatingType: 0,
+    minTokenId: "0",
+    threshold: "0",
+    maxCommits: "0",
+    maxTokenId: "0",
+  },
+  useDepositedFunds: false,
+  signature: SELLER_SIG,
+  sellerId: "12345",
+  buyerId: "0",
+  sellerOfferParams: {
+    collectionIndex: "0",
+    royaltyInfo: { recipients: [], bps: [] },
+    mutualizerAddress: "0x0000000000000000000000000000000000000000",
+  },
+};
+
 async function buildValidPayload(): Promise<EscrowPaymentPayload> {
+  const calldata = buildCreateOfferAndCommitCalldata({
+    fullOffer: fullOffer as Parameters<typeof buildCreateOfferAndCommitCalldata>[0]["fullOffer"],
+  });
   const typedData = await metaTransactionTypedData({
     chainId: CHAIN_ID,
     verifyingContract: ESCROW,
@@ -45,8 +97,8 @@ async function buildValidPayload(): Promise<EscrowPaymentPayload> {
       nonce: BigInt(NONCE),
       from: buyer.address,
       contractAddress: ESCROW,
-      functionName: FUNCTION_NAME,
-      functionSignature: FUNCTION_SIGNATURE,
+      functionName: calldata.functionName,
+      functionSignature: calldata.functionSignature,
     },
   });
   const sig = await buyer.signTypedData({
@@ -64,13 +116,13 @@ async function buildValidPayload(): Promise<EscrowPaymentPayload> {
     payload: {
       action: "boson-createOfferAndCommit",
       tokenAuthStrategy: "none",
-      offerRef: { fullOffer: {}, sellerSig: "0x00" },
+      offerRef: { fullOffer, sellerSig: SELLER_SIG },
       buyer: buyer.address,
       metaTx: {
         from: buyer.address,
         nonce: NONCE,
-        functionName: FUNCTION_NAME,
-        functionSignature: FUNCTION_SIGNATURE,
+        functionName: calldata.functionName,
+        functionSignature: calldata.functionSignature,
         sig: { v, r: parsed.r, s: parsed.s },
       },
     },
@@ -82,14 +134,14 @@ function buildValidRequirements(): EscrowPaymentRequirements {
     scheme: "escrow",
     network: NETWORK,
     asset: ASSET,
-    amount: "1000000",
+    amount: AMOUNT,
     escrowAddress: ESCROW,
     recipientId: "did:boson:seller:42",
     maxTimeoutSeconds: 3600,
     offer: {
-      fullOffer: {},
-      sellerSig: "0x00",
-      creator: "0x1111111111111111111111111111111111111111",
+      fullOffer,
+      sellerSig: SELLER_SIG,
+      creator: SELLER,
     },
     tokenAuthStrategies: ["none"],
     actions: {
@@ -198,7 +250,12 @@ function buildPublicClient(
   return {
     call: async () => {
       if (opts.callBehavior === "revert") {
-        throw new Error("execution reverted: simulated revert");
+        // Match viem's actual error shape: a BaseError whose cause
+        // chain contains a RawContractError. simulate.ts's
+        // isOnChainRevert walks the chain looking for this marker to
+        // distinguish a real revert from a transport-layer failure.
+        const cause = new RawContractError({ message: "execution reverted: simulated revert" });
+        throw new BaseError("Execution reverted", { cause });
       }
       return { data: "0x" };
     },

--- a/typescript/packages/facilitator/test/settle.test.ts
+++ b/typescript/packages/facilitator/test/settle.test.ts
@@ -1,10 +1,4 @@
 import { abis } from "@bosonprotocol/common";
-import { metaTransactionTypedData } from "@bosonprotocol/x402-core/eip712";
-import type {
-  EscrowPaymentPayload,
-  EscrowPaymentRequirements,
-} from "@bosonprotocol/x402-core/schemes/escrow";
-import { buildCreateOfferAndCommitCalldata } from "@bosonprotocol/x402-evm/actions";
 import { describe, expect, it } from "vitest";
 import {
   BaseError,
@@ -13,143 +7,28 @@ import {
   encodeAbiParameters,
   encodeEventTopics,
   keccak256,
-  parseSignature,
   toBytes,
-  type Address,
   type Hex,
   type PublicClient,
   type TransactionReceipt,
   type WalletClient,
 } from "viem";
-import { privateKeyToAccount } from "viem/accounts";
 
 import { settle } from "../src/settle/index.js";
 import type { FacilitatorConfig } from "../src/types.js";
 
-const BUYER_PK = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" as const;
-const buyer = privateKeyToAccount(BUYER_PK);
-const RELAYER_PK = "0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210" as const;
-const relayer = privateKeyToAccount(RELAYER_PK);
+import {
+  buildValidPayload,
+  buildValidRequirements,
+  buyer,
+  CHAIN_ID,
+  ESCROW,
+  NETWORK,
+  relayer,
+} from "./fixtures.js";
 
-const ESCROW: Address = "0xdddddddddddddddddddddddddddddddddddddddd";
-const ASSET: Address = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
-const CHAIN_ID = 1;
-const NETWORK = `eip155:${CHAIN_ID}`;
-const NONCE = "1";
-const SELLER: Address = "0x1111111111111111111111111111111111111111";
-const SELLER_SIG: Hex = `0x${"33".repeat(65)}`;
-const AMOUNT = "1000000";
 const TX_HASH: Hex = `0x${"ab".repeat(32)}`;
 const EXPECTED_EXCHANGE_ID = 42n;
-
-// Mirrors verify.test.ts's fullOffer shape so the verify step inside
-// settle()'s pipeline accepts the calldata as consistent with the
-// advertised offer.
-const fullOffer = {
-  price: AMOUNT,
-  sellerDeposit: "0",
-  agentId: "0",
-  buyerCancelPenalty: "0",
-  quantityAvailable: "1",
-  validFromDateInMS: "1900000000000",
-  validUntilDateInMS: "1900003600000",
-  voucherRedeemableFromDateInMS: "1900000000000",
-  voucherRedeemableUntilDateInMS: "1900003600000",
-  disputePeriodDurationInMS: "86400000",
-  voucherValidDurationInMS: "0",
-  resolutionPeriodDurationInMS: "604800000",
-  exchangeToken: ASSET,
-  disputeResolverId: "1",
-  metadataUri: "ipfs://QmDeadBeef",
-  metadataHash: "QmDeadBeef",
-  collectionIndex: "0",
-  feeLimit: "0",
-  offerCreator: SELLER,
-  committer: buyer.address,
-  condition: {
-    method: 0,
-    tokenType: 0,
-    tokenAddress: "0x0000000000000000000000000000000000000000",
-    gatingType: 0,
-    minTokenId: "0",
-    threshold: "0",
-    maxCommits: "0",
-    maxTokenId: "0",
-  },
-  useDepositedFunds: false,
-  signature: SELLER_SIG,
-  sellerId: "12345",
-  buyerId: "0",
-  sellerOfferParams: {
-    collectionIndex: "0",
-    royaltyInfo: { recipients: [], bps: [] },
-    mutualizerAddress: "0x0000000000000000000000000000000000000000",
-  },
-};
-
-async function buildValidPayload(): Promise<EscrowPaymentPayload> {
-  const calldata = buildCreateOfferAndCommitCalldata({
-    fullOffer: fullOffer as Parameters<typeof buildCreateOfferAndCommitCalldata>[0]["fullOffer"],
-  });
-  const typedData = await metaTransactionTypedData({
-    chainId: CHAIN_ID,
-    verifyingContract: ESCROW,
-    message: {
-      nonce: BigInt(NONCE),
-      from: buyer.address,
-      contractAddress: ESCROW,
-      functionName: calldata.functionName,
-      functionSignature: calldata.functionSignature,
-    },
-  });
-  const sig = await buyer.signTypedData({
-    domain: typedData.domain,
-    types: typedData.types,
-    primaryType: typedData.primaryType,
-    message: typedData.message,
-  });
-  const parsed = parseSignature(sig);
-  const v = parsed.v !== undefined ? Number(parsed.v) : parsed.yParity === 0 ? 27 : 28;
-  return {
-    x402Version: 1,
-    scheme: "escrow",
-    network: NETWORK,
-    payload: {
-      action: "boson-createOfferAndCommit",
-      tokenAuthStrategy: "none",
-      offerRef: { fullOffer, sellerSig: SELLER_SIG },
-      buyer: buyer.address,
-      metaTx: {
-        from: buyer.address,
-        nonce: NONCE,
-        functionName: calldata.functionName,
-        functionSignature: calldata.functionSignature,
-        sig: { v, r: parsed.r, s: parsed.s },
-      },
-    },
-  };
-}
-
-function buildValidRequirements(): EscrowPaymentRequirements {
-  return {
-    scheme: "escrow",
-    network: NETWORK,
-    asset: ASSET,
-    amount: AMOUNT,
-    escrowAddress: ESCROW,
-    recipientId: "did:boson:seller:42",
-    maxTimeoutSeconds: 3600,
-    offer: {
-      fullOffer,
-      sellerSig: SELLER_SIG,
-      creator: SELLER,
-    },
-    tokenAuthStrategies: ["none"],
-    actions: {
-      next: [{ id: "boson-createOfferAndCommit", channels: ["server", "facilitator", "onchain"] }],
-    },
-  };
-}
 
 /**
  * Build a synthetic receipt with one BuyerCommitted log. Encodes the

--- a/typescript/packages/facilitator/test/settle.test.ts
+++ b/typescript/packages/facilitator/test/settle.test.ts
@@ -246,6 +246,7 @@ function buildPublicClient(
   opts: {
     callBehavior?: "pass" | "revert";
     receipt?: TransactionReceipt;
+    waitBehavior?: "ok" | "timeout";
   } = {},
 ): PublicClient {
   return {
@@ -263,7 +264,18 @@ function buildPublicClient(
     readContract: async () => {
       throw new Error("readContract not stubbed");
     },
-    waitForTransactionReceipt: async () => opts.receipt ?? buildReceipt(),
+    waitForTransactionReceipt: async () => {
+      if (opts.waitBehavior === "timeout") {
+        // viem rejects waitForTransactionReceipt with a typed error on
+        // poll timeout (WaitForTransactionReceiptTimeoutError) — a
+        // BaseError subclass. Mimic that shape so submit() exercises
+        // its catch branch.
+        throw new BaseError("Timed out while waiting for transaction receipt", {
+          cause: new Error("poll deadline exceeded after 30s"),
+        });
+      }
+      return opts.receipt ?? buildReceipt();
+    },
   } as unknown as PublicClient;
 }
 
@@ -382,6 +394,20 @@ describe("settle()", () => {
       config,
     );
     expect(result).toMatchObject({ ok: false, code: "INTERNAL_ERROR" });
+  });
+
+  it("returns INTERNAL_ERROR when waitForTransactionReceipt times out", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const config = buildConfig({
+      publicClient: buildPublicClient({ waitBehavior: "timeout" }),
+    });
+    const result = await settle(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      config,
+    );
+    expect(result).toMatchObject({ ok: false, code: "INTERNAL_ERROR" });
+    expect((result as { ok: false; reason: string }).reason).toContain("waitForTransactionReceipt");
   });
 
   it("returns INSUFFICIENT_FUNDS_FOR_GAS when the relayer cannot fund gas", async () => {

--- a/typescript/packages/facilitator/test/settle.test.ts
+++ b/typescript/packages/facilitator/test/settle.test.ts
@@ -1,0 +1,365 @@
+import { abis } from "@bosonprotocol/common";
+import { metaTransactionTypedData } from "@bosonprotocol/x402-core/eip712";
+import type {
+  EscrowPaymentPayload,
+  EscrowPaymentRequirements,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+import { describe, expect, it } from "vitest";
+import {
+  encodeAbiParameters,
+  encodeEventTopics,
+  keccak256,
+  parseSignature,
+  toBytes,
+  type Address,
+  type Hex,
+  type PublicClient,
+  type TransactionReceipt,
+  type WalletClient,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { settle } from "../src/settle/index.js";
+import type { FacilitatorConfig } from "../src/types.js";
+
+const BUYER_PK = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" as const;
+const buyer = privateKeyToAccount(BUYER_PK);
+const RELAYER_PK = "0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210" as const;
+const relayer = privateKeyToAccount(RELAYER_PK);
+
+const ESCROW: Address = "0xdddddddddddddddddddddddddddddddddddddddd";
+const ASSET: Address = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const CHAIN_ID = 1;
+const NETWORK = `eip155:${CHAIN_ID}`;
+const FUNCTION_NAME = "createOfferAndCommit(...)";
+const FUNCTION_SIGNATURE: Hex = "0xdeadbeef";
+const NONCE = "1";
+const TX_HASH: Hex = `0x${"ab".repeat(32)}`;
+const EXPECTED_EXCHANGE_ID = 42n;
+
+async function buildValidPayload(): Promise<EscrowPaymentPayload> {
+  const typedData = await metaTransactionTypedData({
+    chainId: CHAIN_ID,
+    verifyingContract: ESCROW,
+    message: {
+      nonce: BigInt(NONCE),
+      from: buyer.address,
+      contractAddress: ESCROW,
+      functionName: FUNCTION_NAME,
+      functionSignature: FUNCTION_SIGNATURE,
+    },
+  });
+  const sig = await buyer.signTypedData({
+    domain: typedData.domain,
+    types: typedData.types,
+    primaryType: typedData.primaryType,
+    message: typedData.message,
+  });
+  const parsed = parseSignature(sig);
+  const v = parsed.v !== undefined ? Number(parsed.v) : parsed.yParity === 0 ? 27 : 28;
+  return {
+    x402Version: 1,
+    scheme: "escrow",
+    network: NETWORK,
+    payload: {
+      action: "boson-createOfferAndCommit",
+      tokenAuthStrategy: "none",
+      offerRef: { fullOffer: {}, sellerSig: "0x00" },
+      buyer: buyer.address,
+      metaTx: {
+        from: buyer.address,
+        nonce: NONCE,
+        functionName: FUNCTION_NAME,
+        functionSignature: FUNCTION_SIGNATURE,
+        sig: { v, r: parsed.r, s: parsed.s },
+      },
+    },
+  };
+}
+
+function buildValidRequirements(): EscrowPaymentRequirements {
+  return {
+    scheme: "escrow",
+    network: NETWORK,
+    asset: ASSET,
+    amount: "1000000",
+    escrowAddress: ESCROW,
+    recipientId: "did:boson:seller:42",
+    maxTimeoutSeconds: 3600,
+    offer: {
+      fullOffer: {},
+      sellerSig: "0x00",
+      creator: "0x1111111111111111111111111111111111111111",
+    },
+    tokenAuthStrategies: ["none"],
+    actions: {
+      next: [{ id: "boson-createOfferAndCommit", channels: ["server", "facilitator", "onchain"] }],
+    },
+  };
+}
+
+/**
+ * Build a synthetic receipt with one BuyerCommitted log. Encodes the
+ * indexed `exchangeId` into topic[3] so viem's parseEventLogs finds it.
+ */
+function buildReceipt(
+  opts: {
+    status?: "success" | "reverted";
+    withBuyerCommitted?: boolean;
+  } = {},
+): TransactionReceipt {
+  const status = opts.status ?? "success";
+  const withBuyerCommitted = opts.withBuyerCommitted ?? true;
+  const topics = withBuyerCommitted
+    ? encodeEventTopics({
+        abi: abis.IBosonExchangeHandlerABI as readonly unknown[],
+        eventName: "BuyerCommitted",
+        args: {
+          offerId: 1n,
+          buyerId: 2n,
+          exchangeId: EXPECTED_EXCHANGE_ID,
+        },
+      })
+    : [keccak256(toBytes("UnrelatedEvent(uint256)"))];
+  // Non-indexed args of BuyerCommitted: (Exchange exchange, Voucher
+  // voucher, address executedBy). The struct shapes come from
+  // @bosonprotocol/common's IBosonExchangeHandler ABI.
+  const nonIndexedData = withBuyerCommitted
+    ? encodeAbiParameters(
+        [
+          {
+            type: "tuple",
+            components: [
+              { name: "id", type: "uint256" },
+              { name: "offerId", type: "uint256" },
+              { name: "buyerId", type: "uint256" },
+              { name: "finalizedDate", type: "uint256" },
+              { name: "state", type: "uint8" },
+              { name: "mutualizerAddress", type: "address" },
+            ],
+          },
+          {
+            type: "tuple",
+            components: [
+              { name: "committedDate", type: "uint256" },
+              { name: "validUntilDate", type: "uint256" },
+              { name: "redeemedDate", type: "uint256" },
+              { name: "expired", type: "bool" },
+            ],
+          },
+          { type: "address" },
+        ],
+        [
+          {
+            id: EXPECTED_EXCHANGE_ID,
+            offerId: 1n,
+            buyerId: 2n,
+            finalizedDate: 0n,
+            state: 0,
+            mutualizerAddress: "0x0000000000000000000000000000000000000000",
+          },
+          {
+            committedDate: 1700000000n,
+            validUntilDate: 1800000000n,
+            redeemedDate: 0n,
+            expired: false,
+          },
+          relayer.address,
+        ],
+      )
+    : "0x";
+  return {
+    transactionHash: TX_HASH,
+    status,
+    logs: withBuyerCommitted
+      ? [
+          {
+            address: ESCROW,
+            topics,
+            data: nonIndexedData,
+            blockNumber: 1n,
+            transactionIndex: 0,
+            logIndex: 0,
+            blockHash: `0x${"00".repeat(32)}`,
+            transactionHash: TX_HASH,
+            removed: false,
+          },
+        ]
+      : [],
+  } as unknown as TransactionReceipt;
+}
+
+function buildPublicClient(
+  opts: {
+    callBehavior?: "pass" | "revert";
+    receipt?: TransactionReceipt;
+  } = {},
+): PublicClient {
+  return {
+    call: async () => {
+      if (opts.callBehavior === "revert") {
+        throw new Error("execution reverted: simulated revert");
+      }
+      return { data: "0x" };
+    },
+    readContract: async () => {
+      throw new Error("readContract not stubbed");
+    },
+    waitForTransactionReceipt: async () => opts.receipt ?? buildReceipt(),
+  } as unknown as PublicClient;
+}
+
+function buildWalletClient(opts: { sendBehavior?: "pass" | "fail" } = {}): WalletClient {
+  return {
+    account: { address: relayer.address, type: "json-rpc" },
+    chain: {
+      id: CHAIN_ID,
+      name: "test",
+      nativeCurrency: { decimals: 18, name: "ETH", symbol: "ETH" },
+      rpcUrls: { default: { http: [] } },
+    },
+    sendTransaction: async () => {
+      if (opts.sendBehavior === "fail") throw new Error("RPC unreachable");
+      return TX_HASH;
+    },
+  } as unknown as WalletClient;
+}
+
+function buildConfig(
+  opts: { publicClient?: PublicClient; walletClient?: WalletClient } = {},
+): FacilitatorConfig {
+  return {
+    url: "https://facilitator.example",
+    supportedNetworks: [NETWORK],
+    walletClient: opts.walletClient ?? buildWalletClient(),
+    publicClient: opts.publicClient ?? buildPublicClient(),
+  };
+}
+
+describe("settle()", () => {
+  it("happy path: verify passes, envelope built, tx submitted, exchangeId extracted", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const result = await settle(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toEqual({
+      ok: true,
+      exchangeId: EXPECTED_EXCHANGE_ID.toString(),
+      txHash: TX_HASH,
+    });
+  });
+
+  it("re-emits verify failure when network is wrong", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const result = await settle(
+      { scheme: "escrow", network: "eip155:137", payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "NETWORK_MISMATCH" });
+  });
+
+  it("re-emits verify failure when simulation reverts", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const config = buildConfig({
+      publicClient: buildPublicClient({ callBehavior: "revert" }),
+    });
+    const result = await settle(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      config,
+    );
+    expect(result).toMatchObject({ ok: false, code: "SIMULATION_REVERT" });
+  });
+
+  // The non-"none" token-auth path through settle requires a real
+  // signed Permit / ERC-3009 / Permit2 payload AND a working
+  // publicClient.readContract for the token-domain lookup. We exercise
+  // verify's signature-recovery on its own in verify.test.ts and the
+  // UNSUPPORTED_TOKEN_AUTH_STRATEGY mapping in the `buildSettleEnvelope`
+  // describe block below — together they cover the path without a real
+  // anvil fork.
+
+  it("returns ONCHAIN_REVERT when receipt status is reverted", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const config = buildConfig({
+      publicClient: buildPublicClient({
+        receipt: buildReceipt({ status: "reverted" }),
+      }),
+    });
+    const result = await settle(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      config,
+    );
+    expect(result).toMatchObject({ ok: false, code: "ONCHAIN_REVERT" });
+  });
+
+  it("returns EVENT_NOT_FOUND when receipt has no BuyerCommitted log", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const config = buildConfig({
+      publicClient: buildPublicClient({
+        receipt: buildReceipt({ withBuyerCommitted: false }),
+      }),
+    });
+    const result = await settle(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      config,
+    );
+    expect(result).toMatchObject({ ok: false, code: "EVENT_NOT_FOUND" });
+  });
+
+  it("returns ONCHAIN_REVERT when sendTransaction itself fails", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const config = buildConfig({ walletClient: buildWalletClient({ sendBehavior: "fail" }) });
+    const result = await settle(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      config,
+    );
+    expect(result).toMatchObject({ ok: false, code: "ONCHAIN_REVERT" });
+  });
+});
+
+describe("buildSettleEnvelope", () => {
+  it("returns UNSUPPORTED_TOKEN_AUTH_STRATEGY for non-none strategies", async () => {
+    const { buildSettleEnvelope } = await import("../src/settle/build-envelope.js");
+    const result = buildSettleEnvelope({
+      escrowAddress: ESCROW,
+      buyer: buyer.address,
+      metaTx: {
+        from: buyer.address,
+        nonce: "1",
+        functionName: "foo()",
+        functionSignature: "0xdeadbeef",
+        sig: { v: 27, r: `0x${"11".repeat(32)}`, s: `0x${"22".repeat(32)}` },
+      },
+      strategy: "erc3009",
+    });
+    expect(result).toMatchObject({ ok: false, code: "UNSUPPORTED_TOKEN_AUTH_STRATEGY" });
+  });
+
+  it("returns a TxRequest for tokenAuthStrategy 'none'", async () => {
+    const { buildSettleEnvelope } = await import("../src/settle/build-envelope.js");
+    const result = buildSettleEnvelope({
+      escrowAddress: ESCROW,
+      buyer: buyer.address,
+      metaTx: {
+        from: buyer.address,
+        nonce: "1",
+        functionName: "foo()",
+        functionSignature: "0xdeadbeef",
+        sig: { v: 27, r: `0x${"11".repeat(32)}`, s: `0x${"22".repeat(32)}` },
+      },
+      strategy: "none",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.tx.to).toBe(ESCROW);
+      expect(result.tx.data.startsWith("0x")).toBe(true);
+    }
+  });
+});

--- a/typescript/packages/facilitator/test/stubs.test.ts
+++ b/typescript/packages/facilitator/test/stubs.test.ts
@@ -3,27 +3,18 @@ import { describe, expect, it } from "vitest";
 import {
   NotImplementedError,
   performAction,
-  settle,
   type FacilitatorConfig,
   type FacilitatorPerformActionInput,
-  type FacilitatorSettleInput,
 } from "../src/index.js";
 
-// settle() and performAction() remain stubs in this commit — they throw
-// NotImplementedError until later commits wire them up. Cast through
-// unknown so the test doesn't drag the full viem WalletClient /
+// performAction() remains a stub in this commit — it throws
+// NotImplementedError until the next commit wires up the dispatch. Cast
+// through unknown so the test doesn't drag the full viem WalletClient /
 // PublicClient surface into a contract that's checked elsewhere.
 const dummyConfig = {} as unknown as FacilitatorConfig;
-const dummySettleInput = {} as unknown as FacilitatorSettleInput;
 const dummyPerformActionInput = {} as unknown as FacilitatorPerformActionInput;
 
 describe("v0.1 stubs throw NotImplementedError", () => {
-  it("settle() rejects with NotImplementedError and code NOT_IMPLEMENTED", async () => {
-    const promise = settle(dummySettleInput, dummyConfig);
-    await expect(promise).rejects.toBeInstanceOf(NotImplementedError);
-    await expect(promise).rejects.toMatchObject({ code: "NOT_IMPLEMENTED" });
-  });
-
   it("performAction() rejects with NotImplementedError and code NOT_IMPLEMENTED", async () => {
     const promise = performAction(dummyPerformActionInput, dummyConfig);
     await expect(promise).rejects.toBeInstanceOf(NotImplementedError);

--- a/typescript/packages/facilitator/test/verify.test.ts
+++ b/typescript/packages/facilitator/test/verify.test.ts
@@ -1,155 +1,30 @@
-import { metaTransactionTypedData } from "@bosonprotocol/x402-core/eip712";
 import { permit2TypedData } from "@bosonprotocol/x402-core/eip712/token-auth";
-import type {
-  EscrowPaymentPayload,
-  EscrowPaymentRequirements,
-} from "@bosonprotocol/x402-core/schemes/escrow";
-import { buildCreateOfferAndCommitCalldata } from "@bosonprotocol/x402-evm/actions";
 import { describe, expect, it } from "vitest";
 import {
   BaseError,
   RawContractError,
-  parseSignature,
   type Address,
   type Hex,
   type PublicClient,
   type WalletClient,
 } from "viem";
-import { privateKeyToAccount } from "viem/accounts";
 
 import { verify } from "../src/verify/index.js";
 import type { FacilitatorConfig } from "../src/types.js";
 
-// Fixed test vectors — deterministic across runs.
-const BUYER_PK = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" as const;
-const buyer = privateKeyToAccount(BUYER_PK);
-const RELAYER_PK = "0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210" as const;
-const relayer = privateKeyToAccount(RELAYER_PK);
-
-const ESCROW: Address = "0xdddddddddddddddddddddddddddddddddddddddd";
-const ASSET: Address = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
-const CHAIN_ID = 1;
-const NETWORK = `eip155:${CHAIN_ID}`;
-const NONCE = "1";
-const SELLER: Address = "0x1111111111111111111111111111111111111111";
-const SELLER_SIG: Hex = `0x${"33".repeat(65)}`;
-const AMOUNT = "1000000";
-
-const fullOffer = {
-  price: AMOUNT,
-  sellerDeposit: "0",
-  agentId: "0",
-  buyerCancelPenalty: "0",
-  quantityAvailable: "1",
-  validFromDateInMS: "1900000000000",
-  validUntilDateInMS: "1900003600000",
-  voucherRedeemableFromDateInMS: "1900000000000",
-  voucherRedeemableUntilDateInMS: "1900003600000",
-  disputePeriodDurationInMS: "86400000",
-  voucherValidDurationInMS: "0",
-  resolutionPeriodDurationInMS: "604800000",
-  exchangeToken: ASSET,
-  disputeResolverId: "1",
-  metadataUri: "ipfs://QmDeadBeef",
-  metadataHash: "QmDeadBeef",
-  collectionIndex: "0",
-  feeLimit: "0",
-  offerCreator: SELLER,
-  committer: buyer.address,
-  condition: {
-    method: 0,
-    tokenType: 0,
-    tokenAddress: "0x0000000000000000000000000000000000000000",
-    gatingType: 0,
-    minTokenId: "0",
-    threshold: "0",
-    maxCommits: "0",
-    maxTokenId: "0",
-  },
-  useDepositedFunds: false,
-  signature: SELLER_SIG,
-  sellerId: "12345",
-  buyerId: "0",
-  sellerOfferParams: {
-    collectionIndex: "0",
-    royaltyInfo: { recipients: [], bps: [] },
-    mutualizerAddress: "0x0000000000000000000000000000000000000000",
-  },
-};
-
-/** Build a fully-signed EscrowPaymentPayload for `tokenAuthStrategy: "none"`. */
-async function buildValidPayload(): Promise<EscrowPaymentPayload> {
-  const calldata = buildCreateOfferAndCommitCalldata({
-    fullOffer: fullOffer as Parameters<typeof buildCreateOfferAndCommitCalldata>[0]["fullOffer"],
-  });
-  const typedData = await metaTransactionTypedData({
-    chainId: CHAIN_ID,
-    verifyingContract: ESCROW,
-    message: {
-      nonce: BigInt(NONCE),
-      from: buyer.address,
-      contractAddress: ESCROW,
-      functionName: calldata.functionName,
-      functionSignature: calldata.functionSignature,
-    },
-  });
-  const sig = await buyer.signTypedData({
-    domain: typedData.domain,
-    types: typedData.types,
-    primaryType: typedData.primaryType,
-    message: typedData.message,
-  });
-  const parsed = parseSignature(sig);
-  // viem returns v=27/28 only when yParity is set; normalise to 27/28 form
-  // explicitly so the buyer's BosonMetaTx field matches the on-chain
-  // LibSignature.recover expectation.
-  const v = parsed.v !== undefined ? Number(parsed.v) : parsed.yParity === 0 ? 27 : 28;
-  return {
-    x402Version: 1,
-    scheme: "escrow",
-    network: NETWORK,
-    payload: {
-      action: "boson-createOfferAndCommit",
-      tokenAuthStrategy: "none",
-      offerRef: { fullOffer, sellerSig: SELLER_SIG },
-      buyer: buyer.address,
-      metaTx: {
-        from: buyer.address,
-        nonce: NONCE,
-        functionName: calldata.functionName,
-        functionSignature: calldata.functionSignature,
-        sig: { v, r: parsed.r, s: parsed.s },
-      },
-    },
-  };
-}
-
-/** Build matching requirements. */
-function buildValidRequirements(): EscrowPaymentRequirements {
-  return {
-    scheme: "escrow",
-    network: NETWORK,
-    asset: ASSET,
-    amount: AMOUNT,
-    escrowAddress: ESCROW,
-    recipientId: "did:boson:seller:42",
-    maxTimeoutSeconds: 3600,
-    offer: {
-      fullOffer,
-      sellerSig: SELLER_SIG,
-      creator: SELLER,
-    },
-    tokenAuthStrategies: ["none"],
-    actions: {
-      next: [
-        {
-          id: "boson-createOfferAndCommit",
-          channels: ["server", "facilitator", "onchain"],
-        },
-      ],
-    },
-  };
-}
+import {
+  AMOUNT,
+  ASSET,
+  buildValidPayload,
+  buildValidRequirements,
+  buyer,
+  CHAIN_ID,
+  ESCROW,
+  fullOffer,
+  NETWORK,
+  NONCE,
+  relayer,
+} from "./fixtures.js";
 
 /**
  * Build a PublicClient stub whose `call` is configurable per test.

--- a/typescript/packages/facilitator/test/verify.test.ts
+++ b/typescript/packages/facilitator/test/verify.test.ts
@@ -4,7 +4,6 @@ import {
   BaseError,
   RawContractError,
   type Address,
-  type Hex,
   type PublicClient,
   type WalletClient,
 } from "viem";
@@ -22,7 +21,6 @@ import {
   ESCROW,
   fullOffer,
   NETWORK,
-  NONCE,
   relayer,
 } from "./fixtures.js";
 


### PR DESCRIPTION
## Summary

Wires up `@bosonprotocol/x402-facilitator`'s `settle()` library function — the `POST /settle` half of `docs/boson-impl-07-facilitator.md`'s contract. Stacked on top of merged PR #35 (`verify()`).

Pipeline:

1. **Run `verify()` first** — bail on any failure with the underlying `code` / `reason`. The full pre-flight chain (structural / scheme / network / action / strategy / signatures / simulation) runs before any tx is submitted.
2. **Build outer envelope** — dispatch on `payload.tokenAuthStrategy`:
   - `"none"` → `buildExecuteMetaTransactionTx` from `@bosonprotocol/x402-evm/envelope`. Functional today.
   - `"erc3009" | "permit" | "permit2"` → `buildExecuteMetaTransactionWithTokenAuthTx` (deferred in `@bosonprotocol/x402-evm`) — the `NotYetSupportedError` is caught and surfaced as `UNSUPPORTED_TOKEN_AUTH_STRATEGY`.
3. **Submit** via the configured viem `WalletClient` — the relayer pays gas; the facilitator never holds the signing key.
4. **Await the receipt** via `publicClient.waitForTransactionReceipt`. A receipt status of `"reverted"` surfaces as `ONCHAIN_REVERT`.
5. **Extract `exchangeId`** — `parseEventLogs` against `@bosonprotocol/common`'s `IBosonExchangeHandlerABI`, reading the indexed `exchangeId` from `BuyerCommitted`. Receipts without `BuyerCommitted` surface as `EVENT_NOT_FOUND`.

Submission errors are classified rather than collapsed into `ONCHAIN_REVERT`: transport / RPC failures from `sendTransaction` / `waitForTransactionReceipt` distinguish from on-chain reverts so operators get the right signal (retry the relayer vs investigate the payload).

The "fixture-alignment" commit threads through the verify hardening that landed on `main` while this branch was rebased: real calldata via `buildCreateOfferAndCommitCalldata` and viem `BaseError` + `RawContractError` for the revert mock.

Adds `@bosonprotocol/common` to runtime deps (for `IBosonExchangeHandlerABI`).

Spec: [`docs/boson-impl-07-facilitator.md`](./docs/boson-impl-07-facilitator.md) §"Settle path".

## Test plan

- [ ] `pnpm install`
- [ ] `pnpm build` — workspace builds clean
- [ ] `pnpm test` — 39 facilitator tests pass (types, channels, stubs, verify, settle)
- [ ] `pnpm lint` — zero warnings
- [ ] `pnpm format:check` — clean
- [ ] Verify failure-code coverage in `test/settle.test.ts`: every `FacilitatorErrorCode` reachable from `settle()` (verify-bail / `UNSUPPORTED_TOKEN_AUTH_STRATEGY` / `ONCHAIN_REVERT` / `EVENT_NOT_FOUND` / `INTERNAL_ERROR`) has at least one test exercising it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented a full settle() pipeline: verify input, build and submit meta-transaction, await confirmation, and return exchangeId and tx hash on success (supports tokenAuthStrategy "none"; other strategies yield an explicit unsupported response).

* **Bug Fixes**
  * Standardized error mapping for on-chain reverts and missing event cases to clearer failure codes.

* **Tests**
  * Added comprehensive tests covering happy path, multiple failure modes, and shared deterministic fixtures.

* **Chores**
  * Added a new runtime dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/37)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->