### PR TITLE
feat(x402-server): facilitator HTTP client

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       '@bosonprotocol/x402-evm':
         specifier: workspace:^
         version: link:../evm
+      '@bosonprotocol/x402-facilitator':
+        specifier: workspace:^
+        version: link:../facilitator
       viem:
         specifier: ^2.39.3
         version: 2.48.11(typescript@5.9.3)(zod@3.25.76)

--- a/typescript/packages/x402-server/package.json
+++ b/typescript/packages/x402-server/package.json
@@ -38,6 +38,11 @@
       "types": "./dist/cjs/validate/index.d.ts",
       "import": "./dist/esm/validate/index.js",
       "require": "./dist/cjs/validate/index.js"
+    },
+    "./facilitator": {
+      "types": "./dist/cjs/facilitator/index.d.ts",
+      "import": "./dist/esm/facilitator/index.js",
+      "require": "./dist/cjs/facilitator/index.js"
     }
   },
   "files": [
@@ -60,6 +65,7 @@
     "@bosonprotocol/x402-actions": "workspace:^",
     "@bosonprotocol/x402-core": "workspace:^",
     "@bosonprotocol/x402-evm": "workspace:^",
+    "@bosonprotocol/x402-facilitator": "workspace:^",
     "viem": "^2.39.3",
     "zod": "^3.24.2"
   },

--- a/typescript/packages/x402-server/src/facilitator/client.ts
+++ b/typescript/packages/x402-server/src/facilitator/client.ts
@@ -64,7 +64,11 @@ export function createFacilitatorClient(opts: CreateFacilitatorClientOptions): F
   const baseUrl = opts.url.replace(/\/+$/, "");
   const baseHeaders = { "content-type": "application/json", ...(opts.headers ?? {}) };
 
-  const post = async <Req, Res>(path: string, body: Req): Promise<Res> => {
+  const post = async <Req, Res>(
+    path: string,
+    body: Req,
+    validate: (parsed: unknown) => parsed is Res,
+  ): Promise<Res> => {
     let res: Awaited<ReturnType<FetchLike>>;
     try {
       res = await fetchImpl(`${baseUrl}${path}`, {
@@ -113,18 +117,74 @@ export function createFacilitatorClient(opts: CreateFacilitatorClientOptions): F
       );
     }
 
-    return parsed as Res;
+    if (!validate(parsed)) {
+      throw new FacilitatorHttpError(`facilitator returned unexpected body shape (${path})`, {
+        code: "BAD_RESPONSE_BODY",
+        status: res.status,
+      });
+    }
+    return parsed;
   };
 
   return {
-    verify: (input) => post<FacilitatorVerifyInput, FacilitatorVerifyResult>("/verify", input),
-    settle: (input) => post<FacilitatorSettleInput, FacilitatorSettleResult>("/settle", input),
+    verify: (input) =>
+      post<FacilitatorVerifyInput, FacilitatorVerifyResult>("/verify", input, isVerifyResult),
+    settle: (input) =>
+      post<FacilitatorSettleInput, FacilitatorSettleResult>("/settle", input, isSettleResult),
     performAction: (input) =>
       post<FacilitatorPerformActionInput, FacilitatorPerformActionResult>(
         `/perform-action?action=${encodeURIComponent(input.action)}`,
         input,
+        isPerformActionResult,
       ),
   };
+}
+
+// --- Response-shape type guards ----------------------------------------
+//
+// A buggy or malicious facilitator could return any 2xx JSON; without a
+// runtime check, `parsed as Res` would silently slip an unexpected shape
+// past the type system and the convenience handlers (PR 4) would
+// dereference fields that aren't there. These guards mirror the
+// discriminated unions in `@bosonprotocol/x402-facilitator`'s types and
+// fail any response that doesn't fit — surfaced as
+// `BAD_RESPONSE_BODY` so the caller treats it as a transport-layer
+// failure rather than a domain answer.
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object";
+}
+
+/** Failure branch is identical across all three endpoints. */
+function isFailureBranch(v: Record<string, unknown>): boolean {
+  return v.ok === false && typeof v.code === "string" && typeof v.reason === "string";
+}
+
+function isVerifyResult(parsed: unknown): parsed is FacilitatorVerifyResult {
+  if (!isObject(parsed)) return false;
+  if (parsed.ok === true) return true; // `{ ok: true }` carries no further fields
+  return isFailureBranch(parsed);
+}
+
+function isSettleResult(parsed: unknown): parsed is FacilitatorSettleResult {
+  if (!isObject(parsed)) return false;
+  if (parsed.ok === true) {
+    return typeof parsed.exchangeId === "string" && typeof parsed.txHash === "string";
+  }
+  return isFailureBranch(parsed);
+}
+
+function isPerformActionResult(parsed: unknown): parsed is FacilitatorPerformActionResult {
+  if (!isObject(parsed)) return false;
+  if (parsed.ok === true) {
+    if (typeof parsed.txHash !== "string") return false;
+    if (typeof parsed.newExchangeState !== "string") return false;
+    if (parsed.newDisputeState !== undefined && typeof parsed.newDisputeState !== "string") {
+      return false;
+    }
+    return true;
+  }
+  return isFailureBranch(parsed);
 }
 
 function extractFacilitatorCode(body: unknown): FacilitatorErrorCode | undefined {

--- a/typescript/packages/x402-server/src/facilitator/client.ts
+++ b/typescript/packages/x402-server/src/facilitator/client.ts
@@ -1,0 +1,137 @@
+// HTTP client for the Boson facilitator service. The facilitator runs
+// as a remote process implementing the three endpoints in
+// docs/boson-impl-07-facilitator.md (`/verify`, `/settle`,
+// `/perform-action`); this module wraps `fetch` with the typed
+// request/response shapes exported by `@bosonprotocol/x402-facilitator`.
+//
+// Successful responses (`{ ok: true, ... }` or `{ ok: false, code, reason }`)
+// are returned verbatim — both shapes are domain results the caller
+// branches on. HTTP-transport failures (network down, 5xx with an
+// unparseable body, non-JSON 200, etc.) throw `FacilitatorHttpError`
+// so the composition layer can distinguish "facilitator said no" from
+// "we couldn't reach the facilitator".
+
+import type {
+  FacilitatorErrorCode,
+  FacilitatorPerformActionInput,
+  FacilitatorPerformActionResult,
+  FacilitatorSettleInput,
+  FacilitatorSettleResult,
+  FacilitatorVerifyInput,
+  FacilitatorVerifyResult,
+} from "@bosonprotocol/x402-facilitator";
+
+import { FacilitatorHttpError } from "./errors.js";
+
+export type FetchLike = (
+  input: string,
+  init?: { method?: string; headers?: Record<string, string>; body?: string },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  text: () => Promise<string>;
+  json?: () => Promise<unknown>;
+}>;
+
+export interface CreateFacilitatorClientOptions {
+  /** Base URL of the facilitator service (no trailing slash needed). */
+  url: string;
+  /** Optional `fetch` override — defaults to the global `fetch`. Useful for tests + non-`fetch` runtimes. */
+  fetch?: FetchLike;
+  /** Optional headers attached to every request — e.g. an `Authorization` for hosted facilitators. */
+  headers?: Record<string, string>;
+}
+
+export interface FacilitatorClient {
+  verify(input: FacilitatorVerifyInput): Promise<FacilitatorVerifyResult>;
+  settle(input: FacilitatorSettleInput): Promise<FacilitatorSettleResult>;
+  performAction(input: FacilitatorPerformActionInput): Promise<FacilitatorPerformActionResult>;
+}
+
+/**
+ * Construct a typed HTTP client for the facilitator. The returned
+ * methods stringify the input as JSON and POST to the matching path
+ * on the configured URL. Non-2xx responses raise `FacilitatorHttpError`;
+ * 2xx responses are JSON-parsed and returned verbatim.
+ */
+export function createFacilitatorClient(opts: CreateFacilitatorClientOptions): FacilitatorClient {
+  const fetchImpl = opts.fetch ?? (globalThis.fetch as FetchLike | undefined);
+  if (fetchImpl === undefined) {
+    throw new Error(
+      "createFacilitatorClient: no `fetch` implementation available. Pass `opts.fetch` explicitly.",
+    );
+  }
+  const baseUrl = opts.url.replace(/\/+$/, "");
+  const baseHeaders = { "content-type": "application/json", ...(opts.headers ?? {}) };
+
+  const post = async <Req, Res>(path: string, body: Req): Promise<Res> => {
+    let res: Awaited<ReturnType<FetchLike>>;
+    try {
+      res = await fetchImpl(`${baseUrl}${path}`, {
+        method: "POST",
+        headers: baseHeaders,
+        body: JSON.stringify(body),
+      });
+    } catch (cause) {
+      throw new FacilitatorHttpError(`facilitator network error (${path})`, {
+        code: "NETWORK_ERROR",
+        cause,
+      });
+    }
+
+    let text: string;
+    try {
+      text = await res.text();
+    } catch (cause) {
+      throw new FacilitatorHttpError(`facilitator response body could not be read (${path})`, {
+        code: "BAD_RESPONSE_BODY",
+        status: res.status,
+        cause,
+      });
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = text.length === 0 ? null : JSON.parse(text);
+    } catch (cause) {
+      throw new FacilitatorHttpError(`facilitator returned non-JSON body (${path})`, {
+        code: "BAD_RESPONSE_BODY",
+        status: res.status,
+        cause,
+      });
+    }
+
+    if (!res.ok) {
+      const facilitatorCode = extractFacilitatorCode(parsed);
+      throw new FacilitatorHttpError(
+        `facilitator HTTP ${res.status} (${path}): ${reasonString(parsed) ?? text}`,
+        {
+          code: "BAD_HTTP_STATUS",
+          status: res.status,
+          ...(facilitatorCode !== undefined ? { facilitatorCode } : {}),
+        },
+      );
+    }
+
+    return parsed as Res;
+  };
+
+  return {
+    verify: (input) => post<FacilitatorVerifyInput, FacilitatorVerifyResult>("/verify", input),
+    settle: (input) => post<FacilitatorSettleInput, FacilitatorSettleResult>("/settle", input),
+    performAction: (input) =>
+      post<FacilitatorPerformActionInput, FacilitatorPerformActionResult>("/perform-action", input),
+  };
+}
+
+function extractFacilitatorCode(body: unknown): FacilitatorErrorCode | undefined {
+  if (body === null || typeof body !== "object") return undefined;
+  const code = (body as { code?: unknown }).code;
+  return typeof code === "string" ? (code as FacilitatorErrorCode) : undefined;
+}
+
+function reasonString(body: unknown): string | undefined {
+  if (body === null || typeof body !== "object") return undefined;
+  const reason = (body as { reason?: unknown }).reason;
+  return typeof reason === "string" ? reason : undefined;
+}

--- a/typescript/packages/x402-server/src/facilitator/client.ts
+++ b/typescript/packages/x402-server/src/facilitator/client.ts
@@ -1,7 +1,7 @@
 // HTTP client for the Boson facilitator service. The facilitator runs
 // as a remote process implementing the three endpoints in
 // docs/boson-impl-07-facilitator.md (`/verify`, `/settle`,
-// `/perform-action`); this module wraps `fetch` with the typed
+// `/perform-action?action=<action>`); this module wraps `fetch` with the typed
 // request/response shapes exported by `@bosonprotocol/x402-facilitator`.
 //
 // Successful responses (`{ ok: true, ... }` or `{ ok: false, code, reason }`)
@@ -120,7 +120,10 @@ export function createFacilitatorClient(opts: CreateFacilitatorClientOptions): F
     verify: (input) => post<FacilitatorVerifyInput, FacilitatorVerifyResult>("/verify", input),
     settle: (input) => post<FacilitatorSettleInput, FacilitatorSettleResult>("/settle", input),
     performAction: (input) =>
-      post<FacilitatorPerformActionInput, FacilitatorPerformActionResult>("/perform-action", input),
+      post<FacilitatorPerformActionInput, FacilitatorPerformActionResult>(
+        `/perform-action?action=${encodeURIComponent(input.action)}`,
+        input,
+      ),
   };
 }
 

--- a/typescript/packages/x402-server/src/facilitator/errors.ts
+++ b/typescript/packages/x402-server/src/facilitator/errors.ts
@@ -1,0 +1,43 @@
+// Typed error class for HTTP-level facilitator failures. Distinct from
+// the `{ ok: false, code }` shape the facilitator itself returns —
+// those are domain errors and surface in the typed result. This class
+// is thrown only when the HTTP transport fails (network error,
+// non-2xx response with an unparseable body, etc.).
+
+import type { FacilitatorErrorCode } from "@bosonprotocol/x402-facilitator";
+
+/**
+ * Stable, x402-server-side codes for HTTP-transport failures.
+ * Distinct from the facilitator-side `FacilitatorErrorCode` enum so
+ * callers can branch on "the facilitator answered with X" vs "we
+ * never reached the facilitator".
+ */
+export type FacilitatorHttpErrorCode =
+  | "NETWORK_ERROR"
+  | "BAD_HTTP_STATUS"
+  | "BAD_RESPONSE_BODY"
+  | "TIMEOUT";
+
+/** Network- or transport-layer failure when calling the facilitator. */
+export class FacilitatorHttpError extends Error {
+  readonly code: FacilitatorHttpErrorCode;
+  readonly status?: number;
+  /** Original facilitator-side error code, if the body parsed cleanly. */
+  readonly facilitatorCode?: FacilitatorErrorCode;
+
+  constructor(
+    message: string,
+    init: {
+      code: FacilitatorHttpErrorCode;
+      status?: number;
+      facilitatorCode?: FacilitatorErrorCode;
+      cause?: unknown;
+    },
+  ) {
+    super(message, init.cause !== undefined ? { cause: init.cause } : undefined);
+    this.name = "FacilitatorHttpError";
+    this.code = init.code;
+    if (init.status !== undefined) this.status = init.status;
+    if (init.facilitatorCode !== undefined) this.facilitatorCode = init.facilitatorCode;
+  }
+}

--- a/typescript/packages/x402-server/src/facilitator/index.ts
+++ b/typescript/packages/x402-server/src/facilitator/index.ts
@@ -1,0 +1,25 @@
+// `facilitator` subpath — HTTP client for the remote facilitator
+// service. Wire types are re-exported from
+// `@bosonprotocol/x402-facilitator` so client + server stay in
+// lock-step without a separate type-only sub-package.
+
+export {
+  createFacilitatorClient,
+  type CreateFacilitatorClientOptions,
+  type FacilitatorClient,
+  type FetchLike,
+} from "./client.js";
+export { FacilitatorHttpError, type FacilitatorHttpErrorCode } from "./errors.js";
+
+// Re-export the wire types so consumers don't need a separate
+// `@bosonprotocol/x402-facilitator` import just to type a request
+// shape against the client.
+export type {
+  FacilitatorErrorCode,
+  FacilitatorPerformActionInput,
+  FacilitatorPerformActionResult,
+  FacilitatorSettleInput,
+  FacilitatorSettleResult,
+  FacilitatorVerifyInput,
+  FacilitatorVerifyResult,
+} from "@bosonprotocol/x402-facilitator";

--- a/typescript/packages/x402-server/src/index.ts
+++ b/typescript/packages/x402-server/src/index.ts
@@ -29,3 +29,18 @@ export {
   type ValidationErrorCode,
   type ValidationWarning,
 } from "./validate/index.js";
+export {
+  createFacilitatorClient,
+  FacilitatorHttpError,
+  type CreateFacilitatorClientOptions,
+  type FacilitatorClient,
+  type FacilitatorErrorCode,
+  type FacilitatorHttpErrorCode,
+  type FacilitatorPerformActionInput,
+  type FacilitatorPerformActionResult,
+  type FacilitatorSettleInput,
+  type FacilitatorSettleResult,
+  type FacilitatorVerifyInput,
+  type FacilitatorVerifyResult,
+  type FetchLike,
+} from "./facilitator/index.js";

--- a/typescript/packages/x402-server/test/facilitator-client.test.ts
+++ b/typescript/packages/x402-server/test/facilitator-client.test.ts
@@ -146,7 +146,7 @@ describe("createFacilitatorClient", () => {
     expect(stub.calls[0]!.url).toBe(`${BASE_URL}/settle`);
   });
 
-  it("POSTs `/perform-action` with the action-specific input shape", async () => {
+  it("POSTs `/perform-action?action=<action>` with the action-specific input shape", async () => {
     const stub = makeStubFetch(() => ({
       body: {
         ok: true,
@@ -159,7 +159,7 @@ describe("createFacilitatorClient", () => {
     const result = await client.performAction(performActionInput);
 
     expect(result).toMatchObject({ ok: true, txHash: "0xdef", newExchangeState: "COMPLETED" });
-    expect(stub.calls[0]!.url).toBe(`${BASE_URL}/perform-action`);
+    expect(stub.calls[0]!.url).toBe(`${BASE_URL}/perform-action?action=boson-completeExchange`);
     expect(JSON.parse(stub.calls[0]!.init!.body!)).toEqual(performActionInput);
   });
 

--- a/typescript/packages/x402-server/test/facilitator-client.test.ts
+++ b/typescript/packages/x402-server/test/facilitator-client.test.ts
@@ -201,6 +201,40 @@ describe("createFacilitatorClient", () => {
     });
   });
 
+  it("throws FacilitatorHttpError(BAD_RESPONSE_BODY) when 2xx JSON doesn't match the result shape", async () => {
+    // A buggy / malicious facilitator could return any 2xx JSON; without
+    // the runtime guard, `parsed as Res` would slip an off-shape body
+    // straight through to the caller.
+    const stub = makeStubFetch(() => ({
+      status: 200,
+      body: { exchangeId: "42" }, // missing `ok` discriminator + `txHash`
+    }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    await expect(client.settle(settleInput)).rejects.toMatchObject({
+      name: "FacilitatorHttpError",
+      code: "BAD_RESPONSE_BODY",
+      status: 200,
+    });
+  });
+
+  it("throws FacilitatorHttpError(BAD_RESPONSE_BODY) on partial perform-action success body", async () => {
+    // `ok: true` for /perform-action requires `txHash` + `newExchangeState`.
+    // A response that drops `newExchangeState` would otherwise typecheck
+    // away to undefined at the call site.
+    const stub = makeStubFetch(() => ({
+      status: 200,
+      body: { ok: true, txHash: "0xabc" }, // newExchangeState missing
+    }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    await expect(client.performAction(performActionInput)).rejects.toMatchObject({
+      name: "FacilitatorHttpError",
+      code: "BAD_RESPONSE_BODY",
+      status: 200,
+    });
+  });
+
   it("strips a trailing slash from `url`", async () => {
     const stub = makeStubFetch(() => ({ body: { ok: true } }));
     const client = createFacilitatorClient({ url: `${BASE_URL}/`, fetch: stub.fetch });

--- a/typescript/packages/x402-server/test/facilitator-client.test.ts
+++ b/typescript/packages/x402-server/test/facilitator-client.test.ts
@@ -1,0 +1,236 @@
+// HTTP-transport tests for `createFacilitatorClient`. The fetch
+// implementation is stubbed per-test so we exercise the request
+// shape (URL, method, headers, body) and the response branching
+// (success / domain `{ok:false}` / HTTP error → throws
+// FacilitatorHttpError) without standing up a real facilitator.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createFacilitatorClient,
+  FacilitatorHttpError,
+  type FacilitatorPerformActionInput,
+  type FacilitatorSettleInput,
+  type FacilitatorVerifyInput,
+  type FetchLike,
+} from "../src/index.js";
+
+const BASE_URL = "https://facilitator.example";
+const NETWORK = "eip155:8453" as const;
+const ESCROW = "0xdddddddddddddddddddddddddddddddddddddddd" as const;
+
+function makeStubFetch(
+  handler: (req: { url: string; init: Parameters<FetchLike>[1] }) => {
+    status?: number;
+    body?: unknown;
+    textOverride?: string;
+    throwError?: unknown;
+  },
+): { fetch: FetchLike; calls: Array<{ url: string; init: Parameters<FetchLike>[1] }> } {
+  const calls: Array<{ url: string; init: Parameters<FetchLike>[1] }> = [];
+  const fetch: FetchLike = async (url, init) => {
+    calls.push({ url, init });
+    const result = handler({ url, init });
+    if (result.throwError !== undefined) throw result.throwError;
+    const status = result.status ?? 200;
+    const text =
+      result.textOverride !== undefined
+        ? result.textOverride
+        : result.body !== undefined
+          ? JSON.stringify(result.body)
+          : "";
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => text,
+    };
+  };
+  return { fetch, calls };
+}
+
+const verifyInput: FacilitatorVerifyInput = {
+  scheme: "escrow",
+  network: NETWORK,
+  payload: {
+    x402Version: 2,
+    scheme: "escrow",
+    network: NETWORK,
+    payload: {
+      action: "boson-createOfferAndCommit",
+      tokenAuthStrategy: "none",
+      offerRef: { fullOffer: {}, sellerSig: "0x00" },
+      buyer: "0x1111111111111111111111111111111111111111",
+      metaTx: {
+        from: "0x1111111111111111111111111111111111111111",
+        nonce: "1",
+        functionName: "createOfferAndCommit(...)",
+        functionSignature: "0xdeadbeef",
+        sig: { v: 27, r: `0x${"00".repeat(32)}`, s: `0x${"00".repeat(32)}` },
+      },
+    },
+  },
+  requirements: {
+    scheme: "escrow",
+    network: NETWORK,
+    asset: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    amount: "1000000",
+    escrowAddress: ESCROW,
+    recipientId: "did:boson:seller:1",
+    maxTimeoutSeconds: 300,
+    offer: {
+      fullOffer: {},
+      sellerSig: "0x00",
+      creator: "0x1111111111111111111111111111111111111111",
+    },
+    tokenAuthStrategies: ["none"],
+    actions: {
+      next: [
+        {
+          id: "boson-createOfferAndCommit",
+          channels: ["server", "facilitator", "onchain"],
+        },
+      ],
+    },
+  },
+};
+
+const settleInput: FacilitatorSettleInput = verifyInput;
+
+const performActionInput: FacilitatorPerformActionInput = {
+  network: NETWORK,
+  escrowAddress: ESCROW,
+  exchangeId: "42",
+  action: "boson-completeExchange",
+  signedPayload: "0xc0ffee",
+};
+
+describe("createFacilitatorClient", () => {
+  it("POSTs `/verify` with JSON body and returns the parsed result", async () => {
+    const stub = makeStubFetch(() => ({ body: { ok: true } }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    const result = await client.verify(verifyInput);
+
+    expect(result).toEqual({ ok: true });
+    expect(stub.calls).toHaveLength(1);
+    expect(stub.calls[0]!.url).toBe(`${BASE_URL}/verify`);
+    expect(stub.calls[0]!.init?.method).toBe("POST");
+    expect(stub.calls[0]!.init?.headers?.["content-type"]).toBe("application/json");
+    expect(JSON.parse(stub.calls[0]!.init!.body!)).toEqual(verifyInput);
+  });
+
+  it("returns domain `{ok:false}` from /verify verbatim", async () => {
+    const stub = makeStubFetch(() => ({
+      body: { ok: false, code: "BAD_META_TX_SIGNATURE", reason: "sig mismatch" },
+    }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    const result = await client.verify(verifyInput);
+
+    expect(result).toEqual({
+      ok: false,
+      code: "BAD_META_TX_SIGNATURE",
+      reason: "sig mismatch",
+    });
+  });
+
+  it("POSTs `/settle` and returns `{exchangeId, txHash}`", async () => {
+    const stub = makeStubFetch(() => ({
+      body: { ok: true, exchangeId: "100", txHash: "0xabc" },
+    }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    const result = await client.settle(settleInput);
+
+    expect(result).toEqual({ ok: true, exchangeId: "100", txHash: "0xabc" });
+    expect(stub.calls[0]!.url).toBe(`${BASE_URL}/settle`);
+  });
+
+  it("POSTs `/perform-action` with the action-specific input shape", async () => {
+    const stub = makeStubFetch(() => ({
+      body: {
+        ok: true,
+        txHash: "0xdef",
+        newExchangeState: "COMPLETED",
+      },
+    }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    const result = await client.performAction(performActionInput);
+
+    expect(result).toMatchObject({ ok: true, txHash: "0xdef", newExchangeState: "COMPLETED" });
+    expect(stub.calls[0]!.url).toBe(`${BASE_URL}/perform-action`);
+    expect(JSON.parse(stub.calls[0]!.init!.body!)).toEqual(performActionInput);
+  });
+
+  it("throws FacilitatorHttpError(NETWORK_ERROR) when fetch rejects", async () => {
+    const stub = makeStubFetch(() => ({ throwError: new Error("ECONNREFUSED") }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    await expect(client.verify(verifyInput)).rejects.toMatchObject({
+      name: "FacilitatorHttpError",
+      code: "NETWORK_ERROR",
+    });
+  });
+
+  it("throws FacilitatorHttpError(BAD_HTTP_STATUS) on 5xx, carrying facilitatorCode if present", async () => {
+    const stub = makeStubFetch(() => ({
+      status: 500,
+      body: { ok: false, code: "INTERNAL_ERROR", reason: "boom" },
+    }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    await expect(client.settle(settleInput)).rejects.toBeInstanceOf(FacilitatorHttpError);
+    try {
+      await client.settle(settleInput);
+    } catch (e) {
+      expect((e as FacilitatorHttpError).code).toBe("BAD_HTTP_STATUS");
+      expect((e as FacilitatorHttpError).status).toBe(500);
+      expect((e as FacilitatorHttpError).facilitatorCode).toBe("INTERNAL_ERROR");
+    }
+  });
+
+  it("throws FacilitatorHttpError(BAD_RESPONSE_BODY) on non-JSON 200", async () => {
+    const stub = makeStubFetch(() => ({ status: 200, textOverride: "<html>oops</html>" }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    await expect(client.verify(verifyInput)).rejects.toMatchObject({
+      name: "FacilitatorHttpError",
+      code: "BAD_RESPONSE_BODY",
+      status: 200,
+    });
+  });
+
+  it("strips a trailing slash from `url`", async () => {
+    const stub = makeStubFetch(() => ({ body: { ok: true } }));
+    const client = createFacilitatorClient({ url: `${BASE_URL}/`, fetch: stub.fetch });
+
+    await client.verify(verifyInput);
+
+    expect(stub.calls[0]!.url).toBe(`${BASE_URL}/verify`);
+  });
+
+  it("attaches caller-supplied headers to every request", async () => {
+    const stub = makeStubFetch(() => ({ body: { ok: true } }));
+    const client = createFacilitatorClient({
+      url: BASE_URL,
+      fetch: stub.fetch,
+      headers: { authorization: "Bearer token-123" },
+    });
+
+    await client.verify(verifyInput);
+
+    expect(stub.calls[0]!.init?.headers?.authorization).toBe("Bearer token-123");
+  });
+
+  it("throws synchronously if neither global fetch nor an opts.fetch is available", () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      // @ts-expect-error — intentionally erasing global fetch for this test.
+      delete globalThis.fetch;
+      expect(() => createFacilitatorClient({ url: BASE_URL })).toThrow(/no `fetch`/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Third PR of the `@bosonprotocol/x402-server` stack. Adds `createFacilitatorClient` — a typed HTTP wrapper for the remote facilitator service. Input/output types come from `@bosonprotocol/x402-facilitator` (the library that service uses internally), so request/response shapes stay in lock-step with the implementation without a separate types package.

- `createFacilitatorClient({ url, fetch?, headers? })` exposes `verify()`, `settle()`, `performAction()` over the three [boson-impl-07 §Endpoints](docs/boson-impl-07-facilitator.md): `POST {url}/verify`, `POST {url}/settle`, `POST {url}/perform-action`.
- Domain results (`{ ok: true, … } | { ok: false, code, reason }`) are returned verbatim — those are answers the caller branches on.
- HTTP-transport failures raise a typed `FacilitatorHttpError` carrying:
  - a stable `FacilitatorHttpErrorCode` (`NETWORK_ERROR` | `BAD_HTTP_STATUS` | `BAD_RESPONSE_BODY` | `TIMEOUT`),
  - the HTTP `status` (when one was received),
  - the facilitator-side `FacilitatorErrorCode` if the response body parsed cleanly.
- The wire types (`FacilitatorVerifyInput/Result`, `FacilitatorSettleInput/Result`, `FacilitatorPerformActionInput/Result`, `FacilitatorErrorCode`) are re-exported from this package's `./facilitator` subpath so consumers don't need a separate `@bosonprotocol/x402-facilitator` import just to type a request shape.

## Test plan

- [x] `pnpm install`
- [x] `pnpm --filter @bosonprotocol/x402-server build`
- [x] `pnpm --filter @bosonprotocol/x402-server test` — 48 cases pass; the 10 new facilitator-client cases stub `fetch` per-test to cover request shape (URL / method / headers / body), response branching (success / domain `{ok:false}` / HTTP error / non-JSON), trailing-slash URL normalisation, custom headers, and the no-`fetch`-available synchronous guard.
- [x] `pnpm --filter @bosonprotocol/x402-server lint`
- [x] `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a published facilitator client and related types, plus a dedicated facilitator entrypoint for easier consumption.

* **Bug Fixes / Reliability**
  * Introduced distinct transport-level error classifications to improve reporting of network, HTTP, and parsing failures.

* **Tests**
  * Added comprehensive tests covering request construction, response handling, and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/42)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->