### PR TITLE
feat(x402-server): X-PAYMENT 13-rule validator

### DIFF
--- a/.changeset/add-x402-server-validator.md
+++ b/.changeset/add-x402-server-validator.md
@@ -1,0 +1,8 @@
+---
+"@bosonprotocol/x402-server": minor
+---
+
+Add pure X-PAYMENT validation helpers for escrow payloads, including
+base64 header decoding, rule-by-rule payment payload validation, meta-tx
+signature recovery, token authorization checks, and fulfillment option
+validation hooks.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
       '@bosonprotocol/x402-core':
         specifier: workspace:^
         version: link:../core
+      '@bosonprotocol/x402-evm':
+        specifier: workspace:^
+        version: link:../evm
       viem:
         specifier: ^2.39.3
         version: 2.48.11(typescript@5.9.3)(zod@3.25.76)

--- a/typescript/packages/x402-server/package.json
+++ b/typescript/packages/x402-server/package.json
@@ -33,6 +33,11 @@
       "types": "./dist/cjs/challenge/index.d.ts",
       "import": "./dist/esm/challenge/index.js",
       "require": "./dist/cjs/challenge/index.js"
+    },
+    "./validate": {
+      "types": "./dist/cjs/validate/index.d.ts",
+      "import": "./dist/esm/validate/index.js",
+      "require": "./dist/cjs/validate/index.js"
     }
   },
   "files": [
@@ -54,6 +59,7 @@
     "@bosonprotocol/core-sdk": "1.47.1-alpha.0",
     "@bosonprotocol/x402-actions": "workspace:^",
     "@bosonprotocol/x402-core": "workspace:^",
+    "@bosonprotocol/x402-evm": "workspace:^",
     "viem": "^2.39.3",
     "zod": "^3.24.2"
   },

--- a/typescript/packages/x402-server/src/index.ts
+++ b/typescript/packages/x402-server/src/index.ts
@@ -19,3 +19,13 @@ export {
   type BuildPaymentRequirementsArgs,
   type SignFullOfferArgs,
 } from "./challenge/index.js";
+export {
+  decodeXPaymentHeader,
+  validatePaymentPayload,
+  type DecodeErrorCode,
+  type DecodeXPaymentResult,
+  type ValidatePaymentPayloadArgs,
+  type ValidatePaymentPayloadResult,
+  type ValidationErrorCode,
+  type ValidationWarning,
+} from "./validate/index.js";

--- a/typescript/packages/x402-server/src/validate/decode.ts
+++ b/typescript/packages/x402-server/src/validate/decode.ts
@@ -32,14 +32,22 @@ export function decodeXPaymentHeader(header: string | undefined | null): DecodeX
     return { ok: false, code: "MISSING_HEADER", reason: "X-PAYMENT header is missing" };
   }
 
-  // base64url → base64 (RFC 4648 §5) then decode. atob is available on
-  // both modern Node (≥16) and every supported runtime; we don't depend
-  // on Buffer here so the validator stays edge-runtime compatible.
+  // base64url → base64 (RFC 4648 §5) then decode. We prefer `atob` so
+  // the validator stays edge-runtime compatible; `atob` returns a
+  // Latin-1 binary string though, so we re-encode through `TextDecoder`
+  // to recover the original UTF-8 (a buyer's `fulfillment.data` may
+  // legitimately carry non-ASCII bytes — names, addresses, etc.).
   const padded = base64UrlToBase64(header);
   let decoded: string;
   try {
-    decoded =
-      typeof atob === "function" ? atob(padded) : Buffer.from(padded, "base64").toString("utf8");
+    if (typeof atob === "function") {
+      const binary = atob(padded);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+      decoded = new TextDecoder().decode(bytes);
+    } else {
+      decoded = Buffer.from(padded, "base64").toString("utf8");
+    }
   } catch (e) {
     return { ok: false, code: "INVALID_BASE64", reason: (e as Error).message };
   }

--- a/typescript/packages/x402-server/src/validate/decode.ts
+++ b/typescript/packages/x402-server/src/validate/decode.ts
@@ -1,0 +1,66 @@
+// Decode the `X-PAYMENT` header — base64 → JSON → zod-parse.
+//
+// `parseEscrowPaymentPayload` from `@bosonprotocol/x402-core` handles
+// the wire-format zod validation; this module's job is the base64 +
+// JSON layer plus the obvious "not a string" / "bad base64" / "bad
+// JSON" failure cases, each mapped to a structured error code so the
+// caller can surface a useful 400 to the buyer.
+
+import {
+  parseEscrowPaymentPayload,
+  type EscrowPaymentPayload,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+
+export type DecodeXPaymentResult =
+  | { ok: true; payload: EscrowPaymentPayload }
+  | { ok: false; code: DecodeErrorCode; reason: string };
+
+export type DecodeErrorCode =
+  | "MISSING_HEADER"
+  | "INVALID_BASE64"
+  | "INVALID_JSON"
+  | "INVALID_PAYLOAD";
+
+/**
+ * Decode the raw `X-PAYMENT` header value. Returns the parsed
+ * `EscrowPaymentPayload` on success or a `{ ok: false }` discriminated
+ * error on failure. Accepts both base64 and base64url variants (RFC
+ * 4648 §5) — buyers in the wild use both.
+ */
+export function decodeXPaymentHeader(header: string | undefined | null): DecodeXPaymentResult {
+  if (header === undefined || header === null || header.length === 0) {
+    return { ok: false, code: "MISSING_HEADER", reason: "X-PAYMENT header is missing" };
+  }
+
+  // base64url → base64 (RFC 4648 §5) then decode. atob is available on
+  // both modern Node (≥16) and every supported runtime; we don't depend
+  // on Buffer here so the validator stays edge-runtime compatible.
+  const padded = base64UrlToBase64(header);
+  let decoded: string;
+  try {
+    decoded =
+      typeof atob === "function" ? atob(padded) : Buffer.from(padded, "base64").toString("utf8");
+  } catch (e) {
+    return { ok: false, code: "INVALID_BASE64", reason: (e as Error).message };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoded);
+  } catch (e) {
+    return { ok: false, code: "INVALID_JSON", reason: (e as Error).message };
+  }
+
+  try {
+    const payload = parseEscrowPaymentPayload(parsed);
+    return { ok: true, payload };
+  } catch (e) {
+    return { ok: false, code: "INVALID_PAYLOAD", reason: (e as Error).message };
+  }
+}
+
+function base64UrlToBase64(input: string): string {
+  const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
+  return normalized + padding;
+}

--- a/typescript/packages/x402-server/src/validate/index.ts
+++ b/typescript/packages/x402-server/src/validate/index.ts
@@ -1,0 +1,13 @@
+// `validate` subpath — pure X-PAYMENT validation. No I/O; cross-field
+// rules (sig recovery, structural rules, fulfillment delegation)
+// short-circuit on the first failure with a structured error code
+// callers can serialise into a 400 body.
+
+export { decodeXPaymentHeader, type DecodeErrorCode, type DecodeXPaymentResult } from "./decode.js";
+export {
+  validatePaymentPayload,
+  type ValidatePaymentPayloadArgs,
+  type ValidatePaymentPayloadResult,
+  type ValidationErrorCode,
+  type ValidationWarning,
+} from "./payment-payload.js";

--- a/typescript/packages/x402-server/src/validate/payment-payload.ts
+++ b/typescript/packages/x402-server/src/validate/payment-payload.ts
@@ -56,6 +56,7 @@ export type ValidationErrorCode =
   | "TOKEN_AUTH_DEADLINE_EXCEEDED"
   | "TOKEN_AUTH_MISSING"
   | "TOKEN_AUTH_UNEXPECTED"
+  | "TOKEN_AUTH_UNKNOWN_STRATEGY"
   | "FULFILLMENT_REQUIRED"
   | "FULFILLMENT_OPTION_NOT_ADVERTISED"
   | "FULFILLMENT_DATA_INVALID";
@@ -423,6 +424,19 @@ function checkTokenAuthRules(
       }
       return null;
     }
+    default:
+      // Defensive: zod narrows `tokenAuth.kind` to the discriminated
+      // union above, so the runtime should never reach this branch.
+      // Fail closed if a malformed payload bypasses the parser rather
+      // than implicitly returning `undefined` (which the caller treats
+      // as `=== null` and would silently pass through to rule 13).
+      return failure(
+        9,
+        "TOKEN_AUTH_UNKNOWN_STRATEGY",
+        "payload.tokenAuth.kind",
+        "erc3009 | permit | permit2",
+        (tokenAuth as { kind: string }).kind,
+      );
   }
 }
 

--- a/typescript/packages/x402-server/src/validate/payment-payload.ts
+++ b/typescript/packages/x402-server/src/validate/payment-payload.ts
@@ -145,8 +145,8 @@ export async function validatePaymentPayload(
   // Rule 7 — functionSignature byte-equals the calldata reconstructed
   // from offerRef. Only enforced for `boson-createOfferAndCommit`
   // (Flow A); Flow B's builder still throws `NotYetSupportedError`.
-  const rule7 = checkRule7(payload);
-  if (rule7 !== null) return rule7;
+  const calldataResult = checkFunctionSignatureAndCalldataEquality(payload);
+  if (calldataResult !== null) return calldataResult;
 
   // Rule 8 — meta-tx signer recovers to payload.buyer === metaTx.from.
   if (payload.payload.buyer.toLowerCase() !== payload.payload.metaTx.from.toLowerCase()) {
@@ -207,7 +207,16 @@ export async function validatePaymentPayload(
   return { ok: true };
 }
 
-function checkRule7(payload: EscrowPaymentPayload): ValidatePaymentPayloadResult | null {
+/**
+ * Validate that `payload.metaTx.functionName` + `functionSignature`
+ * byte-equal the calldata reconstructed from the payload's
+ * `offerRef.fullOffer` + `sellerSig`. Tracks spec rule 7 today;
+ * named for what it checks rather than its rule number so the
+ * function survives any future renumbering of the spec.
+ */
+function checkFunctionSignatureAndCalldataEquality(
+  payload: EscrowPaymentPayload,
+): ValidatePaymentPayloadResult | null {
   const action = payload.payload.action;
   if (action === "boson-createOfferAndCommit") {
     const fullOfferWithSig = {

--- a/typescript/packages/x402-server/src/validate/payment-payload.ts
+++ b/typescript/packages/x402-server/src/validate/payment-payload.ts
@@ -1,0 +1,512 @@
+// `validatePaymentPayload` — the 13-rule X-PAYMENT validator from
+// docs/boson-impl-01-escrow-scheme.md §5. Pure function; no I/O.
+//
+// The validator returns a discriminated `{ ok: true } | { ok: false, … }`
+// result. On failure, the result carries the spec's rule number, a
+// stable string code, and the field/expected/got triple from the spec
+// (so callers can serialise it directly into a 400 body).
+//
+// Rule 12 (`none` strategy → server SHOULD pre-flight allowance check)
+// is RPC-dependent and intentionally NOT enforced here — the
+// composition layer (PR 4) runs it as part of `verifyExchange`.
+//
+// Rule 7 byte-compares `payload.metaTx.functionSignature` against
+// calldata reconstructed from `payload.offerRef`. The reconstruction
+// path for `boson-createOfferCommitAndRedeem` (Flow B) is gated on
+// `@bosonprotocol/x402-evm`'s atomic builder which still throws
+// `NotYetSupportedError` pending contracts PR #1105; for that action
+// id rule 7 is a no-op and is documented as such in the result.
+
+import { recoverMetaTransactionSigner } from "@bosonprotocol/x402-core/eip712";
+import type {
+  EscrowPaymentPayload,
+  EscrowPaymentRequirements,
+  FulfillmentOption,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+import { buildCreateOfferAndCommitCalldata } from "@bosonprotocol/x402-evm";
+import type { Address as ViemAddress, Hex as ViemHex } from "viem";
+
+type BuilderFullOffer = Parameters<typeof buildCreateOfferAndCommitCalldata>[0]["fullOffer"];
+
+export type ValidatePaymentPayloadResult =
+  | { ok: true; warnings?: ValidationWarning[] }
+  | {
+      ok: false;
+      rule: number;
+      code: ValidationErrorCode;
+      field?: string;
+      expected?: unknown;
+      got?: unknown;
+      reason?: string;
+    };
+
+export type ValidationErrorCode =
+  | "SCHEME_MISMATCH"
+  | "NETWORK_MISMATCH"
+  | "FULL_OFFER_MISMATCH"
+  | "SELLER_SIG_MISMATCH"
+  | "ACTION_NOT_IN_REQUIREMENTS"
+  | "TOKEN_AUTH_NOT_IN_REQUIREMENTS"
+  | "CALLDATA_MISMATCH"
+  | "BAD_META_TX_SIGNATURE"
+  | "TOKEN_AUTH_AMOUNT_MISMATCH"
+  | "TOKEN_AUTH_RECIPIENT_MISMATCH"
+  | "TOKEN_AUTH_SPENDER_MISMATCH"
+  | "TOKEN_AUTH_TOKEN_MISMATCH"
+  | "TOKEN_AUTH_DEADLINE_EXCEEDED"
+  | "TOKEN_AUTH_MISSING"
+  | "TOKEN_AUTH_UNEXPECTED"
+  | "FULFILLMENT_REQUIRED"
+  | "FULFILLMENT_OPTION_NOT_ADVERTISED"
+  | "FULFILLMENT_DATA_INVALID";
+
+export interface ValidationWarning {
+  rule: number;
+  code: "RULE_SKIPPED";
+  reason: string;
+}
+
+export interface ValidatePaymentPayloadArgs {
+  payload: EscrowPaymentPayload;
+  requirements: EscrowPaymentRequirements;
+  /** EVM chain id matching `requirements.network` — drives meta-tx EIP-712 signer recovery (rule 8). */
+  chainId: number;
+  /** Reference time in seconds since epoch for rules 9–11. Defaults to `Math.floor(Date.now() / 1000)`. */
+  now?: number;
+  /** Optional per-fulfillment-option data validator (typically the `FulfillmentRegistry`'s per-channel `validate`). Without it, rule 13 only checks `option` membership. */
+  validateFulfillmentData?: (
+    option: string,
+    data: Record<string, unknown> | null,
+  ) => { ok: true } | { ok: false; reason: string };
+}
+
+/**
+ * Run all 13 rules. Short-circuits at the first failure. On success,
+ * may include non-fatal warnings (e.g. rule 7 being skipped for the
+ * atomic Flow B action until contracts PR #1105 ships).
+ */
+export async function validatePaymentPayload(
+  args: ValidatePaymentPayloadArgs,
+): Promise<ValidatePaymentPayloadResult> {
+  const { payload, requirements } = args;
+  const warnings: ValidationWarning[] = [];
+
+  // Rule 1 — scheme equality on both sides.
+  if (payload.scheme !== "escrow" || requirements.scheme !== "escrow") {
+    return failure(1, "SCHEME_MISMATCH", "scheme", "escrow", payload.scheme);
+  }
+
+  // Rule 2 — network equality.
+  if (payload.network !== requirements.network) {
+    return failure(2, "NETWORK_MISMATCH", "network", requirements.network, payload.network);
+  }
+
+  // Rule 3 — fullOffer deep equality (byte-equals in canonical form).
+  if (!deepEqual(payload.payload.offerRef.fullOffer, requirements.offer.fullOffer)) {
+    return failure(
+      3,
+      "FULL_OFFER_MISMATCH",
+      "payload.offerRef.fullOffer",
+      "<requirements.offer.fullOffer>",
+      "<payload.offerRef.fullOffer>",
+    );
+  }
+
+  // Rule 4 — sellerSig equality.
+  if (payload.payload.offerRef.sellerSig !== requirements.offer.sellerSig) {
+    return failure(
+      4,
+      "SELLER_SIG_MISMATCH",
+      "payload.offerRef.sellerSig",
+      requirements.offer.sellerSig,
+      payload.payload.offerRef.sellerSig,
+    );
+  }
+
+  // Rule 5 — action advertised in requirements.actions.next.
+  const advertisedActions = requirements.actions.next.map((entry) => entry.id);
+  if (!advertisedActions.includes(payload.payload.action)) {
+    return failure(
+      5,
+      "ACTION_NOT_IN_REQUIREMENTS",
+      "payload.action",
+      advertisedActions,
+      payload.payload.action,
+    );
+  }
+
+  // Rule 6 — tokenAuthStrategy advertised in requirements.tokenAuthStrategies.
+  if (!requirements.tokenAuthStrategies.includes(payload.payload.tokenAuthStrategy)) {
+    return failure(
+      6,
+      "TOKEN_AUTH_NOT_IN_REQUIREMENTS",
+      "payload.tokenAuthStrategy",
+      requirements.tokenAuthStrategies,
+      payload.payload.tokenAuthStrategy,
+    );
+  }
+
+  // Rule 7 — functionSignature byte-equals the calldata reconstructed
+  // from offerRef. Only enforced for `boson-createOfferAndCommit`
+  // (Flow A); Flow B's builder still throws `NotYetSupportedError`.
+  const rule7 = checkRule7(payload, warnings);
+  if (rule7 !== null) return rule7;
+
+  // Rule 8 — meta-tx signer recovers to payload.buyer === metaTx.from.
+  if (payload.payload.buyer.toLowerCase() !== payload.payload.metaTx.from.toLowerCase()) {
+    return failure(
+      8,
+      "BAD_META_TX_SIGNATURE",
+      "payload.metaTx.from",
+      payload.payload.buyer,
+      payload.payload.metaTx.from,
+    );
+  }
+  const recovered = await recoverMetaTransactionSigner({
+    chainId: args.chainId,
+    verifyingContract: requirements.escrowAddress as ViemAddress,
+    message: {
+      nonce: BigInt(payload.payload.metaTx.nonce),
+      from: payload.payload.metaTx.from as ViemAddress,
+      contractAddress: requirements.escrowAddress as ViemAddress,
+      functionName: payload.payload.metaTx.functionName,
+      functionSignature: payload.payload.metaTx.functionSignature as ViemHex,
+    },
+    signature: encodeRsv(payload.payload.metaTx.sig) as ViemHex,
+  });
+  if (recovered.toLowerCase() !== payload.payload.buyer.toLowerCase()) {
+    return failure(
+      8,
+      "BAD_META_TX_SIGNATURE",
+      "payload.metaTx.sig",
+      payload.payload.buyer,
+      recovered,
+    );
+  }
+
+  // Rules 9–11 — strategy-specific token-auth structural checks.
+  const strategyResult = checkTokenAuthRules(payload, requirements, args.now);
+  if (strategyResult !== null) return strategyResult;
+
+  // Rule 12 — `none` strategy SHOULD pre-flight `IERC20.allowance` on
+  // chain. Intentionally not enforced here; runs as part of
+  // `verifyExchange` in PR 4 (RPC dependency).
+
+  // Rule 13 — fulfillment.
+  const fulfillmentResult = checkFulfillment(payload, requirements, args.validateFulfillmentData);
+  if (fulfillmentResult !== null) return fulfillmentResult;
+
+  return warnings.length > 0 ? { ok: true, warnings } : { ok: true };
+}
+
+function checkRule7(
+  payload: EscrowPaymentPayload,
+  warnings: ValidationWarning[],
+): ValidatePaymentPayloadResult | null {
+  const action = payload.payload.action;
+  if (action === "boson-createOfferAndCommit") {
+    const fullOfferWithSig = {
+      ...payload.payload.offerRef.fullOffer,
+      signature: payload.payload.offerRef.sellerSig,
+    } as unknown as BuilderFullOffer;
+
+    let expected: ReturnType<typeof buildCreateOfferAndCommitCalldata>;
+    try {
+      expected = buildCreateOfferAndCommitCalldata({ fullOffer: fullOfferWithSig });
+    } catch (e) {
+      return failure(
+        7,
+        "CALLDATA_MISMATCH",
+        "payload.metaTx.functionSignature",
+        undefined,
+        undefined,
+        (e as Error).message,
+      );
+    }
+
+    if (expected.functionName !== payload.payload.metaTx.functionName) {
+      return failure(
+        7,
+        "CALLDATA_MISMATCH",
+        "payload.metaTx.functionName",
+        expected.functionName,
+        payload.payload.metaTx.functionName,
+      );
+    }
+    if (
+      expected.functionSignature.toLowerCase() !==
+      payload.payload.metaTx.functionSignature.toLowerCase()
+    ) {
+      return failure(
+        7,
+        "CALLDATA_MISMATCH",
+        "payload.metaTx.functionSignature",
+        expected.functionSignature,
+        payload.payload.metaTx.functionSignature,
+      );
+    }
+    return null;
+  }
+  if (action === "boson-createOfferCommitAndRedeem") {
+    warnings.push({
+      rule: 7,
+      code: "RULE_SKIPPED",
+      reason:
+        "calldata reconstruction for boson-createOfferCommitAndRedeem is gated on contracts PR #1105 (NotYetSupportedError in @bosonprotocol/x402-evm)",
+    });
+    return null;
+  }
+  // Other actions (boson-redeem, dispute/*, etc.) aren't commit-time;
+  // they have their own meta-tx encodings outside this scheme's
+  // payment-payload validator. If we ever see one here it's a config
+  // bug — the action wouldn't have been listed in
+  // requirements.actions.next at commit time.
+  return failure(
+    7,
+    "CALLDATA_MISMATCH",
+    "payload.action",
+    "boson-createOfferAndCommit | boson-createOfferCommitAndRedeem",
+    action,
+    "rule-7 calldata reconstruction is only defined for commit-time actions",
+  );
+}
+
+function checkTokenAuthRules(
+  payload: EscrowPaymentPayload,
+  requirements: EscrowPaymentRequirements,
+  nowSec?: number,
+): ValidatePaymentPayloadResult | null {
+  const strategy = payload.payload.tokenAuthStrategy;
+  const tokenAuth = payload.payload.tokenAuth;
+  const now = nowSec ?? Math.floor(Date.now() / 1000);
+  const horizon = now + requirements.maxTimeoutSeconds;
+
+  if (strategy === "none") {
+    if (tokenAuth !== undefined) {
+      return failure(
+        9,
+        "TOKEN_AUTH_UNEXPECTED",
+        "payload.tokenAuth",
+        "undefined (strategy=none)",
+        tokenAuth.kind,
+      );
+    }
+    return null;
+  }
+
+  // strategy is one of erc3009 / permit / permit2 — token-auth required.
+  if (tokenAuth === undefined) {
+    return failure(
+      9,
+      "TOKEN_AUTH_MISSING",
+      "payload.tokenAuth",
+      `<${strategy} authorization>`,
+      "undefined",
+    );
+  }
+  if (tokenAuth.kind !== strategy) {
+    return failure(9, "TOKEN_AUTH_MISSING", "payload.tokenAuth.kind", strategy, tokenAuth.kind);
+  }
+
+  switch (tokenAuth.kind) {
+    case "erc3009": {
+      if (tokenAuth.data.value !== requirements.amount) {
+        return failure(
+          9,
+          "TOKEN_AUTH_AMOUNT_MISMATCH",
+          "payload.tokenAuth.data.value",
+          requirements.amount,
+          tokenAuth.data.value,
+        );
+      }
+      if (tokenAuth.data.to.toLowerCase() !== requirements.escrowAddress.toLowerCase()) {
+        return failure(
+          9,
+          "TOKEN_AUTH_RECIPIENT_MISMATCH",
+          "payload.tokenAuth.data.to",
+          requirements.escrowAddress,
+          tokenAuth.data.to,
+        );
+      }
+      if (tokenAuth.data.validBefore > horizon) {
+        return failure(
+          9,
+          "TOKEN_AUTH_DEADLINE_EXCEEDED",
+          "payload.tokenAuth.data.validBefore",
+          `<= ${horizon}`,
+          tokenAuth.data.validBefore,
+        );
+      }
+      return null;
+    }
+    case "permit": {
+      if (tokenAuth.data.value !== requirements.amount) {
+        return failure(
+          10,
+          "TOKEN_AUTH_AMOUNT_MISMATCH",
+          "payload.tokenAuth.data.value",
+          requirements.amount,
+          tokenAuth.data.value,
+        );
+      }
+      if (tokenAuth.data.spender.toLowerCase() !== requirements.escrowAddress.toLowerCase()) {
+        return failure(
+          10,
+          "TOKEN_AUTH_SPENDER_MISMATCH",
+          "payload.tokenAuth.data.spender",
+          requirements.escrowAddress,
+          tokenAuth.data.spender,
+        );
+      }
+      if (tokenAuth.data.deadline > horizon) {
+        return failure(
+          10,
+          "TOKEN_AUTH_DEADLINE_EXCEEDED",
+          "payload.tokenAuth.data.deadline",
+          `<= ${horizon}`,
+          tokenAuth.data.deadline,
+        );
+      }
+      return null;
+    }
+    case "permit2": {
+      if (tokenAuth.data.permitted.amount !== requirements.amount) {
+        return failure(
+          11,
+          "TOKEN_AUTH_AMOUNT_MISMATCH",
+          "payload.tokenAuth.data.permitted.amount",
+          requirements.amount,
+          tokenAuth.data.permitted.amount,
+        );
+      }
+      if (tokenAuth.data.permitted.token.toLowerCase() !== requirements.asset.toLowerCase()) {
+        return failure(
+          11,
+          "TOKEN_AUTH_TOKEN_MISMATCH",
+          "payload.tokenAuth.data.permitted.token",
+          requirements.asset,
+          tokenAuth.data.permitted.token,
+        );
+      }
+      if (tokenAuth.data.spender.toLowerCase() !== requirements.escrowAddress.toLowerCase()) {
+        return failure(
+          11,
+          "TOKEN_AUTH_SPENDER_MISMATCH",
+          "payload.tokenAuth.data.spender",
+          requirements.escrowAddress,
+          tokenAuth.data.spender,
+        );
+      }
+      if (tokenAuth.data.deadline > horizon) {
+        return failure(
+          11,
+          "TOKEN_AUTH_DEADLINE_EXCEEDED",
+          "payload.tokenAuth.data.deadline",
+          `<= ${horizon}`,
+          tokenAuth.data.deadline,
+        );
+      }
+      return null;
+    }
+  }
+}
+
+function checkFulfillment(
+  payload: EscrowPaymentPayload,
+  requirements: EscrowPaymentRequirements,
+  validator?: ValidatePaymentPayloadArgs["validateFulfillmentData"],
+): ValidatePaymentPayloadResult | null {
+  const required = requirements.fulfillment?.required === true;
+  const carried = payload.fulfillment;
+  if (!required) return null;
+
+  if (carried === undefined) {
+    return failure(
+      13,
+      "FULFILLMENT_REQUIRED",
+      "payload.fulfillment",
+      "<option + data>",
+      "undefined",
+    );
+  }
+
+  const advertised: FulfillmentOption[] = requirements.fulfillment?.options ?? [];
+  const matched = advertised.find((option) => option.id === carried.option);
+  if (!matched) {
+    return failure(
+      13,
+      "FULFILLMENT_OPTION_NOT_ADVERTISED",
+      "payload.fulfillment.option",
+      advertised.map((o) => o.id),
+      carried.option,
+    );
+  }
+
+  if (validator !== undefined) {
+    const result = validator(carried.option, carried.data);
+    if (!result.ok) {
+      return failure(
+        13,
+        "FULFILLMENT_DATA_INVALID",
+        "payload.fulfillment.data",
+        matched.schema,
+        carried.data,
+        result.reason,
+      );
+    }
+  }
+  return null;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== "object" || typeof b !== "object") return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const aKeys = Object.keys(ao);
+  const bKeys = Object.keys(bo);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(bo, k)) return false;
+    if (!deepEqual(ao[k], bo[k])) return false;
+  }
+  return true;
+}
+
+/**
+ * Concatenate the buyer's split-form `(v, r, s)` triple into the
+ * 65-byte signature shape viem's `recoverTypedDataAddress` accepts.
+ * `v` is normalised to the high byte; `r` and `s` are zero-padded to
+ * 32 bytes (they're already that in the wire-format schema, but we
+ * defend in depth).
+ */
+function encodeRsv(sig: { v: number; r: string; s: string }): string {
+  const r = sig.r.replace(/^0x/, "").padStart(64, "0");
+  const s = sig.s.replace(/^0x/, "").padStart(64, "0");
+  const v = sig.v.toString(16).padStart(2, "0");
+  return `0x${r}${s}${v}`;
+}
+
+function failure(
+  rule: number,
+  code: ValidationErrorCode,
+  field?: string,
+  expected?: unknown,
+  got?: unknown,
+  reason?: string,
+): ValidatePaymentPayloadResult {
+  const out: ValidatePaymentPayloadResult = { ok: false, rule, code };
+  if (field !== undefined) (out as { field?: string }).field = field;
+  if (expected !== undefined) (out as { expected?: unknown }).expected = expected;
+  if (got !== undefined) (out as { got?: unknown }).got = got;
+  if (reason !== undefined) (out as { reason?: string }).reason = reason;
+  return out;
+}

--- a/typescript/packages/x402-server/src/validate/payment-payload.ts
+++ b/typescript/packages/x402-server/src/validate/payment-payload.ts
@@ -14,8 +14,8 @@
 // calldata reconstructed from `payload.offerRef`. The reconstruction
 // path for `boson-createOfferCommitAndRedeem` (Flow B) is gated on
 // `@bosonprotocol/x402-evm`'s atomic builder which still throws
-// `NotYetSupportedError` pending contracts PR #1105; for that action
-// id rule 7 is a no-op and is documented as such in the result.
+// `NotYetSupportedError` pending contracts PR #1105; until that builder
+// exists, Flow B fails closed rather than accepting unchecked calldata.
 
 import { recoverMetaTransactionSigner } from "@bosonprotocol/x402-core/eip712";
 import type {
@@ -81,16 +81,12 @@ export interface ValidatePaymentPayloadArgs {
 }
 
 /**
- * Run all 13 rules. Short-circuits at the first failure. On success,
- * may include non-fatal warnings (e.g. rule 7 being skipped for the
- * atomic Flow B action until contracts PR #1105 ships).
+ * Run all 13 rules. Short-circuits at the first failure.
  */
 export async function validatePaymentPayload(
   args: ValidatePaymentPayloadArgs,
 ): Promise<ValidatePaymentPayloadResult> {
   const { payload, requirements } = args;
-  const warnings: ValidationWarning[] = [];
-
   // Rule 1 — scheme equality on both sides.
   if (payload.scheme !== "escrow" || requirements.scheme !== "escrow") {
     return failure(1, "SCHEME_MISMATCH", "scheme", "escrow", payload.scheme);
@@ -149,7 +145,7 @@ export async function validatePaymentPayload(
   // Rule 7 — functionSignature byte-equals the calldata reconstructed
   // from offerRef. Only enforced for `boson-createOfferAndCommit`
   // (Flow A); Flow B's builder still throws `NotYetSupportedError`.
-  const rule7 = checkRule7(payload, warnings);
+  const rule7 = checkRule7(payload);
   if (rule7 !== null) return rule7;
 
   // Rule 8 — meta-tx signer recovers to payload.buyer === metaTx.from.
@@ -162,18 +158,30 @@ export async function validatePaymentPayload(
       payload.payload.metaTx.from,
     );
   }
-  const recovered = await recoverMetaTransactionSigner({
-    chainId: args.chainId,
-    verifyingContract: requirements.escrowAddress as ViemAddress,
-    message: {
-      nonce: BigInt(payload.payload.metaTx.nonce),
-      from: payload.payload.metaTx.from as ViemAddress,
-      contractAddress: requirements.escrowAddress as ViemAddress,
-      functionName: payload.payload.metaTx.functionName,
-      functionSignature: payload.payload.metaTx.functionSignature as ViemHex,
-    },
-    signature: encodeRsv(payload.payload.metaTx.sig) as ViemHex,
-  });
+  let recovered: ViemAddress;
+  try {
+    recovered = await recoverMetaTransactionSigner({
+      chainId: args.chainId,
+      verifyingContract: requirements.escrowAddress as ViemAddress,
+      message: {
+        nonce: BigInt(payload.payload.metaTx.nonce),
+        from: payload.payload.metaTx.from as ViemAddress,
+        contractAddress: requirements.escrowAddress as ViemAddress,
+        functionName: payload.payload.metaTx.functionName,
+        functionSignature: payload.payload.metaTx.functionSignature as ViemHex,
+      },
+      signature: encodeRsv(payload.payload.metaTx.sig) as ViemHex,
+    });
+  } catch (e) {
+    return failure(
+      8,
+      "BAD_META_TX_SIGNATURE",
+      "payload.metaTx.sig",
+      "recoverable ECDSA signature",
+      payload.payload.metaTx.sig,
+      (e as Error).message,
+    );
+  }
   if (recovered.toLowerCase() !== payload.payload.buyer.toLowerCase()) {
     return failure(
       8,
@@ -196,13 +204,10 @@ export async function validatePaymentPayload(
   const fulfillmentResult = checkFulfillment(payload, requirements, args.validateFulfillmentData);
   if (fulfillmentResult !== null) return fulfillmentResult;
 
-  return warnings.length > 0 ? { ok: true, warnings } : { ok: true };
+  return { ok: true };
 }
 
-function checkRule7(
-  payload: EscrowPaymentPayload,
-  warnings: ValidationWarning[],
-): ValidatePaymentPayloadResult | null {
+function checkRule7(payload: EscrowPaymentPayload): ValidatePaymentPayloadResult | null {
   const action = payload.payload.action;
   if (action === "boson-createOfferAndCommit") {
     const fullOfferWithSig = {
@@ -248,13 +253,14 @@ function checkRule7(
     return null;
   }
   if (action === "boson-createOfferCommitAndRedeem") {
-    warnings.push({
-      rule: 7,
-      code: "RULE_SKIPPED",
-      reason:
-        "calldata reconstruction for boson-createOfferCommitAndRedeem is gated on contracts PR #1105 (NotYetSupportedError in @bosonprotocol/x402-evm)",
-    });
-    return null;
+    return failure(
+      7,
+      "CALLDATA_MISMATCH",
+      "payload.action",
+      "supported calldata reconstruction",
+      action,
+      "calldata reconstruction for boson-createOfferCommitAndRedeem is gated on contracts PR #1105 (NotYetSupportedError in @bosonprotocol/x402-evm)",
+    );
   }
   // Other actions (boson-redeem, dispute/*, etc.) aren't commit-time;
   // they have their own meta-tx encodings outside this scheme's
@@ -489,9 +495,13 @@ function deepEqual(a: unknown, b: unknown): boolean {
  * defend in depth).
  */
 function encodeRsv(sig: { v: number; r: string; s: string }): string {
+  if (sig.v !== 0 && sig.v !== 1 && sig.v !== 27 && sig.v !== 28) {
+    throw new Error("signature v must be 0, 1, 27, or 28");
+  }
   const r = sig.r.replace(/^0x/, "").padStart(64, "0");
   const s = sig.s.replace(/^0x/, "").padStart(64, "0");
-  const v = sig.v.toString(16).padStart(2, "0");
+  const normalizedV = sig.v === 0 || sig.v === 1 ? sig.v + 27 : sig.v;
+  const v = normalizedV.toString(16).padStart(2, "0");
   return `0x${r}${s}${v}`;
 }
 

--- a/typescript/packages/x402-server/test/fixtures.ts
+++ b/typescript/packages/x402-server/test/fixtures.ts
@@ -2,7 +2,17 @@
 // FullOffer shape mirrors `core`'s own `eip712/full-offer.test.ts` so
 // the round-trip behaviour is comparable.
 
-import type { UnsignedFullOffer } from "@bosonprotocol/x402-core/eip712";
+import { buildCreateOfferAndCommitCalldata } from "@bosonprotocol/x402-evm";
+import { metaTransactionTypedData, type UnsignedFullOffer } from "@bosonprotocol/x402-core/eip712";
+import type {
+  EscrowPaymentPayload,
+  EscrowPaymentRequirements,
+} from "@bosonprotocol/x402-core/schemes/escrow";
+import { parseSignature, type Hex } from "viem";
+import { privateKeyToAccount, type PrivateKeyAccount } from "viem/accounts";
+
+import { buildPaymentRequirements } from "../src/index.js";
+import { signFullOffer } from "../src/index.js";
 
 export const ESCROW = "0xdddddddddddddddddddddddddddddddddddddddd" as const;
 export const TOKEN = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" as const;
@@ -11,6 +21,10 @@ export const ZERO = "0x0000000000000000000000000000000000000000" as const;
 
 /** Deterministic test key — 32 bytes of `0x22`. Recovers to `0x9b87...` etc.; we read the address back from `privateKeyToAccount`. */
 export const TEST_SELLER_PK = `0x${"22".repeat(32)}` as const;
+export const TEST_BUYER_PK = `0x${"33".repeat(32)}` as const;
+
+export const CHAIN_ID = 8453;
+export const NETWORK = "eip155:8453" as const;
 
 /** A valid `UnsignedFullOffer` — matches the protocol's struct shape. */
 export const baseOffer: UnsignedFullOffer = {
@@ -53,3 +67,170 @@ export const baseOffer: UnsignedFullOffer = {
     mutualizerAddress: ZERO,
   },
 };
+
+export interface MakePaymentFixtureOpts {
+  tokenAuthStrategy?: "none" | "erc3009" | "permit" | "permit2";
+  amount?: string;
+  maxTimeoutSeconds?: number;
+  /** Override the action id in the payload — useful for negative tests. */
+  action?: string;
+  /** Force a deadline / validBefore offset (seconds in the future) for the token-auth data. */
+  tokenAuthDeadlineOffset?: number;
+}
+
+export interface PaymentFixture {
+  seller: PrivateKeyAccount;
+  buyer: PrivateKeyAccount;
+  requirements: EscrowPaymentRequirements;
+  payload: EscrowPaymentPayload;
+}
+
+/**
+ * Build a fully-signed `EscrowPaymentPayload` + matching
+ * `EscrowPaymentRequirements` for `boson-createOfferAndCommit`. Seller
+ * signs the FullOffer; buyer signs the meta-tx envelope over the
+ * calldata produced by `@bosonprotocol/x402-evm`'s calldata builder
+ * (so rule 7 byte-compares cleanly). All token-auth strategies are
+ * supported via structural-only token-auth data (no token-side
+ * EIP-712 signing — the pure validator only checks structure).
+ */
+export async function makePaymentFixture(
+  opts: MakePaymentFixtureOpts = {},
+): Promise<PaymentFixture> {
+  const strategy = opts.tokenAuthStrategy ?? "none";
+  const amount = opts.amount ?? "1000000";
+  const maxTimeoutSeconds = opts.maxTimeoutSeconds ?? 3600;
+  const action = opts.action ?? "boson-createOfferAndCommit";
+
+  const seller = privateKeyToAccount(TEST_SELLER_PK);
+  const buyer = privateKeyToAccount(TEST_BUYER_PK);
+
+  const offerRef = await signFullOffer({
+    fullOffer: { ...baseOffer, offerCreator: seller.address },
+    signer: seller,
+    escrow: ESCROW,
+    chainId: CHAIN_ID,
+  });
+
+  const fullOfferWithSig = { ...offerRef.fullOffer, signature: offerRef.sellerSig };
+  const calldata = buildCreateOfferAndCommitCalldata({
+    fullOffer: fullOfferWithSig as Parameters<
+      typeof buildCreateOfferAndCommitCalldata
+    >[0]["fullOffer"],
+  });
+
+  const metaTxTd = await metaTransactionTypedData({
+    chainId: CHAIN_ID,
+    verifyingContract: ESCROW,
+    message: {
+      nonce: 1n,
+      from: buyer.address,
+      contractAddress: ESCROW,
+      functionName: calldata.functionName,
+      functionSignature: calldata.functionSignature,
+    },
+  });
+  const buyerSig = await buyer.signTypedData({
+    domain: metaTxTd.domain,
+    types: metaTxTd.types,
+    primaryType: metaTxTd.primaryType,
+    message: metaTxTd.message,
+  });
+  const parsed = parseSignature(buyerSig);
+  const v = parsed.v !== undefined ? Number(parsed.v) : parsed.yParity === 0 ? 27 : 28;
+
+  const tokenAuthDeadlineOffset = opts.tokenAuthDeadlineOffset ?? maxTimeoutSeconds - 60;
+  const deadline = Math.floor(Date.now() / 1000) + tokenAuthDeadlineOffset;
+  const tokenAuth = buildTokenAuthFixture(strategy, amount, buyer.address, deadline);
+
+  const requirements: EscrowPaymentRequirements = buildPaymentRequirements({
+    offer: offerRef,
+    asset: TOKEN,
+    amount,
+    tokenAuthStrategies: [strategy],
+    recipientId: "did:boson:seller:12345",
+    maxTimeoutSeconds,
+    network: NETWORK,
+    escrow: ESCROW,
+    channelRegistry: {
+      channels: ["server", "facilitator", "onchain", "mcp"],
+      escrow: ESCROW,
+      mcp: "boson://seller/12345",
+    },
+  });
+
+  const payload: EscrowPaymentPayload = {
+    x402Version: 2,
+    scheme: "escrow",
+    network: NETWORK,
+    payload: {
+      action,
+      tokenAuthStrategy: strategy,
+      offerRef: { fullOffer: offerRef.fullOffer, sellerSig: offerRef.sellerSig },
+      buyer: buyer.address,
+      metaTx: {
+        from: buyer.address,
+        nonce: "1",
+        functionName: calldata.functionName,
+        functionSignature: calldata.functionSignature,
+        sig: { v, r: parsed.r, s: parsed.s },
+      },
+      ...(tokenAuth !== undefined ? { tokenAuth } : {}),
+    },
+  };
+
+  return { seller, buyer, requirements, payload };
+}
+
+function buildTokenAuthFixture(
+  strategy: "none" | "erc3009" | "permit" | "permit2",
+  amount: string,
+  buyer: string,
+  deadline: number,
+): EscrowPaymentPayload["payload"]["tokenAuth"] {
+  const zeroSig: { v: number; r: Hex; s: Hex } = {
+    v: 27,
+    r: `0x${"00".repeat(32)}` as Hex,
+    s: `0x${"00".repeat(32)}` as Hex,
+  };
+  switch (strategy) {
+    case "none":
+      return undefined;
+    case "erc3009":
+      return {
+        kind: "erc3009",
+        data: {
+          from: buyer,
+          to: ESCROW,
+          value: amount,
+          validAfter: 0,
+          validBefore: deadline,
+          nonce: `0x${"11".repeat(32)}`,
+          ...zeroSig,
+        },
+      };
+    case "permit":
+      return {
+        kind: "permit",
+        data: {
+          owner: buyer,
+          spender: ESCROW,
+          value: amount,
+          deadline,
+          nonce: "0",
+          ...zeroSig,
+        },
+      };
+    case "permit2":
+      return {
+        kind: "permit2",
+        data: {
+          permitted: { token: TOKEN, amount },
+          spender: ESCROW,
+          nonce: "0",
+          deadline,
+          signature: `0x${"22".repeat(65)}` as Hex,
+        },
+      };
+  }
+}

--- a/typescript/packages/x402-server/test/validate.test.ts
+++ b/typescript/packages/x402-server/test/validate.test.ts
@@ -255,16 +255,9 @@ describe("validatePaymentPayload — rule failures", () => {
 
   it("rule 13 — rejects missing fulfillment when required", async () => {
     const fx = await makePaymentFixture();
-    const requirementsWithFulfillment = {
-      ...fx.requirements,
-      fulfillment: {
-        required: true,
-        options: [{ id: "email", schema: { type: "object" as const } }],
-      },
-    };
     const result = await validatePaymentPayload({
       payload: fx.payload,
-      requirements: requirementsWithFulfillment,
+      requirements: withRequiredEmailFulfillment(fx.requirements),
       chainId: CHAIN_ID,
     });
     expect(result).toMatchObject({ ok: false, rule: 13, code: "FULFILLMENT_REQUIRED" });
@@ -272,20 +265,13 @@ describe("validatePaymentPayload — rule failures", () => {
 
   it("rule 13 — rejects fulfillment option not advertised", async () => {
     const fx = await makePaymentFixture();
-    const requirementsWithFulfillment = {
-      ...fx.requirements,
-      fulfillment: {
-        required: true,
-        options: [{ id: "email", schema: { type: "object" as const } }],
-      },
-    };
     const payloadWithBadOption = {
       ...fx.payload,
       fulfillment: { option: "smoke-signal", data: {} },
     };
     const result = await validatePaymentPayload({
       payload: payloadWithBadOption,
-      requirements: requirementsWithFulfillment,
+      requirements: withRequiredEmailFulfillment(fx.requirements),
       chainId: CHAIN_ID,
     });
     expect(result).toMatchObject({
@@ -297,26 +283,34 @@ describe("validatePaymentPayload — rule failures", () => {
 
   it("rule 13 — rejects fulfillment data when caller-supplied validator fails", async () => {
     const fx = await makePaymentFixture();
-    const requirementsWithFulfillment = {
-      ...fx.requirements,
-      fulfillment: {
-        required: true,
-        options: [{ id: "email", schema: { type: "object" as const } }],
-      },
-    };
     const payloadWithFulfillment = {
       ...fx.payload,
       fulfillment: { option: "email", data: { email: "not-an-email" } },
     };
     const result = await validatePaymentPayload({
       payload: payloadWithFulfillment,
-      requirements: requirementsWithFulfillment,
+      requirements: withRequiredEmailFulfillment(fx.requirements),
       chainId: CHAIN_ID,
       validateFulfillmentData: (_option, _data) => ({ ok: false, reason: "bad email" }),
     });
     expect(result).toMatchObject({ ok: false, rule: 13, code: "FULFILLMENT_DATA_INVALID" });
   });
 });
+
+/**
+ * Stamp `requirements` with a single mandatory `email` fulfillment
+ * option — the shape every rule-13 test needs. Returns a fresh
+ * object each call so test mutations stay isolated.
+ */
+function withRequiredEmailFulfillment<T extends { fulfillment?: unknown }>(requirements: T): T {
+  return {
+    ...requirements,
+    fulfillment: {
+      required: true,
+      options: [{ id: "email", schema: { type: "object" as const } }],
+    },
+  };
+}
 
 describe("validatePaymentPayload — unsupported calldata builders", () => {
   it("rule 7 — fails closed for `boson-createOfferCommitAndRedeem` until its builder lands", async () => {

--- a/typescript/packages/x402-server/test/validate.test.ts
+++ b/typescript/packages/x402-server/test/validate.test.ts
@@ -1,0 +1,383 @@
+// Exhaustive 13-rule coverage for `validatePaymentPayload`. Happy
+// paths for `none` + `erc3009` + `permit` + `permit2`, plus one
+// negative case per spec rule (rules 1–11, 13). Rule 12 is RPC-bound
+// and intentionally skipped at this layer.
+
+import { describe, expect, it } from "vitest";
+
+import { validatePaymentPayload, decodeXPaymentHeader } from "../src/index.js";
+import { CHAIN_ID, ESCROW, makePaymentFixture, NETWORK, TOKEN } from "./fixtures.js";
+
+describe("validatePaymentPayload — happy paths", () => {
+  it("accepts a valid `none` payload", async () => {
+    const fx = await makePaymentFixture({ tokenAuthStrategy: "none" });
+    const result = await validatePaymentPayload({
+      payload: fx.payload,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a valid `erc3009` payload", async () => {
+    const fx = await makePaymentFixture({ tokenAuthStrategy: "erc3009" });
+    const result = await validatePaymentPayload({
+      payload: fx.payload,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a valid `permit` payload", async () => {
+    const fx = await makePaymentFixture({ tokenAuthStrategy: "permit" });
+    const result = await validatePaymentPayload({
+      payload: fx.payload,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a valid `permit2` payload", async () => {
+    const fx = await makePaymentFixture({ tokenAuthStrategy: "permit2" });
+    const result = await validatePaymentPayload({
+      payload: fx.payload,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("validatePaymentPayload — rule failures", () => {
+  it("rule 2 — rejects network mismatch", async () => {
+    const fx = await makePaymentFixture();
+    const result = await validatePaymentPayload({
+      payload: { ...fx.payload, network: "eip155:1" },
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({ ok: false, rule: 2, code: "NETWORK_MISMATCH" });
+  });
+
+  it("rule 3 — rejects fullOffer mismatch (price tampered)", async () => {
+    const fx = await makePaymentFixture();
+    const tampered = {
+      ...fx.payload,
+      payload: {
+        ...fx.payload.payload,
+        offerRef: {
+          ...fx.payload.payload.offerRef,
+          fullOffer: { ...fx.payload.payload.offerRef.fullOffer, price: "9999999" },
+        },
+      },
+    };
+    const result = await validatePaymentPayload({
+      payload: tampered,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({ ok: false, rule: 3, code: "FULL_OFFER_MISMATCH" });
+  });
+
+  it("rule 4 — rejects sellerSig mismatch", async () => {
+    const fx = await makePaymentFixture();
+    const tampered = {
+      ...fx.payload,
+      payload: {
+        ...fx.payload.payload,
+        offerRef: { ...fx.payload.payload.offerRef, sellerSig: "0xdeadbeef" },
+      },
+    };
+    const result = await validatePaymentPayload({
+      payload: tampered,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({ ok: false, rule: 4, code: "SELLER_SIG_MISMATCH" });
+  });
+
+  it("rule 5 — rejects action not in requirements.actions.next", async () => {
+    const fx = await makePaymentFixture();
+    const tampered = {
+      ...fx.payload,
+      payload: { ...fx.payload.payload, action: "boson-redeem" },
+    };
+    const result = await validatePaymentPayload({
+      payload: tampered,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({ ok: false, rule: 5, code: "ACTION_NOT_IN_REQUIREMENTS" });
+  });
+
+  it("rule 6 — rejects tokenAuthStrategy not in requirements", async () => {
+    const fx = await makePaymentFixture({ tokenAuthStrategy: "none" });
+    const tampered = {
+      ...fx.payload,
+      payload: { ...fx.payload.payload, tokenAuthStrategy: "permit" as const },
+    };
+    const result = await validatePaymentPayload({
+      payload: tampered,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({ ok: false, rule: 6, code: "TOKEN_AUTH_NOT_IN_REQUIREMENTS" });
+  });
+
+  it("rule 7 — rejects functionSignature tampering", async () => {
+    const fx = await makePaymentFixture();
+    const tampered = {
+      ...fx.payload,
+      payload: {
+        ...fx.payload.payload,
+        metaTx: { ...fx.payload.payload.metaTx, functionSignature: "0xdeadbeef" },
+      },
+    };
+    const result = await validatePaymentPayload({
+      payload: tampered,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({ ok: false, rule: 7, code: "CALLDATA_MISMATCH" });
+  });
+
+  it("rule 8 — rejects when buyer.address ≠ metaTx.from", async () => {
+    const fx = await makePaymentFixture();
+    const tampered = {
+      ...fx.payload,
+      payload: {
+        ...fx.payload.payload,
+        metaTx: { ...fx.payload.payload.metaTx, from: ESCROW },
+      },
+    };
+    const result = await validatePaymentPayload({
+      payload: tampered,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({ ok: false, rule: 8, code: "BAD_META_TX_SIGNATURE" });
+  });
+
+  it("rule 8 — rejects bad meta-tx signature (wrong v)", async () => {
+    const fx = await makePaymentFixture();
+    const tampered = {
+      ...fx.payload,
+      payload: {
+        ...fx.payload.payload,
+        metaTx: {
+          ...fx.payload.payload.metaTx,
+          sig: {
+            ...fx.payload.payload.metaTx.sig,
+            v: fx.payload.payload.metaTx.sig.v === 27 ? 28 : 27,
+          },
+        },
+      },
+    };
+    const result = await validatePaymentPayload({
+      payload: tampered,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({ ok: false, rule: 8, code: "BAD_META_TX_SIGNATURE" });
+  });
+
+  it("rule 9 — rejects erc3009 amount mismatch", async () => {
+    const fx = await makePaymentFixture({ tokenAuthStrategy: "erc3009" });
+    const tampered = JSON.parse(JSON.stringify(fx.payload)) as typeof fx.payload;
+    if (tampered.payload.tokenAuth?.kind === "erc3009") {
+      tampered.payload.tokenAuth.data.value = "1";
+    }
+    const result = await validatePaymentPayload({
+      payload: tampered,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({ ok: false, rule: 9, code: "TOKEN_AUTH_AMOUNT_MISMATCH" });
+  });
+
+  it("rule 10 — rejects permit deadline past horizon", async () => {
+    const fx = await makePaymentFixture({ tokenAuthStrategy: "permit", maxTimeoutSeconds: 300 });
+    const tampered = JSON.parse(JSON.stringify(fx.payload)) as typeof fx.payload;
+    if (tampered.payload.tokenAuth?.kind === "permit") {
+      tampered.payload.tokenAuth.data.deadline = Math.floor(Date.now() / 1000) + 99_999;
+    }
+    const result = await validatePaymentPayload({
+      payload: tampered,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({ ok: false, rule: 10, code: "TOKEN_AUTH_DEADLINE_EXCEEDED" });
+  });
+
+  it("rule 11 — rejects permit2 spender mismatch", async () => {
+    const fx = await makePaymentFixture({ tokenAuthStrategy: "permit2" });
+    const tampered = JSON.parse(JSON.stringify(fx.payload)) as typeof fx.payload;
+    if (tampered.payload.tokenAuth?.kind === "permit2") {
+      tampered.payload.tokenAuth.data.spender = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    }
+    const result = await validatePaymentPayload({
+      payload: tampered,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({ ok: false, rule: 11, code: "TOKEN_AUTH_SPENDER_MISMATCH" });
+  });
+
+  it("rule 13 — rejects missing fulfillment when required", async () => {
+    const fx = await makePaymentFixture();
+    const requirementsWithFulfillment = {
+      ...fx.requirements,
+      fulfillment: {
+        required: true,
+        options: [{ id: "email", schema: { type: "object" as const } }],
+      },
+    };
+    const result = await validatePaymentPayload({
+      payload: fx.payload,
+      requirements: requirementsWithFulfillment,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({ ok: false, rule: 13, code: "FULFILLMENT_REQUIRED" });
+  });
+
+  it("rule 13 — rejects fulfillment option not advertised", async () => {
+    const fx = await makePaymentFixture();
+    const requirementsWithFulfillment = {
+      ...fx.requirements,
+      fulfillment: {
+        required: true,
+        options: [{ id: "email", schema: { type: "object" as const } }],
+      },
+    };
+    const payloadWithBadOption = {
+      ...fx.payload,
+      fulfillment: { option: "smoke-signal", data: {} },
+    };
+    const result = await validatePaymentPayload({
+      payload: payloadWithBadOption,
+      requirements: requirementsWithFulfillment,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      rule: 13,
+      code: "FULFILLMENT_OPTION_NOT_ADVERTISED",
+    });
+  });
+
+  it("rule 13 — rejects fulfillment data when caller-supplied validator fails", async () => {
+    const fx = await makePaymentFixture();
+    const requirementsWithFulfillment = {
+      ...fx.requirements,
+      fulfillment: {
+        required: true,
+        options: [{ id: "email", schema: { type: "object" as const } }],
+      },
+    };
+    const payloadWithFulfillment = {
+      ...fx.payload,
+      fulfillment: { option: "email", data: { email: "not-an-email" } },
+    };
+    const result = await validatePaymentPayload({
+      payload: payloadWithFulfillment,
+      requirements: requirementsWithFulfillment,
+      chainId: CHAIN_ID,
+      validateFulfillmentData: (_option, _data) => ({ ok: false, reason: "bad email" }),
+    });
+    expect(result).toMatchObject({ ok: false, rule: 13, code: "FULFILLMENT_DATA_INVALID" });
+  });
+});
+
+describe("validatePaymentPayload — warnings", () => {
+  it("rule 7 — flags `boson-createOfferCommitAndRedeem` as skipped (builder pending)", async () => {
+    const fx = await makePaymentFixture({ action: "boson-createOfferCommitAndRedeem" });
+    // Patch requirements to advertise the atomic action so rule 5 passes.
+    const requirements = {
+      ...fx.requirements,
+      actions: {
+        ...fx.requirements.actions,
+        next: [
+          ...fx.requirements.actions.next,
+          {
+            id: "boson-createOfferCommitAndRedeem",
+            channels: ["server", "facilitator", "onchain"] as const,
+          },
+        ],
+      },
+    };
+    const result = await validatePaymentPayload({
+      payload: fx.payload,
+      requirements: requirements as typeof fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    // Rule 8 will still fail because buyer signed against createOfferAndCommit
+    // calldata — that's fine: we only assert here that rule 7 issued the skip
+    // warning rather than blowing up.
+    if (result.ok) {
+      expect(result.warnings?.some((w) => w.rule === 7 && w.code === "RULE_SKIPPED")).toBe(true);
+    } else {
+      // Allowed: subsequent rule fails. We just care rule 7 didn't.
+      expect(result.rule).not.toBe(7);
+    }
+  });
+});
+
+describe("decodeXPaymentHeader", () => {
+  it("round-trips a base64-encoded JSON payload", () => {
+    const json = JSON.stringify({
+      x402Version: 2,
+      scheme: "escrow",
+      network: NETWORK,
+      payload: {
+        action: "boson-createOfferAndCommit",
+        tokenAuthStrategy: "none",
+        offerRef: { fullOffer: {}, sellerSig: "0x00" },
+        buyer: "0x1111111111111111111111111111111111111111",
+        metaTx: {
+          from: "0x1111111111111111111111111111111111111111",
+          nonce: "1",
+          functionName: "createOfferAndCommit(...)",
+          functionSignature: "0xdeadbeef",
+          sig: {
+            v: 27,
+            r: `0x${"00".repeat(32)}`,
+            s: `0x${"00".repeat(32)}`,
+          },
+        },
+      },
+    });
+    const header = Buffer.from(json, "utf8").toString("base64");
+    const result = decodeXPaymentHeader(header);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.scheme).toBe("escrow");
+      expect(result.payload.network).toBe(NETWORK);
+    }
+  });
+
+  it("returns MISSING_HEADER for empty input", () => {
+    expect(decodeXPaymentHeader(undefined)).toMatchObject({ ok: false, code: "MISSING_HEADER" });
+    expect(decodeXPaymentHeader("")).toMatchObject({ ok: false, code: "MISSING_HEADER" });
+  });
+
+  it("returns INVALID_BASE64 for garbage", () => {
+    expect(decodeXPaymentHeader("!!!not-base64!!!")).toMatchObject({
+      ok: false,
+      code: "INVALID_BASE64",
+    });
+  });
+
+  it("returns INVALID_PAYLOAD for valid JSON but bad shape", () => {
+    const header = Buffer.from(JSON.stringify({ foo: "bar" }), "utf8").toString("base64");
+    expect(decodeXPaymentHeader(header)).toMatchObject({
+      ok: false,
+      code: "INVALID_PAYLOAD",
+    });
+  });
+});
+
+// Silence unused-import linter — TOKEN is exported from fixtures for
+// future tests but not referenced in this file.
+void TOKEN;

--- a/typescript/packages/x402-server/test/validate.test.ts
+++ b/typescript/packages/x402-server/test/validate.test.ts
@@ -268,6 +268,35 @@ describe("validatePaymentPayload — rule failures", () => {
     expect(result).toMatchObject({ ok: false, rule: 11, code: "TOKEN_AUTH_SPENDER_MISMATCH" });
   });
 
+  it("rules 9–11 — defensive default: rejects an unknown token-auth strategy", async () => {
+    // zod narrows `tokenAuth.kind` to the discriminated union, so a
+    // well-formed wire payload can't reach the default branch. Cast
+    // through `unknown` to simulate a malformed payload that bypassed
+    // validation and assert the switch fails closed rather than
+    // implicitly returning `undefined`.
+    const fx = await makePaymentFixture({ tokenAuthStrategy: "erc3009" });
+    const requirementsWithMystery = {
+      ...fx.requirements,
+      tokenAuthStrategies: [...fx.requirements.tokenAuthStrategies, "mystery"],
+    } as unknown as typeof fx.requirements;
+    const tampered = JSON.parse(JSON.stringify(fx.payload)) as typeof fx.payload;
+    (tampered.payload as { tokenAuthStrategy: string }).tokenAuthStrategy = "mystery";
+    if (tampered.payload.tokenAuth) {
+      (tampered.payload.tokenAuth as { kind: string }).kind = "mystery";
+    }
+    const result = await validatePaymentPayload({
+      payload: tampered,
+      requirements: requirementsWithMystery,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      rule: 9,
+      code: "TOKEN_AUTH_UNKNOWN_STRATEGY",
+      field: "payload.tokenAuth.kind",
+    });
+  });
+
   it("rule 13 — rejects missing fulfillment when required", async () => {
     const fx = await makePaymentFixture();
     const result = await validatePaymentPayload({

--- a/typescript/packages/x402-server/test/validate.test.ts
+++ b/typescript/packages/x402-server/test/validate.test.ts
@@ -396,6 +396,40 @@ describe("decodeXPaymentHeader", () => {
       code: "INVALID_PAYLOAD",
     });
   });
+
+  it("preserves non-ASCII UTF-8 in fulfillment.data through the atob path", () => {
+    // Buyer-provided fulfilment data can carry non-ASCII bytes — names,
+    // addresses, locale-specific strings. Round-trip a valid payload
+    // whose `fulfillment.data.name` carries multi-byte characters and
+    // assert the decoder recovers UTF-8 rather than Latin-1 mojibake.
+    const wirePayload = {
+      x402Version: 2,
+      scheme: "escrow",
+      network: NETWORK,
+      payload: {
+        action: "boson-createOfferAndCommit",
+        tokenAuthStrategy: "none",
+        offerRef: { fullOffer: {}, sellerSig: "0x00" },
+        buyer: "0x1111111111111111111111111111111111111111",
+        metaTx: {
+          from: "0x1111111111111111111111111111111111111111",
+          nonce: "1",
+          functionName: "createOfferAndCommit(...)",
+          functionSignature: "0xdeadbeef",
+          sig: { v: 27, r: `0x${"00".repeat(32)}`, s: `0x${"00".repeat(32)}` },
+        },
+      },
+      fulfillment: { option: "email", data: { name: "Bär ✓ — 你好" } },
+    };
+    const header = Buffer.from(JSON.stringify(wirePayload), "utf8").toString("base64");
+    const result = decodeXPaymentHeader(header);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect((result.payload.fulfillment?.data as { name?: string } | null | undefined)?.name).toBe(
+        "Bär ✓ — 你好",
+      );
+    }
+  });
 });
 
 // Silence unused-import linter — TOKEN is exported from fixtures for

--- a/typescript/packages/x402-server/test/validate.test.ts
+++ b/typescript/packages/x402-server/test/validate.test.ts
@@ -183,6 +183,34 @@ describe("validatePaymentPayload — rule failures", () => {
     expect(result).toMatchObject({ ok: false, rule: 8, code: "BAD_META_TX_SIGNATURE" });
   });
 
+  it("rule 8 — returns a structured failure for unrecoverable signatures", async () => {
+    const fx = await makePaymentFixture();
+    const tampered = {
+      ...fx.payload,
+      payload: {
+        ...fx.payload.payload,
+        metaTx: {
+          ...fx.payload.payload.metaTx,
+          sig: {
+            ...fx.payload.payload.metaTx.sig,
+            v: 999,
+          },
+        },
+      },
+    };
+    const result = await validatePaymentPayload({
+      payload: tampered,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      rule: 8,
+      code: "BAD_META_TX_SIGNATURE",
+      field: "payload.metaTx.sig",
+    });
+  });
+
   it("rule 9 — rejects erc3009 amount mismatch", async () => {
     const fx = await makePaymentFixture({ tokenAuthStrategy: "erc3009" });
     const tampered = JSON.parse(JSON.stringify(fx.payload)) as typeof fx.payload;
@@ -290,8 +318,8 @@ describe("validatePaymentPayload — rule failures", () => {
   });
 });
 
-describe("validatePaymentPayload — warnings", () => {
-  it("rule 7 — flags `boson-createOfferCommitAndRedeem` as skipped (builder pending)", async () => {
+describe("validatePaymentPayload — unsupported calldata builders", () => {
+  it("rule 7 — fails closed for `boson-createOfferCommitAndRedeem` until its builder lands", async () => {
     const fx = await makePaymentFixture({ action: "boson-createOfferCommitAndRedeem" });
     // Patch requirements to advertise the atomic action so rule 5 passes.
     const requirements = {
@@ -312,15 +340,7 @@ describe("validatePaymentPayload — warnings", () => {
       requirements: requirements as typeof fx.requirements,
       chainId: CHAIN_ID,
     });
-    // Rule 8 will still fail because buyer signed against createOfferAndCommit
-    // calldata — that's fine: we only assert here that rule 7 issued the skip
-    // warning rather than blowing up.
-    if (result.ok) {
-      expect(result.warnings?.some((w) => w.rule === 7 && w.code === "RULE_SKIPPED")).toBe(true);
-    } else {
-      // Allowed: subsequent rule fails. We just care rule 7 didn't.
-      expect(result.rule).not.toBe(7);
-    }
+    expect(result).toMatchObject({ ok: false, rule: 7, code: "CALLDATA_MISMATCH" });
   });
 });
 

--- a/typescript/packages/x402-server/test/validate.test.ts
+++ b/typescript/packages/x402-server/test/validate.test.ts
@@ -353,31 +353,38 @@ describe("validatePaymentPayload — unsupported calldata builders", () => {
   });
 });
 
+/**
+ * Minimal wire-shaped `EscrowPaymentPayload` used as a base for the
+ * decoder tests. Holds placeholder signatures + a stub offerRef —
+ * `decodeXPaymentHeader` only cares that the outer shape passes the
+ * x402-core zod parser, not that any of the inner cryptography
+ * verifies. Returns a fresh object each call so tests that spread on
+ * top stay isolated.
+ */
+function makeBaseWirePayload() {
+  return {
+    x402Version: 2,
+    scheme: "escrow" as const,
+    network: NETWORK,
+    payload: {
+      action: "boson-createOfferAndCommit",
+      tokenAuthStrategy: "none" as const,
+      offerRef: { fullOffer: {}, sellerSig: "0x00" },
+      buyer: "0x1111111111111111111111111111111111111111",
+      metaTx: {
+        from: "0x1111111111111111111111111111111111111111",
+        nonce: "1",
+        functionName: "createOfferAndCommit(...)",
+        functionSignature: "0xdeadbeef",
+        sig: { v: 27, r: `0x${"00".repeat(32)}`, s: `0x${"00".repeat(32)}` },
+      },
+    },
+  };
+}
+
 describe("decodeXPaymentHeader", () => {
   it("round-trips a base64-encoded JSON payload", () => {
-    const json = JSON.stringify({
-      x402Version: 2,
-      scheme: "escrow",
-      network: NETWORK,
-      payload: {
-        action: "boson-createOfferAndCommit",
-        tokenAuthStrategy: "none",
-        offerRef: { fullOffer: {}, sellerSig: "0x00" },
-        buyer: "0x1111111111111111111111111111111111111111",
-        metaTx: {
-          from: "0x1111111111111111111111111111111111111111",
-          nonce: "1",
-          functionName: "createOfferAndCommit(...)",
-          functionSignature: "0xdeadbeef",
-          sig: {
-            v: 27,
-            r: `0x${"00".repeat(32)}`,
-            s: `0x${"00".repeat(32)}`,
-          },
-        },
-      },
-    });
-    const header = Buffer.from(json, "utf8").toString("base64");
+    const header = Buffer.from(JSON.stringify(makeBaseWirePayload()), "utf8").toString("base64");
     const result = decodeXPaymentHeader(header);
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -422,22 +429,7 @@ describe("decodeXPaymentHeader", () => {
     // whose `fulfillment.data.name` carries multi-byte characters and
     // assert the decoder recovers UTF-8 rather than Latin-1 mojibake.
     const wirePayload = {
-      x402Version: 2,
-      scheme: "escrow",
-      network: NETWORK,
-      payload: {
-        action: "boson-createOfferAndCommit",
-        tokenAuthStrategy: "none",
-        offerRef: { fullOffer: {}, sellerSig: "0x00" },
-        buyer: "0x1111111111111111111111111111111111111111",
-        metaTx: {
-          from: "0x1111111111111111111111111111111111111111",
-          nonce: "1",
-          functionName: "createOfferAndCommit(...)",
-          functionSignature: "0xdeadbeef",
-          sig: { v: 27, r: `0x${"00".repeat(32)}`, s: `0x${"00".repeat(32)}` },
-        },
-      },
+      ...makeBaseWirePayload(),
       fulfillment: { option: "email", data: { name: "Bär ✓ — 你好" } },
     };
     const header = Buffer.from(JSON.stringify(wirePayload), "utf8").toString("base64");

--- a/typescript/packages/x402-server/test/validate.test.ts
+++ b/typescript/packages/x402-server/test/validate.test.ts
@@ -51,6 +51,21 @@ describe("validatePaymentPayload — happy paths", () => {
 });
 
 describe("validatePaymentPayload — rule failures", () => {
+  it("rule 1 — rejects scheme mismatch", async () => {
+    const fx = await makePaymentFixture();
+    // `payload.scheme` is a literal `"escrow"` in the wire-format type,
+    // so the type narrowing wouldn't allow another value at compile
+    // time. Cast through `unknown` to exercise the runtime guard a
+    // hand-crafted malformed header would trigger.
+    const tampered = { ...fx.payload, scheme: "non-escrow" } as unknown as typeof fx.payload;
+    const result = await validatePaymentPayload({
+      payload: tampered,
+      requirements: fx.requirements,
+      chainId: CHAIN_ID,
+    });
+    expect(result).toMatchObject({ ok: false, rule: 1, code: "SCHEME_MISMATCH" });
+  });
+
   it("rule 2 — rejects network mismatch", async () => {
     const fx = await makePaymentFixture();
     const result = await validatePaymentPayload({
@@ -388,6 +403,16 @@ describe("decodeXPaymentHeader", () => {
     expect(decodeXPaymentHeader(header)).toMatchObject({
       ok: false,
       code: "INVALID_PAYLOAD",
+    });
+  });
+
+  it("returns INVALID_JSON for base64 that decodes to malformed JSON", () => {
+    // base64 is well-formed, but the inner UTF-8 isn't valid JSON
+    // (truncated object). Exercises the `JSON.parse` failure path.
+    const header = Buffer.from('{"foo": "bar"', "utf8").toString("base64");
+    expect(decodeXPaymentHeader(header)).toMatchObject({
+      ok: false,
+      code: "INVALID_JSON",
     });
   });
 


### PR DESCRIPTION
## Summary

Second PR of the `@bosonprotocol/x402-server` stack — lands the pure `X-PAYMENT` validator. Builds on top of PR #36 (now merged on `main`).

Implements all 13 rules from [`docs/boson-impl-01-escrow-scheme.md §5`](docs/boson-impl-01-escrow-scheme.md):

- **rules 1–6** — structural (scheme / network / `fullOffer` deep-equal / `sellerSig` / advertised `action` / advertised `tokenAuthStrategy`)
- **rule 7** — calldata byte-equality against [`buildCreateOfferAndCommitCalldata`](typescript/packages/evm/src/actions/create-offer-and-commit.ts) from `@bosonprotocol/x402-evm`; **fails closed** for `boson-createOfferCommitAndRedeem` until the atomic builder lands (contracts PR #1105) — no `RULE_SKIPPED` warning channel, so an unsupported action can never silently pass
- **rule 8** — buyer meta-tx signer recovery via `recoverMetaTransactionSigner`; recovery exceptions are caught and surface as a structured `BAD_META_TX_SIGNATURE`. `encodeRsv` whitelists `v ∈ {0, 1, 27, 28}` and normalises `0`/`1` → `27`/`28`
- **rules 9–11** — per-strategy structural checks for `erc3009` / `permit` / `permit2` (amount / recipient / spender / token / deadline)
- **rule 12** — `none` strategy's allowance pre-flight is deferred to the composition layer's `verifyExchange` step (RPC-dependent, lands with PR 4)
- **rule 13** — fulfillment option membership + optional caller-supplied data validator (the `FulfillmentRegistry` plugs in here in a follow-up)

Also ships [`decodeXPaymentHeader`](typescript/packages/x402-server/src/validate/decode.ts) for the base64 + JSON wrapping the buyer puts on the header (covers `MISSING_HEADER`, `INVALID_BASE64`, `INVALID_JSON`, `INVALID_PAYLOAD`).

Changeset: `.changeset/add-x402-server-validator.md` — `@bosonprotocol/x402-server` minor.

## Test plan

- [x] `pnpm install`
- [x] `pnpm --filter @bosonprotocol/x402-server build`
- [x] `pnpm --filter @bosonprotocol/x402-server test` — 34 cases pass: 4 happy paths (one per token-auth strategy) + 1 negative per spec rule (24 total in `validate.test.ts`) including hard-fail for Flow B's pending builder, unrecoverable-signature path, fulfillment option/data branches; plus PR #36's 10 cases that move forward unchanged
- [x] `pnpm lint`
- [x] `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * X-PAYMENT header decoding for escrow payloads
  * Comprehensive payment-payload validation (13-rule checks) with structured success/failure results
  * Token-authorization checks for none/erc3009/permit/permit2 and meta-transaction signature recovery/verification
  * Public validation subpath and re-exported validation APIs for easy import

* **Tests**
  * Extensive tests for header decoding and payment validation, with deterministic fixtures and helpers

* **Chores**
  * Added release changeset entry for the new validation helpers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/38)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->