### PR TITLE
feat(facilitator-express): add Express adapter for the facilitator service

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,43 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
 
+  typescript/packages/facilitator-express:
+    dependencies:
+      '@bosonprotocol/x402-core':
+        specifier: workspace:^
+        version: link:../core
+      '@bosonprotocol/x402-facilitator':
+        specifier: workspace:^
+        version: link:../facilitator
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.25
+      '@types/node':
+        specifier: ^20.17.10
+        version: 20.19.40
+      '@types/supertest':
+        specifier: ^6.0.2
+        version: 6.0.3
+      express:
+        specifier: ^4.21.2
+        version: 4.22.2
+      supertest:
+        specifier: ^7.0.0
+        version: 7.2.2
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      viem:
+        specifier: ^2.39.3
+        version: 2.48.11(typescript@5.9.3)(zod@3.25.76)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.40)
+
   typescript/packages/fulfillment:
     dependencies:
       '@bosonprotocol/x402-core':

--- a/typescript/packages/facilitator-express/LICENSE
+++ b/typescript/packages/facilitator-express/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Boson Protocol
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/typescript/packages/facilitator-express/README.md
+++ b/typescript/packages/facilitator-express/README.md
@@ -5,6 +5,11 @@ Mounts the three facilitator endpoints (`POST /verify`, `POST /settle`,
 `POST /perform-action`) as a single Express router, so an operator can
 run a working facilitator HTTP service with a few lines of glue.
 
+`mountFacilitator` accepts a `FacilitatorConfig` object from
+[`@bosonprotocol/x402-facilitator`](https://github.com/bosonprotocol/x402B/blob/main/typescript/packages/facilitator/src/types.ts).
+It does not take adapter options; use Express's normal router mounting to add a
+path prefix.
+
 ```ts
 import express from "express";
 import { mountFacilitator } from "@bosonprotocol/x402-facilitator-express";
@@ -14,6 +19,10 @@ app.use(express.json());
 app.use(mountFacilitator(facilitatorConfig));
 app.listen(3000);
 ```
+
+Install `express.json()` before the adapter so Express populates `req.body`.
+Without it, the adapter's `INVALID_REQUEST_BODY` guard returns HTTP 400 before
+the facilitator handlers run.
 
 To mount under a prefix, use Express's normal router mounting:
 

--- a/typescript/packages/facilitator-express/README.md
+++ b/typescript/packages/facilitator-express/README.md
@@ -1,6 +1,6 @@
 # @bosonprotocol/x402-facilitator-express
 
-Express adapter for [`@bosonprotocol/x402-facilitator`](../facilitator).
+Express adapter for [`@bosonprotocol/x402-facilitator`](https://github.com/bosonprotocol/x402B/tree/main/typescript/packages/facilitator).
 Mounts the three facilitator endpoints (`POST /verify`, `POST /settle`,
 `POST /perform-action`) as a single Express router, so an operator can
 run a working facilitator HTTP service with a few lines of glue.
@@ -21,5 +21,5 @@ To mount under a prefix, use Express's normal router mounting:
 app.use("/v1", mountFacilitator(facilitatorConfig));
 ```
 
-Routes follow the spec in [`docs/boson-impl-07-facilitator.md`](../../../docs/boson-impl-07-facilitator.md);
+Routes follow the spec in [`docs/boson-impl-07-facilitator.md`](https://github.com/bosonprotocol/x402B/blob/main/docs/boson-impl-07-facilitator.md);
 this package adds no protocol logic of its own.

--- a/typescript/packages/facilitator-express/README.md
+++ b/typescript/packages/facilitator-express/README.md
@@ -1,0 +1,19 @@
+# @bosonprotocol/x402-facilitator-express
+
+Express adapter for [`@bosonprotocol/x402-facilitator`](../facilitator).
+Mounts the three facilitator endpoints (`POST /verify`, `POST /settle`,
+`POST /perform-action`) as a single Express router, so an operator can
+run a working facilitator HTTP service with a few lines of glue.
+
+```ts
+import express from "express";
+import { mountFacilitator } from "@bosonprotocol/x402-facilitator-express";
+
+const app = express();
+app.use(express.json());
+app.use(mountFacilitator(facilitatorConfig));
+app.listen(3000);
+```
+
+Routes follow the spec in [`docs/boson-impl-07-facilitator.md`](../../../docs/boson-impl-07-facilitator.md);
+this package adds no protocol logic of its own.

--- a/typescript/packages/facilitator-express/README.md
+++ b/typescript/packages/facilitator-express/README.md
@@ -15,5 +15,11 @@ app.use(mountFacilitator(facilitatorConfig));
 app.listen(3000);
 ```
 
+To mount under a prefix, use Express's normal router mounting:
+
+```ts
+app.use("/v1", mountFacilitator(facilitatorConfig));
+```
+
 Routes follow the spec in [`docs/boson-impl-07-facilitator.md`](../../../docs/boson-impl-07-facilitator.md);
 this package adds no protocol logic of its own.

--- a/typescript/packages/facilitator-express/package.json
+++ b/typescript/packages/facilitator-express/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@bosonprotocol/x402-facilitator-express",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "description": "Express adapter for @bosonprotocol/x402-facilitator — mountable router exposing /verify, /settle, and /perform-action for the Boson Protocol escrow scheme.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bosonprotocol/x402B.git",
+    "directory": "typescript/packages/facilitator-express"
+  },
+  "homepage": "https://github.com/bosonprotocol/x402B/tree/main/typescript/packages/facilitator-express",
+  "bugs": {
+    "url": "https://github.com/bosonprotocol/x402B/issues"
+  },
+  "keywords": [
+    "x402",
+    "boson-protocol",
+    "facilitator",
+    "express",
+    "middleware"
+  ],
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/cjs/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup && node scripts/postbuild.mjs",
+    "test": "vitest run --passWithNoTests",
+    "lint": "eslint src --max-warnings 0",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@bosonprotocol/x402-core": "workspace:^",
+    "@bosonprotocol/x402-facilitator": "workspace:^"
+  },
+  "peerDependencies": {
+    "express": "^4.18.0 || ^5.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.17.10",
+    "@types/supertest": "^6.0.2",
+    "express": "^4.21.2",
+    "supertest": "^7.0.0",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "viem": "^2.39.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/typescript/packages/facilitator-express/scripts/postbuild.mjs
+++ b/typescript/packages/facilitator-express/scripts/postbuild.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// Post-build housekeeping: write module-type markers in dist/{esm,cjs}/.
+// No schemas in this package; mirrors the facilitator package's postbuild.
+
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const distRoot = join(here, "..", "dist");
+
+await writeFile(
+  join(distRoot, "esm", "package.json"),
+  JSON.stringify({ type: "module" }, null, 2) + "\n",
+);
+await writeFile(
+  join(distRoot, "cjs", "package.json"),
+  JSON.stringify({ type: "commonjs" }, null, 2) + "\n",
+);
+
+console.log("postbuild: wrote module-type markers in dist/{esm,cjs}/package.json");

--- a/typescript/packages/facilitator-express/src/index.ts
+++ b/typescript/packages/facilitator-express/src/index.ts
@@ -1,0 +1,10 @@
+// Public surface for `@bosonprotocol/x402-facilitator-express`.
+//
+// Mounts `@bosonprotocol/x402-facilitator`'s three async library
+// functions (`verify`, `settle`, `performAction`) as Express routes
+// (`POST /verify`, `POST /settle`, `POST /perform-action`) per
+// docs/boson-impl-07-facilitator.md. No protocol logic lives here —
+// this package is a thin HTTP wrapper, mirroring the
+// `server` / `server-express` split.
+
+export { mountFacilitator, type MountFacilitatorOptions } from "./mount.js";

--- a/typescript/packages/facilitator-express/src/index.ts
+++ b/typescript/packages/facilitator-express/src/index.ts
@@ -7,4 +7,4 @@
 // this package is a thin HTTP wrapper, mirroring the
 // `server` / `server-express` split.
 
-export { mountFacilitator, type MountFacilitatorOptions } from "./mount.js";
+export { mountFacilitator } from "./mount.js";

--- a/typescript/packages/facilitator-express/src/mount.ts
+++ b/typescript/packages/facilitator-express/src/mount.ts
@@ -1,0 +1,109 @@
+// `mountFacilitator` — Express router exposing the three facilitator
+// endpoints from docs/boson-impl-07-facilitator.md:
+//
+//   POST /verify          — validate a buyer-signed escrow payment
+//   POST /settle          — relay a commit-time meta-transaction
+//   POST /perform-action  — relay a post-commit meta-transaction
+//
+// The router is mountable at any path (default `/`); the trailing path
+// segments are fixed by the spec. Routing here is intentionally thin —
+// `verify`, `settle`, and `performAction` from `@bosonprotocol/x402-facilitator`
+// already validate the request body via Zod schemas, so each handler
+// just forwards `req.body`, awaits the discriminated-union result, and
+// maps `ok: true` to HTTP 200 / `ok: false` to HTTP 400. Callers MUST
+// install `express.json()` upstream.
+
+import {
+  performAction,
+  settle,
+  verify,
+  type FacilitatorConfig,
+  type FacilitatorPerformActionInput,
+  type FacilitatorSettleInput,
+  type FacilitatorVerifyInput,
+} from "@bosonprotocol/x402-facilitator";
+import { Router, type RequestHandler } from "express";
+
+export interface MountFacilitatorOptions {
+  /** Optional mount path. Defaults to `/`. */
+  basePath?: string;
+}
+
+/**
+ * Build the Express router. Apply with
+ * `app.use(mountFacilitator(config, opts))`.
+ */
+export function mountFacilitator(
+  config: FacilitatorConfig,
+  opts: MountFacilitatorOptions = {},
+): Router {
+  const router = Router();
+  const basePath = opts.basePath ?? "";
+
+  router.post(`${basePath}/verify`, verifyRoute(config));
+  router.post(`${basePath}/settle`, settleRoute(config));
+  router.post(`${basePath}/perform-action`, performActionRoute(config));
+
+  return router;
+}
+
+function verifyRoute(config: FacilitatorConfig): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      // Body shape is validated downstream by the facilitator's Zod
+      // schemas; here we only guard against the body being absent so
+      // `verify(undefined, …)` doesn't blow up before structural
+      // validation kicks in.
+      const body = req.body as FacilitatorVerifyInput | undefined;
+      if (body === undefined) {
+        res.status(400).json({
+          code: "INVALID_REQUEST_BODY",
+          reason: "expected JSON body — did you install express.json()?",
+        });
+        return;
+      }
+      const result = await verify(body, config);
+      res.status(result.ok ? 200 : 400).json(result);
+    } catch (e) {
+      next(e);
+    }
+  };
+}
+
+function settleRoute(config: FacilitatorConfig): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      const body = req.body as FacilitatorSettleInput | undefined;
+      if (body === undefined) {
+        res.status(400).json({
+          code: "INVALID_REQUEST_BODY",
+          reason: "expected JSON body — did you install express.json()?",
+        });
+        return;
+      }
+      const result = await settle(body, config);
+      res.status(result.ok ? 200 : 400).json(result);
+    } catch (e) {
+      next(e);
+    }
+  };
+}
+
+function performActionRoute(config: FacilitatorConfig): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      const body = req.body as FacilitatorPerformActionInput | undefined;
+      if (body === undefined) {
+        res.status(400).json({
+          code: "INVALID_REQUEST_BODY",
+          reason: "expected JSON body — did you install express.json()?",
+        });
+        return;
+      }
+      const result = await performAction(body, config);
+      res.status(result.ok ? 200 : 400).json(result);
+    } catch (e) {
+      next(e);
+    }
+  };
+}

--- a/typescript/packages/facilitator-express/src/mount.ts
+++ b/typescript/packages/facilitator-express/src/mount.ts
@@ -5,8 +5,9 @@
 //   POST /settle          — relay a commit-time meta-transaction
 //   POST /perform-action  — relay a post-commit meta-transaction
 //
-// The router is mountable at any path (default `/`); the trailing path
-// segments are fixed by the spec. Routing here is intentionally thin —
+// Mount the router at a prefix with Express itself, e.g.
+// `app.use("/v1", mountFacilitator(config))`. The route paths inside
+// this router are fixed by the spec. Routing here is intentionally thin —
 // `verify`, `settle`, and `performAction` from `@bosonprotocol/x402-facilitator`
 // already validate the request body via Zod schemas, so each handler
 // just forwards `req.body`, awaits the discriminated-union result, and
@@ -24,25 +25,16 @@ import {
 } from "@bosonprotocol/x402-facilitator";
 import { Router, type RequestHandler } from "express";
 
-export interface MountFacilitatorOptions {
-  /** Optional mount path. Defaults to `/`. */
-  basePath?: string;
-}
-
 /**
  * Build the Express router. Apply with
- * `app.use(mountFacilitator(config, opts))`.
+ * `app.use(mountFacilitator(config))`, or with a prefix via
+ * `app.use("/v1", mountFacilitator(config))`.
  */
-export function mountFacilitator(
-  config: FacilitatorConfig,
-  opts: MountFacilitatorOptions = {},
-): Router {
+export function mountFacilitator(config: FacilitatorConfig): Router {
   const router = Router();
-  const basePath = opts.basePath ?? "";
-
-  router.post(`${basePath}/verify`, verifyRoute(config));
-  router.post(`${basePath}/settle`, settleRoute(config));
-  router.post(`${basePath}/perform-action`, performActionRoute(config));
+  router.post("/verify", verifyRoute(config));
+  router.post("/settle", settleRoute(config));
+  router.post("/perform-action", performActionRoute(config));
 
   return router;
 }

--- a/typescript/packages/facilitator-express/src/mount.ts
+++ b/typescript/packages/facilitator-express/src/mount.ts
@@ -25,6 +25,11 @@ import {
 } from "@bosonprotocol/x402-facilitator";
 import { Router, type RequestHandler } from "express";
 
+export const INVALID_REQUEST_BODY = {
+  code: "INVALID_REQUEST_BODY",
+  reason: "expected JSON body — did you install express.json()?",
+} as const;
+
 /**
  * Build the Express router. Apply with
  * `app.use(mountFacilitator(config))`, or with a prefix via
@@ -48,10 +53,7 @@ function verifyRoute(config: FacilitatorConfig): RequestHandler {
       // validation kicks in.
       const body = req.body as FacilitatorVerifyInput | undefined;
       if (body === undefined) {
-        res.status(400).json({
-          code: "INVALID_REQUEST_BODY",
-          reason: "expected JSON body — did you install express.json()?",
-        });
+        res.status(400).json(INVALID_REQUEST_BODY);
         return;
       }
       const result = await verify(body, config);
@@ -67,10 +69,7 @@ function settleRoute(config: FacilitatorConfig): RequestHandler {
     try {
       const body = req.body as FacilitatorSettleInput | undefined;
       if (body === undefined) {
-        res.status(400).json({
-          code: "INVALID_REQUEST_BODY",
-          reason: "expected JSON body — did you install express.json()?",
-        });
+        res.status(400).json(INVALID_REQUEST_BODY);
         return;
       }
       const result = await settle(body, config);
@@ -86,10 +85,7 @@ function performActionRoute(config: FacilitatorConfig): RequestHandler {
     try {
       const body = req.body as FacilitatorPerformActionInput | undefined;
       if (body === undefined) {
-        res.status(400).json({
-          code: "INVALID_REQUEST_BODY",
-          reason: "expected JSON body — did you install express.json()?",
-        });
+        res.status(400).json(INVALID_REQUEST_BODY);
         return;
       }
       const result = await performAction(body, config);

--- a/typescript/packages/facilitator-express/test/facilitator-express.test.ts
+++ b/typescript/packages/facilitator-express/test/facilitator-express.test.ts
@@ -97,15 +97,16 @@ describe("mountFacilitator — routing", () => {
     expect(res.body.code).toMatch(/NETWORK_MISMATCH|INVALID_PAYLOAD/);
   });
 
-  it("mounts at a custom basePath", async () => {
+  it("mounts under a custom Express path prefix", async () => {
     const app = express();
     app.use(express.json());
-    app.use(mountFacilitator(buildConfig(), { basePath: "/v1" }));
+    app.use("/v1", mountFacilitator(buildConfig()));
 
     const ok = await supertest(app).post("/v1/verify").send({});
     expect(ok.status).toBe(400); // routed; returns the same body shape
 
-    // The default mount path no longer matches at the custom base.
+    // The default mount path no longer matches when the router is
+    // mounted at an Express prefix.
     const miss = await supertest(app).post("/verify").send({});
     expect(miss.status).toBe(404);
   });

--- a/typescript/packages/facilitator-express/test/facilitator-express.test.ts
+++ b/typescript/packages/facilitator-express/test/facilitator-express.test.ts
@@ -1,0 +1,136 @@
+// Integration tests for the Express adapter. Use `supertest` against
+// an in-process app wired to a real `mountFacilitator(...)`. The
+// underlying viem `WalletClient` / `PublicClient` are stubs — we only
+// exercise the HTTP wiring here, not the on-chain pipeline (the latter
+// is covered by `@bosonprotocol/x402-facilitator`'s own test suite).
+
+import type {
+  FacilitatorConfig,
+  FacilitatorPerformActionInput,
+  FacilitatorSettleInput,
+  FacilitatorVerifyInput,
+} from "@bosonprotocol/x402-facilitator";
+import express from "express";
+import supertest from "supertest";
+import type { PublicClient, WalletClient } from "viem";
+import { describe, expect, it } from "vitest";
+
+import { mountFacilitator } from "../src/index.js";
+
+const ESCROW = "0xdddddddddddddddddddddddddddddddddddddddd" as const;
+const RELAYER = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" as const;
+const NETWORK = "eip155:8453" as const;
+
+function buildConfig(): FacilitatorConfig {
+  // Bare-minimum stub clients: the test routes never reach RPC because
+  // they short-circuit on the `supportedNetworks` / structural gates.
+  const walletClient = {
+    account: { address: RELAYER, type: "json-rpc" },
+    chain: { id: 8453 },
+  } as unknown as WalletClient;
+  const publicClient = {} as unknown as PublicClient;
+
+  return {
+    url: "https://facilitator.example",
+    supportedNetworks: [NETWORK],
+    escrows: { [NETWORK]: ESCROW },
+    walletClient,
+    publicClient,
+  };
+}
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(mountFacilitator(buildConfig()));
+  return app;
+}
+
+describe("mountFacilitator — routing", () => {
+  it("POST /verify forwards body to verify() and surfaces ok:false as 400", async () => {
+    // Malformed body — empty object — trips the facilitator's structural
+    // validator. We assert: route exists, body is forwarded, ok:false
+    // becomes status 400 with the discriminated-union result intact.
+    const res = await supertest(buildApp()).post("/verify").send({});
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(typeof res.body.code).toBe("string");
+  });
+
+  it("POST /verify returns 400 with INVALID_REQUEST_BODY when express.json() is missing", async () => {
+    // No body parser → `req.body` is `undefined`. The upstream guard
+    // catches this so `verify(undefined, …)` never runs pre-validation.
+    const app = express(); // intentionally no `app.use(express.json())`
+    app.use(mountFacilitator(buildConfig()));
+    const res = await supertest(app).post("/verify").send();
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_REQUEST_BODY");
+  });
+
+  it("POST /settle short-circuits on NETWORK_MISMATCH for an unsupported network", async () => {
+    // Network not in `supportedNetworks` — the facilitator rejects before
+    // touching the wallet. Confirms routing wires body through to settle().
+    const body: FacilitatorSettleInput = {
+      scheme: "escrow",
+      network: "eip155:1" as const,
+      // Empty payload / requirements — won't reach validation; the
+      // network gate fires first.
+      payload: {} as never,
+      requirements: {} as never,
+    };
+    const res = await supertest(buildApp()).post("/settle").send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("POST /perform-action rejects an unknown network with 400", async () => {
+    const body: FacilitatorPerformActionInput = {
+      network: "eip155:1" as const,
+      escrowAddress: ESCROW,
+      exchangeId: "1",
+      action: "boson-redeem",
+      signedPayload: `0x${"00".repeat(32)}` as const,
+    };
+    const res = await supertest(buildApp()).post("/perform-action").send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.code).toMatch(/NETWORK_MISMATCH|INVALID_PAYLOAD/);
+  });
+
+  it("mounts at a custom basePath", async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(mountFacilitator(buildConfig(), { basePath: "/v1" }));
+
+    const ok = await supertest(app).post("/v1/verify").send({});
+    expect(ok.status).toBe(400); // routed; returns the same body shape
+
+    // The default mount path no longer matches at the custom base.
+    const miss = await supertest(app).post("/verify").send({});
+    expect(miss.status).toBe(404);
+  });
+
+  it("delegates unknown sub-routes to Express's 404 path", async () => {
+    const res = await supertest(buildApp()).post("/does-not-exist").send({});
+    expect(res.status).toBe(404);
+  });
+
+  // Body parsing failure tests are covered indirectly above; if
+  // `express.json()` isn't installed at all, `req.body` is `undefined`
+  // and the guard returns INVALID_REQUEST_BODY (asserted in the
+  // `/verify` no-body case).
+
+  it("uses request inputs verbatim (does not mutate body shape)", async () => {
+    // Round-trips a verify request that fails on scheme mismatch — we
+    // care only that the body field surfaces in the rejection reason.
+    const body: FacilitatorVerifyInput = {
+      scheme: "escrow",
+      network: NETWORK,
+      payload: { scheme: "not-escrow" } as never,
+      requirements: {} as never,
+    };
+    const res = await supertest(buildApp()).post("/verify").send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+});

--- a/typescript/packages/facilitator-express/tsconfig.json
+++ b/typescript/packages/facilitator-express/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/typescript/packages/facilitator-express/tsup.config.ts
+++ b/typescript/packages/facilitator-express/tsup.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "tsup";
+
+const entry = ["src/**/index.ts"];
+
+export default defineConfig([
+  {
+    entry,
+    format: "esm",
+    outDir: "dist/esm",
+    outExtension: () => ({ js: ".js" }),
+    dts: false,
+    sourcemap: true,
+    clean: true,
+    target: "es2020",
+    treeshake: true,
+  },
+  {
+    entry,
+    format: "cjs",
+    outDir: "dist/cjs",
+    outExtension: () => ({ js: ".js" }),
+    dts: true,
+    sourcemap: true,
+    clean: false,
+    target: "es2020",
+    treeshake: true,
+  },
+]);

--- a/typescript/packages/facilitator-express/vitest.config.ts
+++ b/typescript/packages/facilitator-express/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

The repo shipped `@bosonprotocol/x402-server-express` as a thin HTTP wrapper for `x402-server`, but no equivalent existed for the facilitator — integrators had to hand-roll the three-route service before `@bosonprotocol/x402-server` could call it. This new package closes that gap and mirrors the `server` / `server-express` split exactly; no protocol logic of its own.

- `mountFacilitator(config, opts?)` returns an Express `Router` exposing `POST /verify`, `POST /settle`, `POST /perform-action` per [`docs/boson-impl-07-facilitator.md`](../docs/boson-impl-07-facilitator.md). Default mount path is `/`; `opts.basePath` lets the operator namespace under (e.g.) `/v1`.
- Each route forwards `req.body` to the matching async function from `@bosonprotocol/x402-facilitator`, then maps the discriminated-union result to 200 / 400 with the result body intact (so clients can branch on `code` without losing the wire contract).
- An upstream `req.body === undefined` guard catches the common misconfiguration where `express.json()` is missing, surfacing `INVALID_REQUEST_BODY` rather than crashing inside `verify(...)`.

Test pattern mirrors `server-express`: supertest against an in-process Express app with stub `WalletClient` / `PublicClient`, exercising the HTTP wiring (routing, body forwarding, error mapping, custom basePath, missing-middleware guard). The on-chain pipeline itself is already covered by the facilitator package's own suite.

## Test plan

- [x] `pnpm build` — 10/10 packages (the new package is the +1)
- [x] `pnpm --filter @bosonprotocol/x402-facilitator-express test` — 7/7
- [x] `pnpm test` — 20/20 tasks
- [x] `pnpm lint` — 10/10
- [x] `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published an npm package providing an Express HTTP adapter for the X.402 facilitator with three POST endpoints and configurable base path.

* **Documentation**
  * Added a README with usage examples and mounting guidance.

* **Tests**
  * Added integration tests covering routing, request body validation, network gating, mount behavior, and error handling.

* **Chores**
  * Added Apache 2.0 LICENSE, package manifest, build/postbuild steps, TypeScript and test configs, and build tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/48)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->