### PR TITLE
chore: extend per-package lint scripts to cover test/

### DIFF
--- a/typescript/packages/actions/package.json
+++ b/typescript/packages/actions/package.json
@@ -50,7 +50,7 @@
   "scripts": {
     "build": "tsup && node scripts/postbuild.mjs",
     "test": "vitest run --passWithNoTests",
-    "lint": "eslint src --max-warnings 0",
+    "lint": "eslint src test --max-warnings 0",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/typescript/packages/client-fetch/package.json
+++ b/typescript/packages/client-fetch/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "tsup && node scripts/postbuild.mjs",
     "test": "vitest run --passWithNoTests",
-    "lint": "eslint src --max-warnings 0",
+    "lint": "eslint src test --max-warnings 0",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/typescript/packages/client/package.json
+++ b/typescript/packages/client/package.json
@@ -49,7 +49,7 @@
     "prebuild": "pnpm --filter @bosonprotocol/x402-core build",
     "build": "tsup && node scripts/postbuild.mjs",
     "test": "vitest run --passWithNoTests",
-    "lint": "eslint src --max-warnings 0",
+    "lint": "eslint src test --max-warnings 0",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -62,7 +62,7 @@
   "scripts": {
     "build": "tsup && node scripts/postbuild.mjs",
     "test": "vitest run --passWithNoTests",
-    "lint": "eslint src --max-warnings 0",
+    "lint": "eslint src test --max-warnings 0",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/typescript/packages/evm/package.json
+++ b/typescript/packages/evm/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "build": "tsup && node scripts/postbuild.mjs",
     "test": "vitest run --passWithNoTests",
-    "lint": "eslint src --max-warnings 0",
+    "lint": "eslint src test --max-warnings 0",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/typescript/packages/facilitator/package.json
+++ b/typescript/packages/facilitator/package.json
@@ -61,7 +61,7 @@
   "scripts": {
     "build": "tsup && node scripts/postbuild.mjs",
     "test": "vitest run --passWithNoTests",
-    "lint": "eslint src --max-warnings 0",
+    "lint": "eslint src test --max-warnings 0",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/typescript/packages/fulfillment/package.json
+++ b/typescript/packages/fulfillment/package.json
@@ -56,7 +56,7 @@
   "scripts": {
     "build": "tsup && node scripts/postbuild.mjs",
     "test": "vitest run --passWithNoTests",
-    "lint": "eslint src --max-warnings 0",
+    "lint": "eslint src test --max-warnings 0",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/typescript/packages/x402-server/package.json
+++ b/typescript/packages/x402-server/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "build": "tsup && node scripts/postbuild.mjs",
     "test": "vitest run --passWithNoTests",
-    "lint": "eslint src --max-warnings 0",
+    "lint": "eslint src test --max-warnings 0",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Each workspace package's `lint` script runs `eslint src --max-warnings 0` — only covering `src/`. Unused imports and other lint regressions inside `test/` therefore slip past local `pnpm lint` verification. CI / external reviewers catch them via broader lint scope, but only after a PR is opened.

Bump every package's lint script to `eslint src test --max-warnings 0` so the local `pnpm lint` matches what reviewers see.

`turbo.json`'s lint task already declares `test/**` in its inputs, so the caching behavior is unaffected by this change.

Packages touched:

- `@bosonprotocol/x402-actions`
- `@bosonprotocol/x402-client`
- `@bosonprotocol/x402-client-fetch`
- `@bosonprotocol/x402-core`
- `@bosonprotocol/x402-evm`
- `@bosonprotocol/x402-facilitator`
- `@bosonprotocol/x402-fulfillment`
- `@bosonprotocol/x402-server`

All eight lint cleanly under the new scope today — verified by running `pnpm lint` workspace-wide on this branch.

## Test plan

- [ ] `pnpm install`
- [ ] `pnpm lint` — all 8 packages pass with the expanded scope
- [ ] `pnpm build` / `pnpm test` — unchanged behavior
- [ ] `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality assurance across multiple packages by expanding linting coverage to include both source and test directories, ensuring consistent code standards throughout the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/39)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->