### PR TITLE
fix(server-express): emit canonical x402 challenge from mount commit routes

### DIFF
--- a/typescript/packages/server-express/src/internal/x402-challenge.ts
+++ b/typescript/packages/server-express/src/internal/x402-challenge.ts
@@ -1,0 +1,21 @@
+// Shared helper for the canonical x402 challenge response (status 402,
+// body `{ x402Version: 2, accepts: [requirements] }`).
+//
+// Both `expressMiddleware` and `mountX402b`'s commit routes need to
+// emit the same shape when an incoming request is missing `X-PAYMENT`;
+// keeping the format in one place means the two adapter entry points
+// can't drift.
+
+import type { EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
+import type { Response } from "express";
+
+export const X402_VERSION = 2 as const;
+
+/**
+ * Write the canonical x402 challenge response to `res`. The body matches
+ * what `@x402/core` clients expect: `{ x402Version, accepts: [...] }`
+ * with a single entry carrying the resolved `EscrowPaymentRequirements`.
+ */
+export function respondWithChallenge(res: Response, requirements: EscrowPaymentRequirements): void {
+  res.status(402).json({ x402Version: X402_VERSION, accepts: [requirements] });
+}

--- a/typescript/packages/server-express/src/middleware.ts
+++ b/typescript/packages/server-express/src/middleware.ts
@@ -18,6 +18,8 @@ import {
 } from "@bosonprotocol/x402-server";
 import type { NextFunction, Request, RequestHandler, Response } from "express";
 
+import { respondWithChallenge } from "./internal/x402-challenge.js";
+
 export interface ExpressMiddlewareOptions {
   /**
    * Resolve the `EscrowPaymentRequirements` for this request — typically
@@ -74,7 +76,7 @@ export function expressMiddleware(
     if (header === undefined || header.length === 0) {
       try {
         const requirements = await opts.resolveRequirements(req, "challenge");
-        res.status(402).json({ x402Version: 2, accepts: [requirements] });
+        respondWithChallenge(res, requirements);
       } catch (e) {
         next(e);
       }

--- a/typescript/packages/server-express/src/mount.ts
+++ b/typescript/packages/server-express/src/mount.ts
@@ -13,6 +13,8 @@ import {
 } from "@bosonprotocol/x402-server";
 import { Router, type Request, type RequestHandler, type Response } from "express";
 
+import { respondWithChallenge } from "./internal/x402-challenge.js";
+
 export interface MountX402bOptions {
   /**
    * Resolver invoked for the commit-time routes (`/commit`,
@@ -52,11 +54,22 @@ function commitRoute(
 ): RequestHandler {
   return async (req, res, next) => {
     try {
+      const header = req.header("x-payment");
       const requirements = await opts.resolveRequirements(req);
-      const input: CommitHandlerInput = {
-        paymentHeader: req.header("x-payment"),
-        requirements,
-      };
+
+      // Missing `X-PAYMENT` is the canonical x402 challenge case — emit
+      // the same `{ x402Version, accepts: [requirements] }` body
+      // `expressMiddleware` does. Without this short-circuit the
+      // request would fall through to the handler, which returns its
+      // structured-error 402 body ({ code: "MISSING_HEADER", … }) —
+      // useful for non-Express integrators, but not the x402 wire
+      // contract clients branch on.
+      if (header === undefined || header.length === 0) {
+        respondWithChallenge(res, requirements);
+        return;
+      }
+
+      const input: CommitHandlerInput = { paymentHeader: header, requirements };
       const handler = kind === "commit" ? server.handlers.commit : server.handlers.commitAndRedeem;
       const result = await handler(input);
       stampXPaymentResponseIfOk(res, result);

--- a/typescript/packages/server-express/test/express.test.ts
+++ b/typescript/packages/server-express/test/express.test.ts
@@ -306,6 +306,37 @@ describe("mountX402b — convenience routes", () => {
     expect(res.status).toBe(400);
     expect(res.body.code).toBe("INVALID_REQUEST_BODY");
   });
+
+  it.each([["/x402b/commit"], ["/x402b/commit-and-redeem"]])(
+    "POST %s without X-PAYMENT returns the canonical x402 challenge",
+    async (path) => {
+      // Commit routes hit without `X-PAYMENT` should emit the same
+      // `{ x402Version, accepts: [...] }` body as `expressMiddleware()`,
+      // not the handler's structured-error 402. This is what x402
+      // clients pattern-match on to retry with the signed payment.
+      const { requirements } = await buildBuyerPayload();
+      const server = await buildServer(makeStubFetch(() => ({ ok: true })));
+
+      const app = express();
+      app.use(express.json());
+      app.use(
+        mountX402b(server, {
+          resolveRequirements: () =>
+            requirements as unknown as Awaited<ReturnType<typeof server.buildPaymentRequirements>>,
+        }),
+      );
+
+      const res = await supertest(app).post(path).send();
+      expect(res.status).toBe(402);
+      expect(res.body.x402Version).toBe(2);
+      expect(Array.isArray(res.body.accepts)).toBe(true);
+      expect(res.body.accepts[0].scheme).toBe("escrow");
+      // Structured-error fields must NOT leak when emitting the
+      // canonical challenge.
+      expect(res.body.code).toBeUndefined();
+      expect(res.body.reason).toBeUndefined();
+    },
+  );
 });
 
 describe("expressMiddleware — 402 challenge + settle gating", () => {


### PR DESCRIPTION
## Summary

Codex's review caught that `mountX402b()`'s `/commit` and `/commit-and-redeem` routes returned the handler's structured-error body (`{ code: "MISSING_HEADER", reason: "X-PAYMENT header not found" }` at status 402) when `X-PAYMENT` was absent. That's the right shape for non-Express integrators reading library results, but it's NOT the x402 wire contract — clients pattern-match on `{ x402Version, accepts: [...] }` to know it's a payment challenge they can retry. `expressMiddleware()` already produced the canonical shape; the mount routes silently diverged.

- New `respondWithChallenge(res, requirements)` helper in `server-express/src/internal/x402-challenge.ts` — single source of truth for the 402 body shape.
- `expressMiddleware()` switched to use the helper (no behaviour change, just deduplication).
- `mountX402b()` commit routes short-circuit to the helper when `req.header("x-payment")` is missing/empty, before invoking the handler.
- Handler unchanged: it still returns its structured-error 402 body for `MISSING_HEADER`, which non-Express integrators rely on.
- New parameterised test covers both `/commit` and `/commit-and-redeem`, asserts the response is `{ x402Version: 2, accepts: [...] }`, and verifies the structured-error fields don't leak.

## Test plan

- [x] `pnpm --filter @bosonprotocol/x402-server-express test` — 9/9 (two new parameterised cases)
- [x] `pnpm build` — 9/9
- [x] `pnpm lint` — 9/9
- [x] `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized HTTP 402 payment challenge response formatting for consistency across Express routes.

* **Tests**
  * Added integration test coverage for payment challenge scenarios when headers are missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/50)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->