### PR TITLE
fix(server-express): default middleware flow to commit (Flow A)

### DIFF
--- a/typescript/packages/server-express/src/middleware.ts
+++ b/typescript/packages/server-express/src/middleware.ts
@@ -1,11 +1,12 @@
 // `expressMiddleware` — gate an Express route with a 402 challenge.
 // If the request carries a valid `X-PAYMENT`, the middleware runs
-// the commit-and-redeem handler and attaches the result to
-// `res.locals.x402b` so the downstream route handler can read the
-// `exchangeId` / `txHash` / `nextActions`. If the header is missing,
-// the middleware responds with 402 + a fresh `PaymentRequirements`
-// body. On any other failure it responds with the structured error
-// body from the handler.
+// the selected handler (defaults to the commit handler / Flow A)
+// and attaches the result to `res.locals.x402b` so the downstream
+// route handler can read the `exchangeId` / `txHash` /
+// `nextActions`. If the header is missing, the middleware responds
+// with 402 + a fresh `PaymentRequirements` body. On any other
+// failure it responds with the structured error body from the
+// handler.
 
 import type { EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { CommitOk, HandlerResult, X402bServer } from "@bosonprotocol/x402-server";
@@ -25,7 +26,12 @@ export interface ExpressMiddlewareOptions {
     req: Request,
     mode: "challenge" | "settle",
   ) => Promise<EscrowPaymentRequirements> | EscrowPaymentRequirements;
-  /** Optional flow selector — defaults to `commit-and-redeem` (Flow B). */
+  /**
+   * Optional flow selector — defaults to `commit` (Flow A, deferred
+   * redeem). Flow B (`commit-and-redeem`) is opt-in: it relies on
+   * the atomic `createOfferCommitAndRedeem` calldata encoder which
+   * the shipped client cannot yet sign.
+   */
   flow?: "commit" | "commit-and-redeem";
 }
 
@@ -56,7 +62,7 @@ export function expressMiddleware(
   server: X402bServer,
   opts: ExpressMiddlewareOptions,
 ): RequestHandler {
-  const flow = opts.flow ?? "commit-and-redeem";
+  const flow = opts.flow ?? "commit";
   return async (req: Request, res: Response, next: NextFunction) => {
     const header = req.header("x-payment");
     if (header === undefined || header.length === 0) {

--- a/typescript/packages/server-express/test/express.test.ts
+++ b/typescript/packages/server-express/test/express.test.ts
@@ -344,6 +344,31 @@ describe("expressMiddleware — 402 challenge + settle gating", () => {
     expect(res.body.x402b.exchangeId).toBe("99");
   });
 
+  it("defaults to the commit handler (Flow A) when `flow` is omitted", async () => {
+    // The fixture signs `boson-createOfferAndCommit` (Flow A). With the
+    // default in place this path settles cleanly; under the previous
+    // `commit-and-redeem` default the action wouldn't match.
+    const { requirements, headerValue } = await buildBuyerPayload();
+    const server = await buildServer(
+      makeStubFetch(() => ({ ok: true, exchangeId: "101", txHash: "0xc0ffee" })),
+    );
+
+    const app = express();
+    app.use(express.json());
+    app.get(
+      "/datafeed",
+      expressMiddleware(server, {
+        resolveRequirements: () =>
+          requirements as unknown as Awaited<ReturnType<typeof server.buildPaymentRequirements>>,
+      }),
+      (_req, res) => res.json({ x402b: res.locals.x402b }),
+    );
+
+    const res = await supertest(app).get("/datafeed").set("X-PAYMENT", headerValue);
+    expect(res.status).toBe(200);
+    expect(res.body.x402b.exchangeId).toBe("101");
+  });
+
   it("forwards validator failures as the suggested status", async () => {
     const { requirements, payload } = await buildBuyerPayload();
     const server = await buildServer(makeStubFetch(() => ({ ok: true })));


### PR DESCRIPTION
## Summary

- Change `expressMiddleware()`'s default `flow` from `commit-and-redeem` (Flow B) to `commit` (Flow A, deferred-redeem).
- Flow B stays opt-in via `flow: "commit-and-redeem"`.
- Add a test that omits `flow` and asserts the commit path settles cleanly.
- Refresh the surrounding JSDoc.

The previous default was `commit-and-redeem`, which the shipped `@bosonprotocol/x402-client` cannot sign — the atomic `createOfferCommitAndRedeem` calldata encoder is still a deferred stub in `@bosonprotocol/x402-evm`. An integrator who omitted `flow` therefore hit a mismatch on the first request: the server expected a Flow B payload, the client signed Flow A.

Defaulting to `commit` makes the out-of-box `@bosonprotocol/x402-client` → `expressMiddleware()` path compose without any opt-in.

## Test plan

- [x] `pnpm --filter @bosonprotocol/x402-server-express test` — 7 tests (new test exercises the default explicitly)
- [x] `pnpm build` — 9/9
- [x] `pnpm lint` — 9/9
- [x] `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Payment middleware now defaults to a simplified single-step commit flow instead of commit-and-redeem when flow option is not explicitly configured.

* **Tests**
  * Added integration test coverage for default payment flow behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/46)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->