### PR TITLE
feat(examples): add webhook-sink for e2e webhook fulfillment channel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,52 @@
+# dependencies
+node_modules/
+**/node_modules/
+
+# build artifacts
+dist/
+**/dist/
+build/
+**/build/
+*.tsbuildinfo
+**/*.tsbuildinfo
+
+# turbo
+.turbo/
+**/.turbo/
+
+# test / coverage
+coverage/
+**/coverage/
+.nyc_output/
+**/.nyc_output/
+
+# editor / OS
+.DS_Store
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# logs / env
+*.log
+**/*.log
+.env
+.env.local
+.env.*.local
+**/.env
+**/.env.local
+**/.env.*.local
+
+# git / CI / tooling
+.git/
+.github/
+.gitignore
+.gitattributes
+
+# pnpm store
+.pnpm-store/
+
+# claude
+.claude/
+
+# example-level dockerignore is obsolete now that the build context is the repo root

--- a/.dockerignore
+++ b/.dockerignore
@@ -30,12 +30,8 @@ coverage/
 # logs / env
 *.log
 **/*.log
-.env
-.env.local
-.env.*.local
-**/.env
-**/.env.local
-**/.env.*.local
+.env*
+**/.env*
 
 # git / CI / tooling
 .git/

--- a/examples/webhook-sink/.dockerignore
+++ b/examples/webhook-sink/.dockerignore
@@ -1,5 +1,0 @@
-node_modules
-dist
-.turbo
-test
-*.log

--- a/examples/webhook-sink/.dockerignore
+++ b/examples/webhook-sink/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.turbo
+test
+*.log

--- a/examples/webhook-sink/Dockerfile
+++ b/examples/webhook-sink/Dockerfile
@@ -9,8 +9,6 @@ COPY tsconfig.json ./
 COPY src ./src
 
 ENV PORT=4000
-ENV PORT=4000
-EXPOSE 4000
 EXPOSE 4000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD wget -qO- "http://127.0.0.1:${PORT}/health" >/dev/null || exit 1

--- a/examples/webhook-sink/Dockerfile
+++ b/examples/webhook-sink/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --omit=optional --no-audit --no-fund
 
-COPY tsconfig.json ./
 COPY src ./src
 
 ENV PORT=4000

--- a/examples/webhook-sink/Dockerfile
+++ b/examples/webhook-sink/Dockerfile
@@ -11,6 +11,7 @@ COPY src ./src
 ENV PORT=4000
 ENV PORT=4000
 EXPOSE 4000
+EXPOSE 4000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD wget -qO- "http://127.0.0.1:${PORT}/health" >/dev/null || exit 1
 

--- a/examples/webhook-sink/Dockerfile
+++ b/examples/webhook-sink/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --omit=optional --no-audit --no-fund
+
+COPY tsconfig.json ./
+COPY src ./src
+
+ENV PORT=4000
+EXPOSE 4000
+
+CMD ["npx", "tsx", "src/index.ts"]

--- a/examples/webhook-sink/Dockerfile
+++ b/examples/webhook-sink/Dockerfile
@@ -11,3 +11,18 @@ ENV PORT=4000
 EXPOSE 4000
 
 CMD ["npx", "tsx", "src/index.ts"]
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --omit=optional --no-audit --no-fund
+
+COPY tsconfig.json ./
+COPY src ./src
+
+ENV PORT=4000
+EXPOSE 4000
+
+USER node
+CMD ["npx", "tsx", "src/index.ts"]

--- a/examples/webhook-sink/Dockerfile
+++ b/examples/webhook-sink/Dockerfile
@@ -1,11 +1,30 @@
-FROM node:22-alpine
+# syntax=docker/dockerfile:1.7
+#
+# Build from the monorepo root so the root pnpm-lock.yaml is in context:
+#   docker build -t x402b-webhook-sink -f examples/webhook-sink/Dockerfile .
+#
+# corepack reads `packageManager` from the root package.json and pins pnpm.
 
+FROM node:22-alpine AS base
+RUN corepack enable
+WORKDIR /repo
+
+FROM base AS deps
+COPY . .
+RUN pnpm install --frozen-lockfile \
+    --filter @bosonprotocol/x402-example-webhook-sink...
+
+# `pnpm deploy` materializes a self-contained directory with a flat
+# node_modules — required because the workspace install uses a virtual
+# store, and the symlinks under examples/webhook-sink/node_modules point
+# back into /repo/node_modules/.pnpm/... which wouldn't exist in the
+# runtime stage. --legacy keeps the pnpm-9 behavior (includes
+# devDependencies so `tsx` is available at runtime).
+RUN pnpm --filter @bosonprotocol/x402-example-webhook-sink deploy --legacy /deploy
+
+FROM node:22-alpine AS runtime
 WORKDIR /app
-
-COPY package.json ./
-RUN npm install --omit=optional --no-audit --no-fund
-
-COPY src ./src
+COPY --from=deps /deploy ./
 
 ENV PORT=4000
 EXPOSE 4000

--- a/examples/webhook-sink/Dockerfile
+++ b/examples/webhook-sink/Dockerfile
@@ -5,19 +5,6 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --omit=optional --no-audit --no-fund
 
-COPY src ./src
-
-ENV PORT=4000
-EXPOSE 4000
-
-CMD ["npx", "tsx", "src/index.ts"]
-FROM node:22-alpine
-
-WORKDIR /app
-
-COPY package.json ./
-RUN npm install --omit=optional --no-audit --no-fund
-
 COPY tsconfig.json ./
 COPY src ./src
 
@@ -27,4 +14,5 @@ EXPOSE 4000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD wget -qO- "http://127.0.0.1:${PORT}/health" >/dev/null || exit 1
 
+USER node
 CMD ["npx", "tsx", "src/index.ts"]

--- a/examples/webhook-sink/Dockerfile
+++ b/examples/webhook-sink/Dockerfile
@@ -22,7 +22,9 @@ COPY tsconfig.json ./
 COPY src ./src
 
 ENV PORT=4000
+ENV PORT=4000
 EXPOSE 4000
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- "http://127.0.0.1:${PORT}/health" >/dev/null || exit 1
 
-USER node
 CMD ["npx", "tsx", "src/index.ts"]

--- a/examples/webhook-sink/README.md
+++ b/examples/webhook-sink/README.md
@@ -1,0 +1,32 @@
+# webhook-sink
+
+Minimal Express service that captures POST bodies. Used by the x402B
+e2e test suite to verify the `webhook` fulfillment channel — without
+a callback endpoint to receive `onCommit` / `onFulfill` payloads,
+that channel can't be exercised end-to-end.
+
+Not a reference for production use. It has no auth, persists nothing,
+and stores received bodies in memory.
+
+## Endpoints
+
+| Route | Purpose |
+|---|---|
+| `GET  /health`    | Liveness probe. Returns `{ ok: true }`. |
+| `POST /hook`      | Stores the JSON request body. Returns `204`. |
+| `GET  /received`  | Returns the array of stored bodies. |
+| `DELETE /received`| Clears the in-memory store. Returns `204`. |
+
+## Run locally
+
+```sh
+pnpm --filter @bosonprotocol/x402-example-webhook-sink start
+# PORT=4000 by default
+```
+
+## Run in Docker
+
+```sh
+docker build -t x402b-webhook-sink examples/webhook-sink
+docker run --rm -p 4000:4000 x402b-webhook-sink
+```

--- a/examples/webhook-sink/README.md
+++ b/examples/webhook-sink/README.md
@@ -26,7 +26,12 @@ pnpm --filter @bosonprotocol/x402-example-webhook-sink start
 
 ## Run in Docker
 
+Build from the **repo root** so the monorepo `pnpm-lock.yaml` is in the
+build context — the image installs deps with `pnpm --frozen-lockfile`
+against that lockfile, so versions stay pinned to whatever the workspace
+resolved.
+
 ```sh
-docker build -t x402b-webhook-sink examples/webhook-sink
+docker build -t x402b-webhook-sink -f examples/webhook-sink/Dockerfile .
 docker run --rm -p 4000:4000 x402b-webhook-sink
 ```

--- a/examples/webhook-sink/package.json
+++ b/examples/webhook-sink/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@bosonprotocol/x402-example-webhook-sink",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "description": "Minimal Express service that captures POST bodies, used by the x402B e2e suite to verify the `webhook` fulfillment channel.",
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "start": "tsx src/index.ts",
+    "test": "vitest run --passWithNoTests",
+    "lint": "eslint src --max-warnings 0",
+    "clean": "rm -rf .turbo"
+  },
+  "dependencies": {
+    "express": "^4.21.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.17.10",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/examples/webhook-sink/package.json
+++ b/examples/webhook-sink/package.json
@@ -13,14 +13,14 @@
     "clean": "rm -rf .turbo"
   },
   "dependencies": {
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "tsx": "^4.19.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^20.17.10",
     "@types/supertest": "^6.0.2",
     "supertest": "^7.0.0",
-    "tsx": "^4.19.2",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"
   }

--- a/examples/webhook-sink/package.json
+++ b/examples/webhook-sink/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc --noEmit",
     "start": "tsx src/index.ts",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "lint": "eslint src --max-warnings 0",
     "clean": "rm -rf .turbo"
   },

--- a/examples/webhook-sink/src/app.ts
+++ b/examples/webhook-sink/src/app.ts
@@ -1,0 +1,42 @@
+import express, { type Express } from "express";
+
+export interface WebhookSink {
+  app: Express;
+  /** Clear the in-memory store. Tests call this between cases. */
+  clear: () => void;
+  /** Read-only snapshot of bodies received so far. */
+  snapshot: () => readonly unknown[];
+}
+
+export function createWebhookSink(): WebhookSink {
+  const app = express();
+  app.use(express.json({ limit: "1mb" }));
+
+  const received: unknown[] = [];
+
+  app.get("/health", (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  app.post("/hook", (req, res) => {
+    received.push(req.body);
+    res.status(204).end();
+  });
+
+  app.get("/received", (_req, res) => {
+    res.json(received);
+  });
+
+  app.delete("/received", (_req, res) => {
+    received.length = 0;
+    res.status(204).end();
+  });
+
+  return {
+    app,
+    clear: () => {
+      received.length = 0;
+    },
+    snapshot: () => received.slice(),
+  };
+}

--- a/examples/webhook-sink/src/index.ts
+++ b/examples/webhook-sink/src/index.ts
@@ -1,6 +1,11 @@
 import { createWebhookSink } from "./app.js";
 
-const port = Number(process.env.PORT ?? 4000);
+const rawPort = process.env.PORT;
+const parsedPort = rawPort === undefined ? 4000 : Number.parseInt(rawPort, 10);
+if (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535) {
+  throw new Error(`[webhook-sink] invalid PORT: ${rawPort}`);
+}
+const port = parsedPort;
 const { app } = createWebhookSink();
 
 app.listen(port, () => {

--- a/examples/webhook-sink/src/index.ts
+++ b/examples/webhook-sink/src/index.ts
@@ -1,0 +1,8 @@
+import { createWebhookSink } from "./app.js";
+
+const port = Number(process.env.PORT ?? 4000);
+const { app } = createWebhookSink();
+
+app.listen(port, () => {
+  console.log(`[webhook-sink] listening on :${port}`);
+});

--- a/examples/webhook-sink/test/webhook-sink.test.ts
+++ b/examples/webhook-sink/test/webhook-sink.test.ts
@@ -1,0 +1,52 @@
+import supertest from "supertest";
+import { describe, expect, it, beforeEach } from "vitest";
+
+import { createWebhookSink } from "../src/app.js";
+
+describe("webhook-sink", () => {
+  let sink = createWebhookSink();
+  let agent = supertest(sink.app);
+
+  beforeEach(() => {
+    sink = createWebhookSink();
+    agent = supertest(sink.app);
+  });
+
+  it("GET /health returns ok", async () => {
+    const res = await agent.get("/health");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("POST /hook stores the body and GET /received returns it", async () => {
+    const payload = { exchangeId: "42", action: "boson-redeem" };
+
+    const post = await agent.post("/hook").send(payload);
+    expect(post.status).toBe(204);
+
+    const get = await agent.get("/received");
+    expect(get.status).toBe(200);
+    expect(get.body).toEqual([payload]);
+  });
+
+  it("multiple POSTs accumulate in order", async () => {
+    await agent.post("/hook").send({ n: 1 });
+    await agent.post("/hook").send({ n: 2 });
+    await agent.post("/hook").send({ n: 3 });
+
+    const res = await agent.get("/received");
+    expect(res.body).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+  });
+
+  it("DELETE /received empties the store", async () => {
+    await agent.post("/hook").send({ n: 1 });
+    expect(sink.snapshot()).toHaveLength(1);
+
+    const del = await agent.delete("/received");
+    expect(del.status).toBe(204);
+
+    const res = await agent.get("/received");
+    expect(res.body).toEqual([]);
+    expect(sink.snapshot()).toEqual([]);
+  });
+});

--- a/examples/webhook-sink/tsconfig.json
+++ b/examples/webhook-sink/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["src", "test"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/examples/webhook-sink/vitest.config.ts
+++ b/examples/webhook-sink/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
         version: 3.8.3
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.14)(tsx@4.22.0)(typescript@5.9.3)
       turbo:
         specifier: ^2.3.3
         version: 2.9.10
@@ -37,6 +37,34 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.7.5)
+
+  examples/webhook-sink:
+    dependencies:
+      express:
+        specifier: ^4.21.2
+        version: 4.22.2
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.25
+      '@types/node':
+        specifier: ^20.17.10
+        version: 20.19.40
+      '@types/supertest':
+        specifier: ^6.0.2
+        version: 6.0.3
+      supertest:
+        specifier: ^7.0.0
+        version: 7.2.2
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.40)
 
   typescript/packages/actions:
     dependencies:
@@ -52,7 +80,7 @@ importers:
         version: 20.19.40
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.14)(tsx@4.22.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -86,7 +114,7 @@ importers:
         version: 20.19.40
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.14)(tsx@4.22.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -105,7 +133,7 @@ importers:
         version: 20.19.40
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.14)(tsx@4.22.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -148,7 +176,7 @@ importers:
         version: 3.0.1(ajv@8.20.0)
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.14)(tsx@4.22.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -176,7 +204,7 @@ importers:
         version: 20.19.40
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.14)(tsx@4.22.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -207,7 +235,7 @@ importers:
         version: 20.19.40
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.14)(tsx@4.22.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -241,7 +269,7 @@ importers:
         version: 7.2.2
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.14)(tsx@4.22.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -272,7 +300,7 @@ importers:
         version: 8.20.0
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.14)(tsx@4.22.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -312,7 +340,7 @@ importers:
         version: 20.19.40
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.14)(tsx@4.22.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -352,7 +380,7 @@ importers:
         version: 7.2.2
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.14)(tsx@4.22.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -454,6 +482,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -462,6 +496,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -478,6 +518,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -486,6 +532,12 @@ packages:
 
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -502,6 +554,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
@@ -510,6 +568,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -526,6 +590,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
@@ -534,6 +604,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -550,6 +626,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
@@ -558,6 +640,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -574,6 +662,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
@@ -582,6 +676,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -598,6 +698,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
@@ -606,6 +712,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -622,6 +734,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -630,6 +748,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -646,8 +770,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -664,8 +800,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -682,8 +830,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -700,6 +860,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
@@ -708,6 +874,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -724,6 +896,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -732,6 +910,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1563,6 +1747,11 @@ packages:
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2469,6 +2658,11 @@ packages:
       typescript:
         optional: true
 
+  tsx@4.22.0:
+    resolution: {integrity: sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo@2.9.10:
     resolution: {integrity: sha512-YBLeNT0wLoysGgQEkvBWE2GA1liGGZ1j13wa7xHTwELJx4ZhM+c2szeXj6wUOUGO86BmyhY0Q/ELWwU3WDXzZA==}
     hasBin: true
@@ -2851,10 +3045,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
@@ -2863,10 +3063,16 @@ snapshots:
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
@@ -2875,10 +3081,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
@@ -2887,10 +3099,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
@@ -2899,10 +3117,16 @@ snapshots:
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
@@ -2911,10 +3135,16 @@ snapshots:
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
@@ -2923,10 +3153,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
@@ -2935,10 +3171,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
@@ -2947,7 +3189,13 @@ snapshots:
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -2956,7 +3204,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -2965,7 +3219,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
@@ -2974,10 +3234,16 @@ snapshots:
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.21.5':
@@ -2986,10 +3252,16 @@ snapshots:
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
@@ -3928,6 +4200,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
@@ -4549,11 +4850,12 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.14):
+  postcss-load-config@6.0.1(postcss@8.5.14)(tsx@4.22.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.14
+      tsx: 4.22.0
 
   postcss@8.5.14:
     dependencies:
@@ -4837,7 +5139,7 @@ snapshots:
 
   tslib@2.7.0: {}
 
-  tsup@8.5.1(postcss@8.5.14)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.14)(tsx@4.22.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -4848,7 +5150,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.14)
+      postcss-load-config: 6.0.1(postcss@8.5.14)(tsx@4.22.0)
       resolve-from: 5.0.0
       rollup: 4.60.3
       source-map: 0.7.6
@@ -4864,6 +5166,12 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tsx@4.22.0:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   turbo@2.9.10:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.22.2
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.0
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
@@ -56,9 +59,6 @@ importers:
       supertest:
         specifier: ^7.0.0
         version: 7.2.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.22.0
       typescript:
         specifier: ^5.7.2
         version: 5.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   # Single-star glob (`*` not `**`) so post-build `dist/{cjs,esm}/package.json`
   # markers don't get picked up as nested workspaces and dirty the lockfile.
   - "typescript/packages/*"
+  - "examples/*"


### PR DESCRIPTION
## Summary

- Adds `examples/webhook-sink`: a minimal Express service that captures POST bodies, used by the forthcoming x402B e2e suite to verify the `webhook` fulfillment channel end-to-end.
- Adds `examples/*` to the pnpm workspace globs so future demo apps sit alongside this one.

This is **PR 1 of 6** in the staged rollout of the e2e test suite — see the [plan](https://github.com/bosonprotocol/x402B/issues) (TBD link) for the full sequence.

Endpoints:

| Route | Purpose |
|---|---|
| `GET  /health`    | Liveness probe. Returns `{ ok: true }`. |
| `POST /hook`      | Stores the JSON request body. Returns `204`. |
| `GET  /received`  | Returns the array of stored bodies. |
| `DELETE /received`| Clears the in-memory store. Returns `204`. |

Drafted because it's standalone but only becomes useful once PR4 (e2e stack) and PR6 (the `webhook`-channel scenario) land. Safe to merge ahead of those — it has no consumers in `main` yet.

## Test plan

- [ ] `pnpm install` resolves cleanly with `examples/*` added to the workspace
- [ ] `pnpm --filter @bosonprotocol/x402-example-webhook-sink build` (tsc --noEmit) passes
- [ ] `pnpm --filter @bosonprotocol/x402-example-webhook-sink test` runs the 4 supertest cases green
- [ ] `pnpm --filter @bosonprotocol/x402-example-webhook-sink lint` passes
- [ ] `pnpm format:check` clean
- [ ] `docker build -t x402b-webhook-sink examples/webhook-sink` succeeds (verified locally before merge)
- [ ] `docker run --rm -p 4000:4000 x402b-webhook-sink` boots and responds to `curl localhost:4000/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-memory webhook sink example service for testing webhook fulfillment.

* **Documentation**
  * Added README describing endpoints, usage, and local/Docker run instructions.

* **Tests**
  * Added integration tests validating health, receive, list, and clear behaviors.

* **Chores**
  * Added example package metadata and TypeScript/test configs.
  * Added multi-stage container build with runtime healthcheck and default port.
  * Expanded workspace packages and updated repo-level container ignore rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/56)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->