### PR TITLE
feat(evm,client): move post-commit codec to x402-evm and expose on client

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@bosonprotocol/x402-core':
         specifier: workspace:^
         version: link:../core
+      '@bosonprotocol/x402-evm':
+        specifier: workspace:^
+        version: link:../evm
       ajv:
         specifier: ^8.17.1
         version: 8.20.0

--- a/typescript/packages/client/package.json
+++ b/typescript/packages/client/package.json
@@ -56,6 +56,7 @@
     "@bosonprotocol/common": "^1.32.2",
     "@bosonprotocol/core-sdk": "1.47.1-alpha.0",
     "@bosonprotocol/x402-core": "workspace:^",
+    "@bosonprotocol/x402-evm": "workspace:^",
     "ajv": "^8.17.1",
     "viem": "^2.39.3"
   },

--- a/typescript/packages/client/src/client.ts
+++ b/typescript/packages/client/src/client.ts
@@ -12,7 +12,6 @@
 
 import {
   parseEscrowPaymentRequirements,
-  type BosonMetaTx,
   type EscrowPaymentRequirements,
 } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { Address } from "viem";
@@ -22,7 +21,11 @@ import { createCoreSdkFactory } from "./core-sdk-factory.js";
 import { resolveFulfillment } from "./fulfillment.js";
 import { assembleAndEncodePayload } from "./payload.js";
 import { signCreateOfferAndCommitMetaTx } from "./pre-commit.js";
-import { signPostCommitAction, type SignActionArgs } from "./post-commit.js";
+import {
+  signPostCommitAction,
+  type SignActionArgs,
+  type SignedPostCommitAction,
+} from "./post-commit.js";
 import { parsePaymentResponse } from "./response.js";
 import { buildAndSignTokenAuth } from "./token-auth/index.js";
 import { MaxAmountExceededError } from "./errors.js";
@@ -37,10 +40,13 @@ export interface X402bClient {
 
   /**
    * Sign a Boson protocol meta-transaction for a buyer-driven post-commit
-   * action (redeem, cancel, complete, dispute family). Returns the
-   * wire-format `BosonMetaTx` envelope the caller delivers to the chosen
-   * channel — typically as the JSON body of a POST to the server endpoint
-   * the prior response advertised under `actions.next[].endpoints.server`.
+   * action (redeem, cancel, complete, dispute family). Returns both the
+   * wire-format `BosonMetaTx` envelope and the ABI-encoded `signedPayload`
+   * Hex — pick the shape that matches the chosen channel. Server /
+   * facilitator HTTP routes consume `signedPayload` directly (e.g. as
+   * the `signedPayload` field on the JSON POST body to the endpoint the
+   * prior response advertised under `actions.next[].endpoints.server`);
+   * on-chain and MCP channels use the `metaTx` object.
    *
    * Note: `boson-escalateDispute` signs only the meta-tx. If the dispute
    * resolver requires an escalation deposit, the resolver/server returns
@@ -48,7 +54,7 @@ export interface X402bClient {
    * this meta-tx with a token-auth payload — the deposit wrapper is out
    * of MVP.
    */
-  signAction(args: SignActionArgs): Promise<BosonMetaTx>;
+  signAction(args: SignActionArgs): Promise<SignedPostCommitAction>;
 
   /**
    * Best-effort decode of `X-PAYMENT-RESPONSE` after a successful retry.

--- a/typescript/packages/client/src/index.ts
+++ b/typescript/packages/client/src/index.ts
@@ -32,4 +32,9 @@ export { resolveFulfillment, type ResolvedFulfillment } from "./fulfillment.js";
 export { parseChainId } from "./core-sdk-factory.js";
 export { parsePaymentResponse } from "./response.js";
 export { createX402bClient, type X402bClient } from "./client.js";
-export type { ResolveDisputeArgs, SignActionArgs, SimplePostCommitArgs } from "./post-commit.js";
+export type {
+  ResolveDisputeArgs,
+  SignActionArgs,
+  SignedPostCommitAction,
+  SimplePostCommitArgs,
+} from "./post-commit.js";

--- a/typescript/packages/client/src/post-commit.ts
+++ b/typescript/packages/client/src/post-commit.ts
@@ -9,6 +9,12 @@
 // returned `BosonMetaTx` is the full wire-format the server consumes —
 // usually as a JSON POST body, not an `X-PAYMENT` header.
 //
+// We return both the `BosonMetaTx` envelope (useful for on-chain or MCP
+// channels) and the ABI-encoded `signedPayload` Hex consumed by the
+// server/facilitator HTTP convenience routes. The encoder lives in
+// `@bosonprotocol/x402-evm/codec` so client and facilitator share one
+// implementation.
+//
 // `boson-escalateDispute` is the one exception. If the dispute resolver
 // requires an escalation deposit, the resolver/server can return its own
 // 402 carrying an `escrow` `PaymentRequirements` and the buyer pairs this
@@ -16,8 +22,9 @@
 // we only sign the meta-tx itself; the deposit flow is a later PR.
 
 import type { CoreSDK } from "@bosonprotocol/core-sdk";
-import type { BosonMetaTx } from "@bosonprotocol/x402-core/schemes/escrow";
+import type { BosonMetaTx, Hex as WireHex } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { ActionId } from "@bosonprotocol/x402-core/state-machine";
+import { encodeSignedPayload } from "@bosonprotocol/x402-evm/codec";
 import type { Address, Hex } from "viem";
 
 import { randomUint256 } from "./utils/crypto.js";
@@ -72,22 +79,40 @@ export interface SignPostCommitActionDeps {
 }
 
 /**
+ * Wire-format result of `signPostCommitAction`: the signed `BosonMetaTx`
+ * envelope plus its ABI-encoded `signedPayload` Hex. Pick the one that
+ * matches the channel — the server/facilitator HTTP routes consume
+ * `signedPayload`; direct on-chain or MCP submissions use `metaTx`.
+ */
+export interface SignedPostCommitAction {
+  metaTx: BosonMetaTx;
+  /**
+   * ABI-encoded `BosonMetaTx` ready to drop into a server / facilitator
+   * route's `signedPayload` field. The hex is JSON-serialisable; we type
+   * it as the loose wire `Hex` (string) rather than viem's strict
+   * `\`0x\${string}\`` so the codec's output matches the schemes module's
+   * own `Hex` alias.
+   */
+  signedPayload: WireHex;
+}
+
+/**
  * Sign a post-commit action through the appropriate `CoreSDK.signMetaTx*`
- * mixin method. Returns the wire-format `BosonMetaTx` envelope ready to be
- * delivered to whichever channel the caller chooses (server POST,
- * facilitator, direct on-chain submission).
+ * mixin method. Returns both the wire-format `BosonMetaTx` envelope and
+ * the ABI-encoded `signedPayload` Hex ready to POST to a server /
+ * facilitator route.
  */
 export async function signPostCommitAction(
   args: SignActionArgs,
   deps: SignPostCommitActionDeps,
-): Promise<BosonMetaTx> {
+): Promise<SignedPostCommitAction> {
   const nonce = randomUint256();
   const buyer = await deps.getBuyerAddress();
   const { coreSdk } = deps.buildCoreSdk(args.network, args.escrowAddress);
 
   const signed = await callSignMetaTx(coreSdk, args, nonce);
 
-  return {
+  const metaTx: BosonMetaTx = {
     from: buyer,
     nonce: nonce.toString(),
     functionName: signed.functionName,
@@ -98,6 +123,8 @@ export async function signPostCommitAction(
       s: signed.s as Hex,
     },
   };
+
+  return { metaTx, signedPayload: encodeSignedPayload(metaTx) };
 }
 
 interface SignedMetaTxShape {

--- a/typescript/packages/client/test/post-commit.test.ts
+++ b/typescript/packages/client/test/post-commit.test.ts
@@ -4,11 +4,15 @@
 // method (asserted via the `functionName` core-sdk embeds in the result)
 // and shapes the result into a wire-format `BosonMetaTx` with the buyer's
 // address, a numeric-string nonce, and a 65-byte signature split into
-// `{ v, r, s }`. The protocol meta-tx domain is salt-based; verifying
-// recoverability here would mean reconstructing core-sdk's domain by hand,
-// so we instead lean on the round-trip test in `handle402.test.ts` (which
-// already exercises the same signing path through createOfferAndCommit).
+// `{ v, r, s }`. Also verifies the paired `signedPayload` Hex round-trips
+// back to the same meta-tx through the shared `@bosonprotocol/x402-evm`
+// codec — that's the wire-format contract with the server / facilitator.
+// The protocol meta-tx domain is salt-based; verifying recoverability
+// here would mean reconstructing core-sdk's domain by hand, so we instead
+// lean on the round-trip test in `handle402.test.ts` (which already
+// exercises the same signing path through createOfferAndCommit).
 
+import { decodeSignedPayload } from "@bosonprotocol/x402-evm/codec";
 import { describe, expect, it } from "vitest";
 import { privateKeyToAccount } from "viem/accounts";
 
@@ -45,23 +49,34 @@ describe("signAction — simple post-commit actions", () => {
     "%s signs a meta-tx with functionName=$functionName and the buyer's address",
     async ({ actionId, functionName }) => {
       const client = makeClient();
-      const meta = await client.signAction({
+      const { metaTx, signedPayload } = await client.signAction({
         actionId: actionId as Exclude<typeof actionId, "boson-resolveDispute">,
         exchangeId: EXCHANGE_ID,
         network: NETWORK,
         escrowAddress: ESCROW,
       });
 
-      expect(meta.from.toLowerCase()).toBe(BUYER_ACCOUNT.address.toLowerCase());
-      expect(meta.nonce).toMatch(/^\d+$/);
-      expect(meta.functionName).toBe(functionName);
-      expect(meta.functionSignature.startsWith("0x")).toBe(true);
-      expect(meta.functionSignature.length).toBeGreaterThan(2);
-      expect(meta.sig.r.startsWith("0x")).toBe(true);
-      expect(meta.sig.r).toHaveLength(66);
-      expect(meta.sig.s.startsWith("0x")).toBe(true);
-      expect(meta.sig.s).toHaveLength(66);
-      expect(typeof meta.sig.v).toBe("number");
+      expect(metaTx.from.toLowerCase()).toBe(BUYER_ACCOUNT.address.toLowerCase());
+      expect(metaTx.nonce).toMatch(/^\d+$/);
+      expect(metaTx.functionName).toBe(functionName);
+      expect(metaTx.functionSignature.startsWith("0x")).toBe(true);
+      expect(metaTx.functionSignature.length).toBeGreaterThan(2);
+      expect(metaTx.sig.r.startsWith("0x")).toBe(true);
+      expect(metaTx.sig.r).toHaveLength(66);
+      expect(metaTx.sig.s.startsWith("0x")).toBe(true);
+      expect(metaTx.sig.s).toHaveLength(66);
+      expect(typeof metaTx.sig.v).toBe("number");
+
+      // `signedPayload` must round-trip back to the same meta-tx through
+      // the shared codec — that's the wire-format contract with the
+      // server / facilitator. Address comparison is case-insensitive
+      // because viem re-checksums addresses when decoding ABI tuples.
+      const decoded = decodeSignedPayload(signedPayload);
+      expect(decoded.from.toLowerCase()).toBe(metaTx.from.toLowerCase());
+      expect(decoded.nonce).toBe(metaTx.nonce);
+      expect(decoded.functionName).toBe(metaTx.functionName);
+      expect(decoded.functionSignature).toBe(metaTx.functionSignature);
+      expect(decoded.sig).toEqual(metaTx.sig);
     },
   );
 
@@ -79,7 +94,7 @@ describe("signAction — simple post-commit actions", () => {
       network: NETWORK,
       escrowAddress: ESCROW,
     });
-    expect(a.nonce).not.toBe(b.nonce);
+    expect(a.metaTx.nonce).not.toBe(b.metaTx.nonce);
   });
 });
 
@@ -88,7 +103,7 @@ describe("signAction — boson-resolveDispute", () => {
     const client = makeClient();
     const counterpartySig = `0x${"11".repeat(32)}${"22".repeat(32)}1b` as `0x${string}`; // dummy 65-byte hex
 
-    const meta = await client.signAction({
+    const { metaTx } = await client.signAction({
       actionId: "boson-resolveDispute",
       exchangeId: EXCHANGE_ID,
       network: NETWORK,
@@ -97,9 +112,9 @@ describe("signAction — boson-resolveDispute", () => {
       counterpartySig,
     });
 
-    expect(meta.functionName).toBe("resolveDispute(uint256,uint256,bytes)");
-    expect(meta.from.toLowerCase()).toBe(BUYER_ACCOUNT.address.toLowerCase());
-    expect(meta.functionSignature.startsWith("0x")).toBe(true);
+    expect(metaTx.functionName).toBe("resolveDispute(uint256,uint256,bytes)");
+    expect(metaTx.from.toLowerCase()).toBe(BUYER_ACCOUNT.address.toLowerCase());
+    expect(metaTx.functionSignature.startsWith("0x")).toBe(true);
   });
 
   it("accepts an object-form counterpartySig", async () => {
@@ -107,7 +122,7 @@ describe("signAction — boson-resolveDispute", () => {
     const r = `0x${"aa".repeat(32)}` as const;
     const s = `0x${"bb".repeat(32)}` as const;
 
-    const meta = await client.signAction({
+    const { metaTx } = await client.signAction({
       actionId: "boson-resolveDispute",
       exchangeId: EXCHANGE_ID,
       network: NETWORK,
@@ -116,6 +131,6 @@ describe("signAction — boson-resolveDispute", () => {
       counterpartySig: { r, s, v: 27 },
     });
 
-    expect(meta.functionName).toBe("resolveDispute(uint256,uint256,bytes)");
+    expect(metaTx.functionName).toBe("resolveDispute(uint256,uint256,bytes)");
   });
 });

--- a/typescript/packages/evm/package.json
+++ b/typescript/packages/evm/package.json
@@ -34,6 +34,11 @@
       "import": "./dist/esm/actions/index.js",
       "require": "./dist/cjs/actions/index.js"
     },
+    "./codec": {
+      "types": "./dist/cjs/codec/index.d.ts",
+      "import": "./dist/esm/codec/index.js",
+      "require": "./dist/cjs/codec/index.js"
+    },
     "./envelope": {
       "types": "./dist/cjs/envelope/index.d.ts",
       "import": "./dist/esm/envelope/index.js",

--- a/typescript/packages/evm/src/codec/index.ts
+++ b/typescript/packages/evm/src/codec/index.ts
@@ -1,0 +1,1 @@
+export { decodeSignedPayload, encodeSignedPayload } from "./signed-payload.js";

--- a/typescript/packages/evm/src/codec/signed-payload.ts
+++ b/typescript/packages/evm/src/codec/signed-payload.ts
@@ -1,14 +1,12 @@
-// Wire-format codec for `FacilitatorPerformActionInput.signedPayload`.
+// Wire-format codec for the post-commit `signedPayload` Hex.
 //
 // The signed-payload Hex is the ABI-encoded tuple
 //   (address from, string functionName, bytes functionSignature,
 //    uint256 nonce, uint8 v, bytes32 r, bytes32 s)
 // — i.e. a serialised `BosonMetaTx` ready to be unpacked and wrapped in
-// `MetaTransactionsHandlerFacet.executeMetaTransaction(...)`.
-//
-// This codec is the inverse of whatever the buyer / seller's client used
-// to build the request body. We ship both directions (encode + decode)
-// so client SDKs can re-use the same shape.
+// `MetaTransactionsHandlerFacet.executeMetaTransaction(...)`. It lives
+// here so the buyer's client (encoding) and the facilitator (decoding)
+// share one definition and cannot drift.
 
 import type { BosonMetaTx, Hex } from "@bosonprotocol/x402-core/schemes/escrow";
 import { decodeAbiParameters, encodeAbiParameters, type AbiParameter } from "viem";

--- a/typescript/packages/evm/src/index.ts
+++ b/typescript/packages/evm/src/index.ts
@@ -14,4 +14,5 @@ export * from "./errors.js";
 export type { InnerActionCalldata, TxRequest } from "./types.js";
 
 export * from "./actions/index.js";
+export * from "./codec/index.js";
 export * from "./envelope/index.js";

--- a/typescript/packages/evm/test/codec/signed-payload.test.ts
+++ b/typescript/packages/evm/test/codec/signed-payload.test.ts
@@ -1,0 +1,48 @@
+import type { BosonMetaTx } from "@bosonprotocol/x402-core/schemes/escrow";
+import { describe, expect, it } from "vitest";
+
+import { decodeSignedPayload, encodeSignedPayload } from "../../src/codec/signed-payload.js";
+
+describe("signed-payload codec", () => {
+  it("round-trips a BosonMetaTx through encode → decode", () => {
+    const metaTx: BosonMetaTx = {
+      from: "0x1111111111111111111111111111111111111111",
+      nonce: "42",
+      functionName: "redeemVoucher(uint256)",
+      functionSignature: `0x${"ab".repeat(36)}`,
+      sig: {
+        v: 28,
+        r: `0x${"11".repeat(32)}`,
+        s: `0x${"22".repeat(32)}`,
+      },
+    };
+
+    const encoded = encodeSignedPayload(metaTx);
+    expect(encoded.startsWith("0x")).toBe(true);
+
+    const decoded = decodeSignedPayload(encoded);
+    expect(decoded).toEqual({
+      from: metaTx.from.toLowerCase(),
+      nonce: metaTx.nonce,
+      functionName: metaTx.functionName,
+      functionSignature: metaTx.functionSignature,
+      sig: metaTx.sig,
+    });
+  });
+
+  it("preserves a v=27 signature", () => {
+    const metaTx: BosonMetaTx = {
+      from: "0x2222222222222222222222222222222222222222",
+      nonce: "0",
+      functionName: "completeExchange(uint256)",
+      functionSignature: `0x${"cd".repeat(36)}`,
+      sig: {
+        v: 27,
+        r: `0x${"33".repeat(32)}`,
+        s: `0x${"44".repeat(32)}`,
+      },
+    };
+
+    expect(decodeSignedPayload(encodeSignedPayload(metaTx)).sig.v).toBe(27);
+  });
+});

--- a/typescript/packages/facilitator/src/index.ts
+++ b/typescript/packages/facilitator/src/index.ts
@@ -14,7 +14,10 @@ export * from "./errors.js";
 export { verify } from "./verify/index.js";
 export { settle } from "./settle/index.js";
 export { performAction } from "./perform-action/index.js";
-export { decodeSignedPayload, encodeSignedPayload } from "./perform-action/codec.js";
+// Codec lives in `@bosonprotocol/x402-evm/codec` so client and facilitator
+// share one implementation. Re-exported here for backward compatibility
+// with existing facilitator consumers that import it from the barrel.
+export { decodeSignedPayload, encodeSignedPayload } from "@bosonprotocol/x402-evm/codec";
 
 export {
   FacilitatorChannelAdapter,

--- a/typescript/packages/facilitator/src/perform-action/index.ts
+++ b/typescript/packages/facilitator/src/perform-action/index.ts
@@ -45,8 +45,9 @@ import { recoverMetaTxSigner } from "../verify/meta-tx-signature.js";
 import { simulateExecuteMetaTransaction } from "../verify/simulate.js";
 import { parseChainId } from "../verify/structural.js";
 
+import { decodeSignedPayload } from "@bosonprotocol/x402-evm/codec";
+
 import { validatePerformActionMetaTx } from "./action-calldata.js";
-import { decodeSignedPayload } from "./codec.js";
 import { deriveNewState } from "./new-state.js";
 
 export async function performAction(

--- a/typescript/packages/facilitator/test/perform-action.test.ts
+++ b/typescript/packages/facilitator/test/perform-action.test.ts
@@ -15,7 +15,7 @@ import {
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 
-import { encodeSignedPayload } from "../src/perform-action/codec.js";
+import { encodeSignedPayload } from "@bosonprotocol/x402-evm/codec";
 import { performAction } from "../src/perform-action/index.js";
 import type { FacilitatorConfig } from "../src/types.js";
 
@@ -368,7 +368,7 @@ describe("performAction()", () => {
     const signedPayload = await buildSignedPayload({ signer: buyer });
     // Mutate the decoded BosonMetaTx and re-encode so metaTx.from is
     // seller while the sig still corresponds to buyer.
-    const { decodeSignedPayload } = await import("../src/perform-action/codec.js");
+    const { decodeSignedPayload } = await import("@bosonprotocol/x402-evm/codec");
     const decoded = decodeSignedPayload(signedPayload);
     const tampered = encodeSignedPayload({ ...decoded, from: seller.address });
     const result = await performAction(
@@ -597,7 +597,7 @@ describe("performAction()", () => {
 
 describe("encodeSignedPayload / decodeSignedPayload", () => {
   it("round-trips a BosonMetaTx", async () => {
-    const { decodeSignedPayload } = await import("../src/perform-action/codec.js");
+    const { decodeSignedPayload } = await import("@bosonprotocol/x402-evm/codec");
     const original = {
       from: buyer.address,
       nonce: "42",


### PR DESCRIPTION
## Summary

Codex's review caught a wire-shape gap: `@bosonprotocol/x402-client` returned a `BosonMetaTx` object from `signAction()`, but the server and facilitator HTTP routes expect an ABI-encoded `signedPayload` hex. The codec already existed in `x402-facilitator/perform-action` but wasn't reachable from the client surface, so external integrators couldn't produce server-ready bodies without hand-rolling the ABI.

- Move `encodeSignedPayload` / `decodeSignedPayload` into `@bosonprotocol/x402-evm/codec` (new subpath export). One implementation, used by both client and facilitator, so the codecs cannot drift.
- Change `client.signAction()`'s return shape from `BosonMetaTx` to `{ metaTx, signedPayload }`. The `metaTx` is for on-chain / MCP channels; the `signedPayload` Hex is what server / facilitator HTTP routes consume.
- `@bosonprotocol/x402-facilitator` keeps re-exporting `decode` / `encode` (now from `x402-evm`) so existing facilitator consumers don't break.
- Add `@bosonprotocol/x402-evm` workspace dep on the client.
- New codec round-trip test in `x402-evm`; the client post-commit test now also asserts `signedPayload` decodes back to the same meta-tx.

## Test plan

- [x] `pnpm build` — 9/9
- [x] `pnpm test` — 18/18 tasks (client 39 tests, evm 15 tests, facilitator 63 tests — codec round-trips cleanly in both directions)
- [x] `pnpm lint` — 9/9
- [x] `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exposed codec utilities for encoding and decoding signed payloads across packages

* **Refactor**
  * Updated client's action signing method return structure to include both transaction envelope and ABI-encoded payload
  * Consolidated codec functionality across packages for improved reusability and maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/47)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->