### PR TITLE
fix(verify): resolve escrow from server-side allowlist

### DIFF
--- a/.changeset/harden-verify-settle-escrow-allowlist.md
+++ b/.changeset/harden-verify-settle-escrow-allowlist.md
@@ -1,0 +1,20 @@
+---
+"@bosonprotocol/x402-facilitator": minor
+---
+
+Extend the `FacilitatorConfig.escrows` allowlist enforcement to
+`verify()` and `settle()`. Previously only `performAction()` validated
+the target Diamond against the operator-configured allowlist;
+`verify()`/`settle()` trusted `input.requirements.escrowAddress`
+directly, so a malicious seller could direct the relayer at any
+contract on a supported chain that exposes a compatible
+`executeMetaTransaction(...)` selector.
+
+`verify()` (and transitively `settle()`) now reject:
+- Networks with no `config.escrows[network]` entry →
+  `NETWORK_MISMATCH`.
+- `requirements.escrowAddress` mismatched against the configured
+  Diamond → `INVALID_PAYLOAD`.
+
+Spec doc and `FacilitatorConfig.escrows` JSDoc updated to reflect that
+all three library functions now consume the same allowlist.

--- a/docs/boson-impl-07-facilitator.md
+++ b/docs/boson-impl-07-facilitator.md
@@ -56,6 +56,21 @@ POST /perform-action?action=<ActionId>     // optional, for the "facilitator" ch
 - `${url}/settle` for commit-time actions (`boson-createOfferAndCommit`, `boson-createOfferCommitAndRedeem`).
 - `${url}/perform-action?action=${action}` for post-commit actions.
 
+## Escrow allowlist
+
+The facilitator operator MUST configure
+`FacilitatorConfig.escrows: Record<EvmNetwork, Address>` — the set of
+Boson Diamond addresses the relayer is willing to sponsor gas for.
+`verify()`, `settle()`, and `performAction()` all reject requests for
+networks without an allowlist entry, and reject requests whose
+`escrowAddress` (in `requirements` for verify/settle, in the request
+body for perform-action) doesn't match the configured Diamond.
+
+Without this gate, anyone could direct the relayer at an arbitrary
+contract on a supported chain that exposes a compatible
+`executeMetaTransaction(...)` selector — the facilitator would become
+a generic gas sponsor rather than a Boson-only relay.
+
 ## Settle path
 
 In v0.1, `verify()` performs structural validation, offer/calldata

--- a/typescript/packages/facilitator/src/types.ts
+++ b/typescript/packages/facilitator/src/types.ts
@@ -152,13 +152,15 @@ export interface FacilitatorConfig {
    * `executeMetaTransaction(...)` selector could trick the relayer into
    * sponsoring gas for non-Boson calls.
    *
-   * `performAction()` consumes this today: it rejects requests for
-   * networks without an entry, and rejects requests whose body
-   * `escrowAddress` doesn't match the configured Diamond.
+   * All three library functions enforce the allowlist:
    *
-   * Note: `verify()` and `settle()` still resolve the escrow from
-   * `input.requirements.escrowAddress` and should adopt the same
-   * allowlist check — tracked as a follow-up hardening.
+   * - `verify()` and `settle()` reject when
+   *   `input.requirements.escrowAddress` doesn't match
+   *   `escrows[input.network]`.
+   * - `performAction()` rejects when `input.escrowAddress` doesn't match
+   *   `escrows[input.network]`.
+   *
+   * Networks without an entry are rejected as `NETWORK_MISMATCH`.
    */
   escrows: Readonly<Record<EvmNetwork, Address>>;
   /** viem WalletClient — pays gas on settle / perform-action. Network must be in `supportedNetworks`. */

--- a/typescript/packages/facilitator/src/verify/index.ts
+++ b/typescript/packages/facilitator/src/verify/index.ts
@@ -13,11 +13,16 @@
 //   6. Confirm `payload.tokenAuthStrategy` is in
 //      `requirements.tokenAuthStrategies` (and the cross-field rule:
 //      tokenAuth must be present iff strategy != "none").
-//   7. Recover the buyer's meta-tx signature against the Diamond domain.
-//   8. If `tokenAuthStrategy !== "none"`, recover the token-auth
+//   7. Confirm `requirements.escrowAddress` is the Boson Diamond the
+//      operator has whitelisted for this network via `config.escrows`.
+//      Prevents a malicious seller from directing the facilitator at
+//      an arbitrary contract that shares the `executeMetaTransaction`
+//      selector.
+//   8. Recover the buyer's meta-tx signature against the Diamond domain.
+//   9. If `tokenAuthStrategy !== "none"`, recover the token-auth
 //      signature against the asset's EIP-712 domain and enforce
 //      amount/deadline constraints.
-//   9. Simulate `executeMetaTransaction(...)` via `eth_call` to catch
+//  10. Simulate `executeMetaTransaction(...)` via `eth_call` to catch
 //      protocol-level reverts (duplicate nonce, expired auth, …)
 //      without spending gas.
 //
@@ -120,7 +125,31 @@ export async function verify(
     }
 
     const inner = input.payload.payload;
-    const escrowAddress = input.requirements.escrowAddress as `0x${string}`;
+
+    // Resolve the canonical escrow from the operator's allowlist —
+    // trusting `input.requirements.escrowAddress` directly would let a
+    // malicious seller direct the facilitator at any contract on a
+    // supported chain that exposes a compatible
+    // `executeMetaTransaction(...)` selector, turning the relayer into
+    // a generic gas sponsor for non-Boson calls. Reject if the network
+    // has no allowlist entry, or if the requirements advertise a
+    // Diamond the operator hasn't whitelisted.
+    const allowlistedEscrow = config.escrows[input.network];
+    if (!allowlistedEscrow) {
+      return {
+        ok: false,
+        code: "NETWORK_MISMATCH",
+        reason: `network "${input.network}" has no escrow configured in config.escrows`,
+      };
+    }
+    if (input.requirements.escrowAddress.toLowerCase() !== allowlistedEscrow.toLowerCase()) {
+      return {
+        ok: false,
+        code: "INVALID_PAYLOAD",
+        reason: `requirements.escrowAddress "${input.requirements.escrowAddress}" is not the configured Diamond for network "${input.network}" ("${allowlistedEscrow}")`,
+      };
+    }
+    const escrowAddress = allowlistedEscrow as `0x${string}`;
 
     // 8. Meta-tx signature recovery.
     const metaSig = await verifyMetaTxSignature({

--- a/typescript/packages/facilitator/test/verify.test.ts
+++ b/typescript/packages/facilitator/test/verify.test.ts
@@ -154,6 +154,33 @@ describe("verify()", () => {
     expect(result).toMatchObject({ ok: false, code: "TOKEN_AUTH_NOT_IN_REQUIREMENTS" });
   });
 
+  it("rejects when the network has no configured escrow allowlist entry", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+    const config = buildConfig();
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      { ...config, escrows: {} },
+    );
+    expect(result).toMatchObject({ ok: false, code: "NETWORK_MISMATCH" });
+    expect((result as { ok: false; reason: string }).reason).toMatch(/no escrow configured/i);
+  });
+
+  it("rejects when requirements.escrowAddress is not the configured Diamond", async () => {
+    const payload = await buildValidPayload();
+    const ATTACKER_CONTRACT: Address = "0xcafecafecafecafecafecafecafecafecafecafe";
+    // The seller advertised a different escrow than the operator's
+    // allowlist — could be a malicious seller trying to direct the
+    // relayer at an arbitrary contract.
+    const requirements = { ...buildValidRequirements(), escrowAddress: ATTACKER_CONTRACT };
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "INVALID_PAYLOAD" });
+    expect((result as { ok: false; reason: string }).reason).toMatch(/not the configured Diamond/i);
+  });
+
   it("rejects when payload.offerRef does not match requirements.offer", async () => {
     const payload = await buildValidPayload();
     payload.payload.offerRef.fullOffer = { ...fullOffer, price: "2" };


### PR DESCRIPTION
## Summary

Extend `FacilitatorConfig.escrows` enforcement to `verify()` (which `settle()` also benefits from transitively, since it runs `verify()` first).

PR #40 introduced the operator-controlled escrow allowlist and wired it into `performAction()`. `verify()` and `settle()` still resolved the target Diamond from `input.requirements.escrowAddress` — that trust path let a malicious seller advertise any contract on a supported chain that exposes a compatible `executeMetaTransaction(...)` selector, turning the facilitator into a generic gas sponsor for non-Boson calls. This PR closes that gap.

`verify()` now:

- Looks up `config.escrows[input.network]` before any signature work. No entry → `NETWORK_MISMATCH` with a clear "no escrow configured" reason.
- Compares the configured Diamond against `input.requirements.escrowAddress` (case-insensitive). Mismatch → `INVALID_PAYLOAD` with a "not the configured Diamond" reason.
- Routes every downstream call (`verifyMetaTxSignature`, `verifyTokenAuthSignature`, `simulateExecuteMetaTransaction`) through the allowlisted address.

`settle()` inherits this for free since it runs `verify()` first.

`FacilitatorConfig.escrows` JSDoc and `docs/boson-impl-07-facilitator.md` updated to document the consolidated allowlist: all three library functions now enforce the same gate.

## Test plan

- [ ] `pnpm install`
- [ ] `pnpm build` — workspace builds clean
- [ ] `pnpm test` — 63 facilitator tests pass (two new in `verify.test.ts`: missing allowlist entry → NETWORK_MISMATCH; mismatched `requirements.escrowAddress` → INVALID_PAYLOAD)
- [ ] `pnpm lint` — zero warnings
- [ ] `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced `verify()` to enforce escrow allowlist validation, rejecting requests for networks without configured escrows and requests with mismatched escrow addresses.

* **Documentation**
  * Updated specification and JSDoc to reflect that all three library functions now validate against the escrow allowlist.

* **Tests**
  * Added test coverage for escrow validation scenarios in `verify()`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/41)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->