### PR TITLE
fix(server): stamp endpoints.facilitator on post-commit nextActions

### DIFF
--- a/typescript/packages/server/src/handlers/commit-and-redeem.ts
+++ b/typescript/packages/server/src/handlers/commit-and-redeem.ts
@@ -169,6 +169,7 @@ async function handleCommitImpl(
       >,
     },
     ctx.config.channelRegistry,
+    ctx.config.facilitator.url,
   );
   return handlerOk({
     exchangeId: settleResult.exchangeId,

--- a/typescript/packages/server/src/handlers/next-actions.ts
+++ b/typescript/packages/server/src/handlers/next-actions.ts
@@ -3,6 +3,13 @@
 // `endpoints` / `channels` from the configured `ChannelRegistry`,
 // returns the discriminated `EscrowNextActions` shape (post-commit)
 // every convenience handler attaches to its response body.
+//
+// When the caller passes `facilitatorUrl`, the wrapper additionally
+// stamps `endpoints.facilitator` on every entry whose `channels`
+// include `"facilitator"` — matching the pre-commit behaviour in
+// `server.buildPaymentRequirements`. Without that stamp the buyer
+// sees `facilitator` advertised in `channels` but no URL to hit; the
+// channel is effectively dead.
 
 import {
   deriveNextActions,
@@ -11,6 +18,8 @@ import {
   type ChannelRegistry,
   type EscrowNextActions,
 } from "@bosonprotocol/x402-actions";
+
+import { stampFacilitatorEndpoints } from "../internal/facilitator-endpoints.js";
 
 export type EmitNextActionsInput = {
   exchangeId: string;
@@ -21,25 +30,36 @@ export type EmitNextActionsInput = {
 
 /**
  * Build the `nextActions` envelope a handler attaches to its 200 body.
- * Pure wrapper; the only logic here beyond `deriveNextActions` is the
- * `DISPUTED → disputeState required` narrowing.
+ * Pure wrapper; the logic beyond `deriveNextActions` is the
+ * `DISPUTED → disputeState required` narrowing and the optional
+ * facilitator-endpoint stamp.
  */
 export function emitNextActions(
   input: EmitNextActionsInput,
   registry: ChannelRegistry,
+  facilitatorUrl?: string,
 ): EscrowNextActions {
-  if (input.exchangeState === ExchangeState.DISPUTED) {
-    return deriveNextActions(
-      {
-        exchangeId: input.exchangeId,
-        exchangeState: ExchangeState.DISPUTED,
-        disputeState: input.disputeState,
-      },
-      registry,
-    );
+  const derived =
+    input.exchangeState === ExchangeState.DISPUTED
+      ? deriveNextActions(
+          {
+            exchangeId: input.exchangeId,
+            exchangeState: ExchangeState.DISPUTED,
+            disputeState: input.disputeState,
+          },
+          registry,
+        )
+      : deriveNextActions(
+          { exchangeId: input.exchangeId, exchangeState: input.exchangeState },
+          registry,
+        );
+
+  if (facilitatorUrl === undefined) {
+    return derived;
   }
-  return deriveNextActions(
-    { exchangeId: input.exchangeId, exchangeState: input.exchangeState },
-    registry,
-  );
+
+  return {
+    ...derived,
+    next: stampFacilitatorEndpoints(derived.next, facilitatorUrl),
+  };
 }

--- a/typescript/packages/server/src/handlers/perform-action.ts
+++ b/typescript/packages/server/src/handlers/perform-action.ts
@@ -113,6 +113,7 @@ export async function handlePerformAction(
             disputeState: postState.dispute,
           },
           ctx.config.channelRegistry,
+          ctx.config.facilitator.url,
         )
       : emitNextActions(
           {
@@ -123,6 +124,7 @@ export async function handlePerformAction(
             >,
           },
           ctx.config.channelRegistry,
+          ctx.config.facilitator.url,
         );
 
   return handlerOk({ txHash: result.txHash, nextActions });

--- a/typescript/packages/server/src/internal/facilitator-endpoints.ts
+++ b/typescript/packages/server/src/internal/facilitator-endpoints.ts
@@ -1,0 +1,55 @@
+// Helpers for stamping `endpoints.facilitator` on every `NextAction`
+// entry that advertises the `facilitator` channel. Used both at the
+// 402 challenge (pre-commit `EscrowPaymentRequirements.actions.next`)
+// and on every post-commit `EscrowNextActions` envelope a handler
+// returns — keeping the URL-shape logic in one place so the two
+// surfaces can't drift.
+
+import type { NextAction } from "@bosonprotocol/x402-core/schemes/escrow";
+
+const COMMIT_ACTION_IDS = new Set([
+  "boson-createOfferAndCommit",
+  "boson-createOfferCommitAndRedeem",
+]);
+
+/**
+ * Pick the facilitator endpoint URL for a given action id. Commit-time
+ * actions route to `/settle`; every other action routes to
+ * `/perform-action?action=<id>` so the facilitator can dispatch per
+ * action without re-parsing the meta-tx calldata.
+ */
+export function facilitatorEndpointFor(actionId: string, facilitatorUrl: string): string {
+  const base = facilitatorUrl.replace(/\/+$/, "");
+  if (COMMIT_ACTION_IDS.has(actionId)) {
+    return `${base}/settle`;
+  }
+  return `${base}/perform-action?action=${encodeURIComponent(actionId)}`;
+}
+
+/**
+ * Return a new `NextAction[]` with `endpoints.facilitator` stamped on
+ * every entry that advertises the `facilitator` channel. Entries that
+ * already carry an explicit `endpoints.facilitator` are left as-is
+ * (the caller wins) — same for entries whose `channels` don't include
+ * `"facilitator"`.
+ */
+export function stampFacilitatorEndpoints(
+  next: readonly NextAction[],
+  facilitatorUrl: string,
+): NextAction[] {
+  return next.map((entry) => {
+    if (!entry.channels.includes("facilitator")) {
+      return entry;
+    }
+    if (entry.endpoints?.facilitator !== undefined) {
+      return entry;
+    }
+    return {
+      ...entry,
+      endpoints: {
+        ...entry.endpoints,
+        facilitator: facilitatorEndpointFor(entry.id, facilitatorUrl),
+      },
+    };
+  });
+}

--- a/typescript/packages/server/src/server.ts
+++ b/typescript/packages/server/src/server.ts
@@ -32,6 +32,7 @@ import {
   type PerformActionInput,
   type PerformActionOk,
 } from "./handlers/index.js";
+import { stampFacilitatorEndpoints } from "./internal/facilitator-endpoints.js";
 import type { ExchangeReader } from "./onchain/verify-exchange.js";
 
 /** Per-offer inputs for `server.buildPaymentRequirements` — everything the offer-level args carry, minus the per-server context the factory already holds. */
@@ -68,19 +69,6 @@ export interface X402bServer {
   };
 }
 
-const COMMIT_ACTION_IDS = new Set([
-  "boson-createOfferAndCommit",
-  "boson-createOfferCommitAndRedeem",
-]);
-
-function facilitatorEndpointFor(actionId: string, facilitatorUrl: string): string {
-  const base = facilitatorUrl.replace(/\/+$/, "");
-  if (COMMIT_ACTION_IDS.has(actionId)) {
-    return `${base}/settle`;
-  }
-  return `${base}/perform-action?action=${encodeURIComponent(actionId)}`;
-}
-
 function withFacilitatorEndpoints(
   requirements: EscrowPaymentRequirements,
   facilitatorUrl: string,
@@ -89,18 +77,7 @@ function withFacilitatorEndpoints(
     ...requirements,
     actions: {
       ...requirements.actions,
-      next: requirements.actions.next.map((entry) => {
-        if (!entry.channels.includes("facilitator")) {
-          return entry;
-        }
-        return {
-          ...entry,
-          endpoints: {
-            ...entry.endpoints,
-            facilitator: facilitatorEndpointFor(entry.id, facilitatorUrl),
-          },
-        };
-      }),
+      next: stampFacilitatorEndpoints(requirements.actions.next, facilitatorUrl),
     },
   };
 }

--- a/typescript/packages/server/test/handlers.test.ts
+++ b/typescript/packages/server/test/handlers.test.ts
@@ -121,6 +121,21 @@ describe("handlers.commit / commitAndRedeem", () => {
       expect(result.body.txHash).toBe("0xabc");
       expect(result.body.nextActions.exchangeState).toBe(ExchangeState.COMMITTED);
       expect(result.body.nextActions.exchangeId).toBe("42");
+
+      // Every nextAction advertising `facilitator` in `channels` must
+      // also carry an `endpoints.facilitator` URL; otherwise clients
+      // see the channel advertised but have nowhere to route. The
+      // commit-time challenge stamps these in `buildPaymentRequirements`;
+      // the post-commit envelope stamps them in `emitNextActions`.
+      const facilitatorEntries = result.body.nextActions.next.filter((entry) =>
+        entry.channels.includes("facilitator"),
+      );
+      expect(facilitatorEntries.length).toBeGreaterThan(0);
+      for (const entry of facilitatorEntries) {
+        expect(entry.endpoints?.facilitator).toBe(
+          `${facilitatorUrl}/perform-action?action=${encodeURIComponent(entry.id)}`,
+        );
+      }
     }
   });
 
@@ -361,6 +376,17 @@ describe("handlers.disputeRaise — DISPUTED post-state path", () => {
         expect(result.body.nextActions.exchangeState).toBe(ExchangeState.DISPUTED);
         if ("disputeState" in result.body.nextActions) {
           expect(result.body.nextActions.disputeState).toBe("RESOLVING");
+        }
+
+        // Facilitator endpoints get stamped on the DISPUTED path too.
+        const facilitatorEntries = result.body.nextActions.next.filter((entry) =>
+          entry.channels.includes("facilitator"),
+        );
+        expect(facilitatorEntries.length).toBeGreaterThan(0);
+        for (const entry of facilitatorEntries) {
+          expect(entry.endpoints?.facilitator).toBe(
+            `${facilitatorUrl}/perform-action?action=${encodeURIComponent(entry.id)}`,
+          );
         }
       }
     } finally {


### PR DESCRIPTION
## Summary

Codex's review caught that pre-commit `nextActions` (built in `server.buildPaymentRequirements` via `withFacilitatorEndpoints`) carried `endpoints.facilitator`, but the post-commit envelope emitted by every convenience handler (via `emitNextActions` → `deriveNextActions`) didn't — `deriveNextActions` only sees the channel registry, not the server config that holds the facilitator URL. Clients saw `facilitator` advertised in `channels` for the follow-up actions (redeem, complete, dispute family) with no URL to hit; the channel was effectively dead after the first response.

- New shared helper `server/src/internal/facilitator-endpoints.ts` with `facilitatorEndpointFor(actionId, url)` and `stampFacilitatorEndpoints(next, url)`. One source of truth — both pre- and post-commit paths route through it.
- `server.ts`'s `withFacilitatorEndpoints` now delegates to the shared helper (drops the inline duplicate).
- `emitNextActions(input, registry, facilitatorUrl?)` gains an optional URL parameter and stamps after `deriveNextActions`. Entries with an explicit `endpoints.facilitator` are left as-is so callers can still override.
- `handleCommitImpl` and `handlePerformAction` pass `ctx.config.facilitator.url`.
- Existing happy-path tests pick up two new assertions covering both the non-DISPUTED (commit → COMMITTED) and DISPUTED (disputeRaise → RESOLVING) emission paths: every `facilitator`-channel entry must carry `endpoints.facilitator` matching `${facilitatorUrl}/perform-action?action=${id}`.

## Test plan

- [x] `pnpm --filter @bosonprotocol/x402-server test` — 5 files, 64 tests (two new assertions on existing happy paths)
- [x] `pnpm build` — 9/9
- [x] `pnpm test` — 18/18 tasks
- [x] `pnpm lint` — 9/9
- [x] `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Next actions now include configured facilitator endpoint URLs, enabling proper routing of follow-up actions through the escrow system.

* **Tests**
  * Added test assertions verifying facilitator endpoints are correctly stamped on action responses in commit and dispute scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/51)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->