### PR TITLE
feat(client): add signerFromEthersAdapter translator helper

### DIFF
--- a/typescript/packages/client/src/index.ts
+++ b/typescript/packages/client/src/index.ts
@@ -37,3 +37,4 @@ export type {
   SignedPostCommitAction,
   SimplePostCommitArgs,
 } from "./post-commit.js";
+export { signerFromEthersAdapter, type Web3LibAdapterLike } from "./signer-from-adapter.js";

--- a/typescript/packages/client/src/signer-from-adapter.ts
+++ b/typescript/packages/client/src/signer-from-adapter.ts
@@ -16,7 +16,14 @@
 // from `domain`'s field presence — the same rule viem applies internally
 // in `getTypesForEIP712Domain`.
 
-import type { Address, Hex, TypedDataDomain, TypedDataParameter } from "viem";
+import {
+  serializeTypedData,
+  type Address,
+  type Hex,
+  type TypedDataDomain,
+  type TypedDataDefinition,
+  type TypedDataParameter,
+} from "viem";
 
 import type { Signer } from "./types.js";
 
@@ -42,12 +49,13 @@ export function signerFromEthersAdapter(adapter: Web3LibAdapterLike): Signer {
     getAddress: async () => (await adapter.getSignerAddress()) as Address,
     signTypedData: async ({ domain, types, primaryType, message }) => {
       const from = await adapter.getSignerAddress();
-      const json = JSON.stringify({
+      const typedData = {
         domain,
         types: { EIP712Domain: deriveEip712DomainType(domain), ...types },
         primaryType,
         message,
-      });
+      };
+      const json = serializeTypedData(typedData as unknown as TypedDataDefinition);
       const sig = await adapter.send("eth_signTypedData_v4", [from, json]);
       if (typeof sig !== "string" || !sig.startsWith("0x")) {
         throw new Error(

--- a/typescript/packages/client/src/signer-from-adapter.ts
+++ b/typescript/packages/client/src/signer-from-adapter.ts
@@ -1,0 +1,77 @@
+// Translator that wraps a Boson `Web3LibAdapter` (e.g. an `EthersAdapter`
+// from `@bosonprotocol/ethers-sdk`) as an x402-client `Signer`. The point
+// is to let consumers who already hold an adapter for the deployed Boson
+// protocol reuse it with `createX402bClient` without writing the shim
+// themselves — and without forcing this package to take `ethers` (or
+// `@bosonprotocol/common`) as a peer dep.
+//
+// Structural typing keeps the coupling minimal: `Web3LibAdapterLike` picks
+// only the two methods we actually invoke. The consumer's own `ethers` /
+// `@bosonprotocol/ethers-sdk` install carries the full types — an
+// `EthersAdapter` instance satisfies `Web3LibAdapterLike` by shape.
+//
+// Note on `EIP712Domain` injection: `eth_signTypedData_v4` (and the
+// `EthersAdapter` JSON path) expects `types.EIP712Domain` to be present
+// and to match exactly the fields populated on `domain`. We derive it
+// from `domain`'s field presence — the same rule viem applies internally
+// in `getTypesForEIP712Domain`.
+
+import type { Address, Hex, TypedDataDomain, TypedDataParameter } from "viem";
+
+import type { Signer } from "./types.js";
+
+/**
+ * Structural subset of `@bosonprotocol/common`'s `Web3LibAdapter` that
+ * {@link signerFromEthersAdapter} actually exercises. An `EthersAdapter`
+ * from `@bosonprotocol/ethers-sdk` (or any future concrete adapter)
+ * satisfies this shape without an explicit cast.
+ */
+export interface Web3LibAdapterLike {
+  getSignerAddress(): Promise<string>;
+  send(method: string, params: readonly unknown[]): Promise<unknown>;
+}
+
+/**
+ * Wrap a Boson `Web3LibAdapter`-shaped object as an x402-client
+ * {@link Signer}. `signTypedData` builds the standard
+ * `eth_signTypedData_v4` JSON payload (including a derived
+ * `EIP712Domain` type list) and routes it through `adapter.send`.
+ */
+export function signerFromEthersAdapter(adapter: Web3LibAdapterLike): Signer {
+  return {
+    getAddress: async () => (await adapter.getSignerAddress()) as Address,
+    signTypedData: async ({ domain, types, primaryType, message }) => {
+      const from = await adapter.getSignerAddress();
+      const json = JSON.stringify({
+        domain,
+        types: { EIP712Domain: deriveEip712DomainType(domain), ...types },
+        primaryType,
+        message,
+      });
+      const sig = await adapter.send("eth_signTypedData_v4", [from, json]);
+      if (typeof sig !== "string" || !sig.startsWith("0x")) {
+        throw new Error(
+          "signerFromEthersAdapter: adapter.send did not return a 0x-prefixed signature string",
+        );
+      }
+      return sig as Hex;
+    },
+  };
+}
+
+/**
+ * Build the `EIP712Domain` type-list from the fields actually present on
+ * `domain`, in the canonical EIP-712 order (`name`, `version`, `chainId`,
+ * `verifyingContract`, `salt`). Matches viem's internal derivation so the
+ * resulting digest agrees with what a viem signer would produce.
+ */
+function deriveEip712DomainType(domain: TypedDataDomain): readonly TypedDataParameter[] {
+  const fields: TypedDataParameter[] = [];
+  if (domain.name !== undefined) fields.push({ name: "name", type: "string" });
+  if (domain.version !== undefined) fields.push({ name: "version", type: "string" });
+  if (domain.chainId !== undefined) fields.push({ name: "chainId", type: "uint256" });
+  if (domain.verifyingContract !== undefined)
+    fields.push({ name: "verifyingContract", type: "address" });
+  if (domain.salt !== undefined) fields.push({ name: "salt", type: "bytes32" });
+  return fields;
+}

--- a/typescript/packages/client/src/signer-from-adapter.ts
+++ b/typescript/packages/client/src/signer-from-adapter.ts
@@ -51,15 +51,15 @@ export function signerFromEthersAdapter(adapter: Web3LibAdapterLike): Signer {
       const from = await adapter.getSignerAddress();
       const typedData = {
         domain,
-        types: { EIP712Domain: deriveEip712DomainType(domain), ...types },
+        types: { ...types, EIP712Domain: deriveEip712DomainType(domain) },
         primaryType,
         message,
       };
       const json = serializeTypedData(typedData as unknown as TypedDataDefinition);
       const sig = await adapter.send("eth_signTypedData_v4", [from, json]);
-      if (typeof sig !== "string" || !sig.startsWith("0x")) {
+      if (typeof sig !== "string" || !/^0x[0-9a-fA-F]+$/.test(sig)) {
         throw new Error(
-          "signerFromEthersAdapter: adapter.send did not return a 0x-prefixed signature string",
+          "signerFromEthersAdapter: adapter.send did not return a hex signature string",
         );
       }
       return sig as Hex;

--- a/typescript/packages/client/src/signer-from-adapter.ts
+++ b/typescript/packages/client/src/signer-from-adapter.ts
@@ -17,6 +17,7 @@
 // in `getTypesForEIP712Domain`.
 
 import {
+  getAddress,
   serializeTypedData,
   type Address,
   type Hex,
@@ -45,10 +46,11 @@ export interface Web3LibAdapterLike {
  * `EIP712Domain` type list) and routes it through `adapter.send`.
  */
 export function signerFromEthersAdapter(adapter: Web3LibAdapterLike): Signer {
+  const resolveAddress = async (): Promise<Address> => getAddress(await adapter.getSignerAddress());
   return {
-    getAddress: async () => (await adapter.getSignerAddress()) as Address,
+    getAddress: resolveAddress,
     signTypedData: async ({ domain, types, primaryType, message }) => {
-      const from = await adapter.getSignerAddress();
+      const from = await resolveAddress();
       const typedData = {
         domain,
         types: { ...types, EIP712Domain: deriveEip712DomainType(domain) },

--- a/typescript/packages/client/test/signer-from-adapter.test.ts
+++ b/typescript/packages/client/test/signer-from-adapter.test.ts
@@ -48,10 +48,9 @@ function buildMockAdapter(): {
       }
       const [, raw] = params as [string, string];
       const { domain, types: parsedTypes, primaryType, message: msg } = JSON.parse(raw);
-      const { EIP712Domain: _ignored, ...rest } = parsedTypes as Record<string, unknown>;
       return account.signTypedData({
         domain,
-        types: rest as Parameters<typeof account.signTypedData>[0]["types"],
+        types: parsedTypes as Parameters<typeof account.signTypedData>[0]["types"],
         primaryType,
         message: msg,
       });
@@ -146,6 +145,47 @@ describe("signerFromEthersAdapter", () => {
       { name: "name", type: "string" },
       { name: "salt", type: "bytes32" },
     ]);
+  });
+
+  it("serializes bigint domain and message values for JSON-RPC signing", async () => {
+    const { adapter, calls } = buildMockAdapter();
+    const signer = signerFromEthersAdapter(adapter);
+    const bigintDomain: TypedDataDomain = {
+      name: "Test",
+      version: "1",
+      chainId: 8453n,
+      verifyingContract: "0xdddddddddddddddddddddddddddddddddddddddd",
+    };
+    const paymentTypes = {
+      Payment: [
+        { name: "payer", type: "address" },
+        { name: "amount", type: "uint256" },
+      ],
+    } as const;
+    const paymentMessage = {
+      payer: account.address,
+      amount: 123n,
+    };
+    const sig = await signer.signTypedData({
+      domain: bigintDomain,
+      types: paymentTypes,
+      primaryType: "Payment",
+      message: paymentMessage,
+    });
+    const recovered = await recoverTypedDataAddress({
+      domain: bigintDomain,
+      types: paymentTypes,
+      primaryType: "Payment",
+      message: paymentMessage,
+      signature: sig,
+    });
+    const parsed = JSON.parse(calls[0]!.params[1] as string) as {
+      domain: { chainId: string };
+      message: { amount: string };
+    };
+    expect(recovered.toLowerCase()).toBe(account.address.toLowerCase());
+    expect(parsed.domain.chainId).toBe("8453");
+    expect(parsed.message.amount).toBe("123");
   });
 
   it("rejects when adapter.send returns a non-hex value", async () => {

--- a/typescript/packages/client/test/signer-from-adapter.test.ts
+++ b/typescript/packages/client/test/signer-from-adapter.test.ts
@@ -28,6 +28,15 @@ const message = {
   contents: "hello",
 } as const;
 
+const EXPECTED_FULL_EIP712_DOMAIN = [
+  { name: "name", type: "string" },
+  { name: "version", type: "string" },
+  { name: "chainId", type: "uint256" },
+  { name: "verifyingContract", type: "address" },
+] as const;
+
+const HEX_SIGNATURE_ERROR = /hex signature string/;
+
 /**
  * Build a mock `Web3LibAdapterLike` that records every `send(...)` call and
  * signs typed-data internally with the wrapped viem account — mirroring
@@ -96,12 +105,7 @@ describe("signerFromEthersAdapter", () => {
     const parsed = JSON.parse(calls[0]!.params[1] as string) as {
       types: { EIP712Domain: { name: string; type: string }[] };
     };
-    expect(parsed.types.EIP712Domain).toEqual([
-      { name: "name", type: "string" },
-      { name: "version", type: "string" },
-      { name: "chainId", type: "uint256" },
-      { name: "verifyingContract", type: "address" },
-    ]);
+    expect(parsed.types.EIP712Domain).toEqual(EXPECTED_FULL_EIP712_DOMAIN);
   });
 
   it("omits absent domain fields from the derived EIP712Domain type list", async () => {
@@ -196,7 +200,7 @@ describe("signerFromEthersAdapter", () => {
     const signer = signerFromEthersAdapter(adapter);
     await expect(
       signer.signTypedData({ domain: fullDomain, types, primaryType: "Mail", message }),
-    ).rejects.toThrow(/hex signature string/);
+    ).rejects.toThrow(HEX_SIGNATURE_ERROR);
   });
 
   it("rejects when adapter.send returns a 0x-prefixed string with non-hex chars", async () => {
@@ -207,7 +211,29 @@ describe("signerFromEthersAdapter", () => {
     const signer = signerFromEthersAdapter(adapter);
     await expect(
       signer.signTypedData({ domain: fullDomain, types, primaryType: "Mail", message }),
-    ).rejects.toThrow(/hex signature string/);
+    ).rejects.toThrow(HEX_SIGNATURE_ERROR);
+  });
+
+  it("rejects when adapter.getSignerAddress returns a malformed address", async () => {
+    const adapter: Web3LibAdapterLike = {
+      getSignerAddress: async () => "not-an-address",
+      send: async () => `0x${"00".repeat(65)}`,
+    };
+    const signer = signerFromEthersAdapter(adapter);
+    await expect(signer.getAddress()).rejects.toThrow();
+    await expect(
+      signer.signTypedData({ domain: fullDomain, types, primaryType: "Mail", message }),
+    ).rejects.toThrow();
+  });
+
+  it("checksums a lowercase address returned by the adapter", async () => {
+    const lowercase = account.address.toLowerCase();
+    const adapter: Web3LibAdapterLike = {
+      getSignerAddress: async () => lowercase,
+      send: async () => `0x${"00".repeat(65)}`,
+    };
+    const signer = signerFromEthersAdapter(adapter);
+    expect(await signer.getAddress()).toBe(account.address);
   });
 
   it("derived EIP712Domain wins over a caller-supplied entry of the same name", async () => {
@@ -226,11 +252,6 @@ describe("signerFromEthersAdapter", () => {
     const parsed = JSON.parse(calls[0]!.params[1] as string) as {
       types: { EIP712Domain: { name: string; type: string }[] };
     };
-    expect(parsed.types.EIP712Domain).toEqual([
-      { name: "name", type: "string" },
-      { name: "version", type: "string" },
-      { name: "chainId", type: "uint256" },
-      { name: "verifyingContract", type: "address" },
-    ]);
+    expect(parsed.types.EIP712Domain).toEqual(EXPECTED_FULL_EIP712_DOMAIN);
   });
 });

--- a/typescript/packages/client/test/signer-from-adapter.test.ts
+++ b/typescript/packages/client/test/signer-from-adapter.test.ts
@@ -188,7 +188,7 @@ describe("signerFromEthersAdapter", () => {
     expect(parsed.message.amount).toBe("123");
   });
 
-  it("rejects when adapter.send returns a non-hex value", async () => {
+  it("rejects when adapter.send returns a non-string value", async () => {
     const adapter: Web3LibAdapterLike = {
       getSignerAddress: async () => account.address,
       send: async () => 42,
@@ -196,6 +196,41 @@ describe("signerFromEthersAdapter", () => {
     const signer = signerFromEthersAdapter(adapter);
     await expect(
       signer.signTypedData({ domain: fullDomain, types, primaryType: "Mail", message }),
-    ).rejects.toThrow(/0x-prefixed signature string/);
+    ).rejects.toThrow(/hex signature string/);
+  });
+
+  it("rejects when adapter.send returns a 0x-prefixed string with non-hex chars", async () => {
+    const adapter: Web3LibAdapterLike = {
+      getSignerAddress: async () => account.address,
+      send: async () => "0xzz",
+    };
+    const signer = signerFromEthersAdapter(adapter);
+    await expect(
+      signer.signTypedData({ domain: fullDomain, types, primaryType: "Mail", message }),
+    ).rejects.toThrow(/hex signature string/);
+  });
+
+  it("derived EIP712Domain wins over a caller-supplied entry of the same name", async () => {
+    const { adapter, calls } = buildMockAdapter();
+    const signer = signerFromEthersAdapter(adapter);
+    const hostileTypes = {
+      EIP712Domain: [{ name: "name", type: "string" }],
+      Mail: types.Mail,
+    } as const;
+    await signer.signTypedData({
+      domain: fullDomain,
+      types: hostileTypes,
+      primaryType: "Mail",
+      message,
+    });
+    const parsed = JSON.parse(calls[0]!.params[1] as string) as {
+      types: { EIP712Domain: { name: string; type: string }[] };
+    };
+    expect(parsed.types.EIP712Domain).toEqual([
+      { name: "name", type: "string" },
+      { name: "version", type: "string" },
+      { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
+    ]);
   });
 });

--- a/typescript/packages/client/test/signer-from-adapter.test.ts
+++ b/typescript/packages/client/test/signer-from-adapter.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { recoverTypedDataAddress, type TypedDataDomain } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { signerFromEthersAdapter, type Web3LibAdapterLike } from "../src/signer-from-adapter.js";
+
+const TEST_KEY = `0x${"42".repeat(32)}` as const;
+const account = privateKeyToAccount(TEST_KEY);
+
+const fullDomain: TypedDataDomain = {
+  name: "Test",
+  version: "1",
+  chainId: 8453,
+  verifyingContract: "0xdddddddddddddddddddddddddddddddddddddddd",
+};
+
+const types = {
+  Mail: [
+    { name: "from", type: "address" },
+    { name: "to", type: "address" },
+    { name: "contents", type: "string" },
+  ],
+} as const;
+
+const message = {
+  from: account.address,
+  to: "0x1111111111111111111111111111111111111111",
+  contents: "hello",
+} as const;
+
+/**
+ * Build a mock `Web3LibAdapterLike` that records every `send(...)` call and
+ * signs typed-data internally with the wrapped viem account — mirroring
+ * what `EthersAdapter.send("eth_signTypedData_v4", [from, json])` does end
+ * to end.
+ */
+function buildMockAdapter(): {
+  adapter: Web3LibAdapterLike;
+  calls: { method: string; params: readonly unknown[] }[];
+} {
+  const calls: { method: string; params: readonly unknown[] }[] = [];
+  const adapter: Web3LibAdapterLike = {
+    getSignerAddress: async () => account.address,
+    send: async (method, params) => {
+      calls.push({ method, params });
+      if (method !== "eth_signTypedData_v4") {
+        throw new Error(`unexpected method: ${method}`);
+      }
+      const [, raw] = params as [string, string];
+      const { domain, types: parsedTypes, primaryType, message: msg } = JSON.parse(raw);
+      const { EIP712Domain: _ignored, ...rest } = parsedTypes as Record<string, unknown>;
+      return account.signTypedData({
+        domain,
+        types: rest as Parameters<typeof account.signTypedData>[0]["types"],
+        primaryType,
+        message: msg,
+      });
+    },
+  };
+  return { adapter, calls };
+}
+
+describe("signerFromEthersAdapter", () => {
+  it("getAddress() returns the wrapped adapter's signer address", async () => {
+    const { adapter } = buildMockAdapter();
+    const signer = signerFromEthersAdapter(adapter);
+    expect(await signer.getAddress()).toBe(account.address);
+  });
+
+  it("signTypedData() round-trips through the adapter and recovers the signer", async () => {
+    const { adapter, calls } = buildMockAdapter();
+    const signer = signerFromEthersAdapter(adapter);
+    const sig = await signer.signTypedData({
+      domain: fullDomain,
+      types,
+      primaryType: "Mail",
+      message,
+    });
+    const recovered = await recoverTypedDataAddress({
+      domain: fullDomain,
+      types,
+      primaryType: "Mail",
+      message,
+      signature: sig,
+    });
+    expect(recovered.toLowerCase()).toBe(account.address.toLowerCase());
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.method).toBe("eth_signTypedData_v4");
+    expect(calls[0]!.params[0]).toBe(account.address);
+    expect(typeof calls[0]!.params[1]).toBe("string");
+  });
+
+  it("derives EIP712Domain entries from a full 4-field domain in canonical order", async () => {
+    const { adapter, calls } = buildMockAdapter();
+    const signer = signerFromEthersAdapter(adapter);
+    await signer.signTypedData({ domain: fullDomain, types, primaryType: "Mail", message });
+    const parsed = JSON.parse(calls[0]!.params[1] as string) as {
+      types: { EIP712Domain: { name: string; type: string }[] };
+    };
+    expect(parsed.types.EIP712Domain).toEqual([
+      { name: "name", type: "string" },
+      { name: "version", type: "string" },
+      { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
+    ]);
+  });
+
+  it("omits absent domain fields from the derived EIP712Domain type list", async () => {
+    const { adapter, calls } = buildMockAdapter();
+    const signer = signerFromEthersAdapter(adapter);
+    const partialDomain: TypedDataDomain = { name: "Test", chainId: 8453 };
+    await signer.signTypedData({
+      domain: partialDomain,
+      types,
+      primaryType: "Mail",
+      message,
+    });
+    const parsed = JSON.parse(calls[0]!.params[1] as string) as {
+      types: { EIP712Domain: { name: string; type: string }[] };
+      domain: TypedDataDomain;
+    };
+    expect(parsed.types.EIP712Domain).toEqual([
+      { name: "name", type: "string" },
+      { name: "chainId", type: "uint256" },
+    ]);
+    expect(parsed.domain).toEqual(partialDomain);
+  });
+
+  it("includes a salt entry when the domain carries one", async () => {
+    const { adapter, calls } = buildMockAdapter();
+    const signer = signerFromEthersAdapter(adapter);
+    const saltDomain: TypedDataDomain = {
+      name: "Test",
+      salt: `0x${"ab".repeat(32)}`,
+    };
+    await signer.signTypedData({
+      domain: saltDomain,
+      types,
+      primaryType: "Mail",
+      message,
+    });
+    const parsed = JSON.parse(calls[0]!.params[1] as string) as {
+      types: { EIP712Domain: { name: string; type: string }[] };
+    };
+    expect(parsed.types.EIP712Domain).toEqual([
+      { name: "name", type: "string" },
+      { name: "salt", type: "bytes32" },
+    ]);
+  });
+
+  it("rejects when adapter.send returns a non-hex value", async () => {
+    const adapter: Web3LibAdapterLike = {
+      getSignerAddress: async () => account.address,
+      send: async () => 42,
+    };
+    const signer = signerFromEthersAdapter(adapter);
+    await expect(
+      signer.signTypedData({ domain: fullDomain, types, primaryType: "Mail", message }),
+    ).rejects.toThrow(/0x-prefixed signature string/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `signerFromEthersAdapter(adapter)` in `@bosonprotocol/x402-client` so consumers who already hold a Boson `EthersAdapter` (or any `Web3LibAdapter`-shaped object) can pass it to `createX402bClient` without writing the shim themselves.
- Uses structural typing on a new `Web3LibAdapterLike` interface — the client package picks up zero new peer deps (neither `ethers` nor `@bosonprotocol/common` need to be installed by us).
- Builds the `eth_signTypedData_v4` JSON envelope with a derived `EIP712Domain` type list (canonical field order, conditional on which `TypedDataDomain` fields are populated).

## Test plan
- [x] `pnpm build` — 10/10 workspace packages
- [x] `pnpm test` — 51/51 client tests, including 6 new in `signer-from-adapter.test.ts` covering address forwarding, signature round-trip via `recoverTypedDataAddress`, EIP712Domain derivation (full 4-field domain, partial 2-field domain, salt-bearing domain), and non-hex `send` return rejection
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API extended to allow external Web3 adapter-based signers and perform EIP‑712 v4 typed-data signing with canonical domain derivation and address validation.

* **Tests**
  * Added comprehensive tests for adapter behavior, address handling, typed-data serialization, signature round-trips, bigint handling, domain-derivation rules, and failure cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/55)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->