### PR TITLE
feat(server): allow buyer to update fulfillment data on redeem

### DIFF
--- a/docs/boson-impl-03-fulfillment-channels.md
+++ b/docs/boson-impl-03-fulfillment-channels.md
@@ -137,7 +137,9 @@ In the two-step flow A (`boson-createOfferAndCommit` followed later by `boson-re
 | `A` | `B` (different) | **REQUIRED** — server rejects with `FULFILLMENT_REQUIRED_ON_WALLET_CHANGE` if absent |
 | absent (legacy / atomic) | any | no-op |
 
-When a redeem request carries `fulfillment`, the server runs `channel.validate(data)` and then `channel.onCommit(exchangeId, data)` — channels treat `onCommit` as an upsert. The wire shape is identical to the commit-time `fulfillment` envelope: `{ option: string, data: <schema-of-option> | null }`.
+When a redeem request carries `fulfillment`, `option` MUST be one of the options advertised in the original 402 for that exchange. The server runs `channel.validate(data)` and then `channel.onCommit(exchangeId, data)` — channels treat `onCommit` as an upsert. The wire shape is identical to the commit-time `fulfillment` envelope: `{ option: string, data: <schema-of-option> | null }`.
+
+Because the on-chain redeem is irreversible, servers should record a pending fulfillment update before the post-redeem channel upsert and clear it only after `onCommit` succeeds. If that upsert fails, the redeem response should still report the successful transaction and include a warning such as `FULFILLMENT_UPDATE_DEFERRED`, leaving the pending update for host-side replay/reconciliation.
 
 Flow B (`boson-createOfferCommitAndRedeem`, atomic) is unaffected — the exchange reaches `REDEEMED` in a single transaction; there is no later redeem step.
 

--- a/docs/boson-impl-03-fulfillment-channels.md
+++ b/docs/boson-impl-03-fulfillment-channels.md
@@ -44,6 +44,8 @@ The `X-PAYMENT` payload includes:
 
 For channels where data is collected post-commit (e.g. `widget`), `fulfillment.data` is `null` in the X-PAYMENT and the actual collection happens between commit and redeem via the channel itself.
 
+For the two-step flow (`boson-createOfferAndCommit` followed later by `boson-redeem`), the buyer MAY also re-submit `fulfillment` at redeem time — see [Re-submission at redeem](#re-submission-at-redeem) below.
+
 ## `FulfillmentChannel` interface (TypeScript)
 
 ```ts
@@ -124,6 +126,20 @@ Seller adapters MUST refuse plain `http://` URLs — TLS is mandatory for the tr
 2. The chosen option's `buyerDataSchema` MUST validate `payload.fulfillment.data` (or `null` if schema is `null`).
 3. The server-side instance of the channel MUST be configured (at boot, not per-request).
 4. After commit acceptance, server calls `channel.onCommit(exchangeId, data)` BEFORE returning 200.
+
+## Re-submission at redeem
+
+In the two-step flow A (`boson-createOfferAndCommit` followed later by `boson-redeem`) the redeeming wallet is not guaranteed to be the same wallet that committed — the voucher NFT is transferable. The server tracks the committer wallet at commit time and applies the following rule at redeem:
+
+| Stored committer | Redeemer wallet | Buyer `fulfillment` field |
+|---|---|---|
+| `A` | `A` | OPTIONAL — when supplied, replaces previously stored data |
+| `A` | `B` (different) | **REQUIRED** — server rejects with `FULFILLMENT_REQUIRED_ON_WALLET_CHANGE` if absent |
+| absent (legacy / atomic) | any | no-op |
+
+When a redeem request carries `fulfillment`, the server runs `channel.validate(data)` and then `channel.onCommit(exchangeId, data)` — channels treat `onCommit` as an upsert. The wire shape is identical to the commit-time `fulfillment` envelope: `{ option: string, data: <schema-of-option> | null }`.
+
+Flow B (`boson-createOfferCommitAndRedeem`, atomic) is unaffected — the exchange reaches `REDEEMED` in a single transaction; there is no later redeem step.
 
 ## Client-side helper
 

--- a/docs/boson-impl-04-state-machine-and-next-actions.md
+++ b/docs/boson-impl-04-state-machine-and-next-actions.md
@@ -133,6 +133,8 @@ Stable string identifiers, one per legal transition that either party (buyer or 
 
 The action-id list and the two transition tables live in `@bosonprotocol/x402-core/state-machine` as a single source of truth. `@bosonprotocol/x402-actions` derives `next[]` from those tables at runtime; servers never hand-code transitions. Clients that don't recognise an action's prefix MUST skip it rather than try to dispatch.
 
+**`boson-redeem` and the voucher-transfer case.** Because the Boson voucher is a transferable NFT, the wallet that signs `boson-redeem` is not necessarily the wallet that committed. Servers that accept the two-step flow MUST treat the redeem step as a fulfillment-data rebinding point: see [§Re-submission at redeem in `03-fulfillment-channels.md`](./boson-impl-03-fulfillment-channels.md#re-submission-at-redeem) for the wallet-vs-fulfillment matrix.
+
 **Out of scope for `nextActions`:**
 
 - Dispute-resolver-only transitions (`decideDispute`, `refuseEscalatedDispute`) are protocol-level state changes but not buyer/seller-invokable, so they have no `boson-*` action id.

--- a/typescript/packages/server-express/src/index.ts
+++ b/typescript/packages/server-express/src/index.ts
@@ -13,4 +13,4 @@ export {
   type ExpressMiddlewareOptions,
   type X402bResLocals,
 } from "./middleware.js";
-export { mountX402b, type MountX402bOptions } from "./mount.js";
+export { INVALID_REQUEST_BODY, mountX402b, type MountX402bOptions } from "./mount.js";

--- a/typescript/packages/server-express/src/mount.ts
+++ b/typescript/packages/server-express/src/mount.ts
@@ -16,6 +16,12 @@ import { Router, type Request, type RequestHandler, type Response } from "expres
 
 import { respondWithChallenge } from "./internal/x402-challenge.js";
 
+/** Shared error code for malformed `POST /x402b/*` bodies. */
+const INVALID_REQUEST_BODY = "INVALID_REQUEST_BODY" as const;
+
+/** Hex-string check matching the `0x[0-9a-fA-F]*` shape `signedPayload` is typed as. */
+const HEX_BYTES_RE = /^0x[0-9a-fA-F]*$/;
+
 export interface MountX402bOptions {
   /**
    * Resolver invoked for the commit-time routes (`/commit`,
@@ -101,8 +107,15 @@ function performActionRoute(
         typeof body.signedPayload !== "string"
       ) {
         res.status(400).json({
-          code: "INVALID_REQUEST_BODY",
+          code: INVALID_REQUEST_BODY,
           reason: "expected JSON body with { exchangeId, signedPayload }",
+        });
+        return;
+      }
+      if (!HEX_BYTES_RE.test(body.signedPayload)) {
+        res.status(400).json({
+          code: INVALID_REQUEST_BODY,
+          reason: "signedPayload must be a 0x-prefixed hex string",
         });
         return;
       }
@@ -155,7 +168,7 @@ function buildRedeemInput(
   }
   if (!isRedeemFulfillment(fulfillment)) {
     res.status(400).json({
-      code: "INVALID_REQUEST_BODY",
+      code: INVALID_REQUEST_BODY,
       reason: "expected fulfillment to be { option: string, data: object | null } when present",
     });
     return undefined;

--- a/typescript/packages/server-express/src/mount.ts
+++ b/typescript/packages/server-express/src/mount.ts
@@ -17,7 +17,7 @@ import { Router, type Request, type RequestHandler, type Response } from "expres
 import { respondWithChallenge } from "./internal/x402-challenge.js";
 
 /** Shared error code for malformed `POST /x402b/*` bodies. */
-const INVALID_REQUEST_BODY = "INVALID_REQUEST_BODY" as const;
+export const INVALID_REQUEST_BODY = "INVALID_REQUEST_BODY" as const;
 
 /** Hex-string check matching the `0x[0-9a-fA-F]*` shape `signedPayload` is typed as. */
 const HEX_BYTES_RE = /^0x[0-9a-fA-F]*$/;

--- a/typescript/packages/server-express/src/mount.ts
+++ b/typescript/packages/server-express/src/mount.ts
@@ -9,6 +9,7 @@ import {
   X_PAYMENT_RESPONSE_HEADER,
   type CommitHandlerInput,
   type PerformActionInput,
+  type RedeemHandlerInput,
   type X402bServer,
 } from "@bosonprotocol/x402-server";
 import { Router, type Request, type RequestHandler, type Response } from "express";
@@ -89,7 +90,7 @@ function performActionRoute(
 ): RequestHandler {
   return async (req, res, next) => {
     try {
-      const body = req.body as Partial<PerformActionInput> | null | undefined;
+      const body = req.body as Partial<RedeemHandlerInput> | null | undefined;
       if (
         body == null ||
         typeof body.exchangeId !== "string" ||
@@ -101,11 +102,15 @@ function performActionRoute(
         });
         return;
       }
-      const input: PerformActionInput = {
+      const baseInput: PerformActionInput = {
         exchangeId: body.exchangeId,
         signedPayload: body.signedPayload as `0x${string}`,
       };
-      const result = await server.handlers[action](input);
+      const result =
+        action === "redeem"
+          ? await handleRedeemRoute(server, baseInput, body, res)
+          : await server.handlers[action](baseInput);
+      if (result === undefined) return;
       // No `X-PAYMENT-RESPONSE` here — post-commit actions (redeem,
       // complete, dispute raise/resolve/retract/escalate) don't carry
       // a payment. The header is reserved for commit-time settlements;
@@ -116,6 +121,48 @@ function performActionRoute(
       next(e);
     }
   };
+}
+
+async function handleRedeemRoute(
+  server: X402bServer,
+  baseInput: PerformActionInput,
+  body: Partial<RedeemHandlerInput>,
+  res: Response,
+) {
+  const input = buildRedeemInput(baseInput, body, res);
+  if (input === undefined) return undefined;
+  return await server.handlers.redeem(input);
+}
+
+function buildRedeemInput(
+  baseInput: PerformActionInput,
+  body: Partial<RedeemHandlerInput>,
+  res: Response,
+): RedeemHandlerInput | undefined {
+  if (body.fulfillment === undefined) {
+    return baseInput;
+  }
+  if (!isRedeemFulfillment(body.fulfillment)) {
+    res.status(400).json({
+      code: "INVALID_REQUEST_BODY",
+      reason:
+        "expected fulfillment to be { option: string, data: object | null } when present",
+    });
+    return undefined;
+  }
+  return { ...baseInput, fulfillment: body.fulfillment };
+}
+
+function isRedeemFulfillment(value: unknown): value is RedeemHandlerInput["fulfillment"] {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as { option?: unknown; data?: unknown };
+  if (typeof candidate.option !== "string") return false;
+  return (
+    candidate.data === null ||
+    (typeof candidate.data === "object" &&
+      candidate.data !== null &&
+      !Array.isArray(candidate.data))
+  );
 }
 
 // Stamp base64(JSON.stringify(body)) onto the `X-PAYMENT-RESPONSE` header.

--- a/typescript/packages/server-express/src/mount.ts
+++ b/typescript/packages/server-express/src/mount.ts
@@ -145,8 +145,7 @@ function buildRedeemInput(
   if (!isRedeemFulfillment(body.fulfillment)) {
     res.status(400).json({
       code: "INVALID_REQUEST_BODY",
-      reason:
-        "expected fulfillment to be { option: string, data: object | null } when present",
+      reason: "expected fulfillment to be { option: string, data: object | null } when present",
     });
     return undefined;
   }

--- a/typescript/packages/server-express/src/mount.ts
+++ b/typescript/packages/server-express/src/mount.ts
@@ -90,7 +90,11 @@ function performActionRoute(
 ): RequestHandler {
   return async (req, res, next) => {
     try {
-      const body = req.body as Partial<RedeemHandlerInput> | null | undefined;
+      // The common post-commit body is just `{ exchangeId, signedPayload }`.
+      // `fulfillment` is redeem-specific and is left as `unknown` here —
+      // `handleRedeemRoute` narrows it via `isRedeemFulfillment` before
+      // assembling the typed `RedeemHandlerInput`.
+      const body = req.body as PostCommitBody | null | undefined;
       if (
         body == null ||
         typeof body.exchangeId !== "string" ||
@@ -108,7 +112,7 @@ function performActionRoute(
       };
       const result =
         action === "redeem"
-          ? await handleRedeemRoute(server, baseInput, body, res)
+          ? await handleRedeemRoute(server, baseInput, body.fulfillment, res)
           : await server.handlers[action](baseInput);
       if (result === undefined) return;
       // No `X-PAYMENT-RESPONSE` here — post-commit actions (redeem,
@@ -123,33 +127,40 @@ function performActionRoute(
   };
 }
 
+interface PostCommitBody {
+  exchangeId?: unknown;
+  signedPayload?: unknown;
+  /** Redeem-only; untyped here and narrowed by `isRedeemFulfillment`. */
+  fulfillment?: unknown;
+}
+
 async function handleRedeemRoute(
   server: X402bServer,
   baseInput: PerformActionInput,
-  body: Partial<RedeemHandlerInput>,
+  fulfillment: unknown,
   res: Response,
 ) {
-  const input = buildRedeemInput(baseInput, body, res);
+  const input = buildRedeemInput(baseInput, fulfillment, res);
   if (input === undefined) return undefined;
   return await server.handlers.redeem(input);
 }
 
 function buildRedeemInput(
   baseInput: PerformActionInput,
-  body: Partial<RedeemHandlerInput>,
+  fulfillment: unknown,
   res: Response,
 ): RedeemHandlerInput | undefined {
-  if (body.fulfillment === undefined) {
+  if (fulfillment === undefined) {
     return baseInput;
   }
-  if (!isRedeemFulfillment(body.fulfillment)) {
+  if (!isRedeemFulfillment(fulfillment)) {
     res.status(400).json({
       code: "INVALID_REQUEST_BODY",
       reason: "expected fulfillment to be { option: string, data: object | null } when present",
     });
     return undefined;
   }
-  return { ...baseInput, fulfillment: body.fulfillment };
+  return { ...baseInput, fulfillment };
 }
 
 function isRedeemFulfillment(value: unknown): value is RedeemHandlerInput["fulfillment"] {

--- a/typescript/packages/server-express/test/express.test.ts
+++ b/typescript/packages/server-express/test/express.test.ts
@@ -11,10 +11,11 @@ import {
   signFullOffer,
   type ExchangeReader,
   type FetchLike,
+  type X402bServer,
 } from "@bosonprotocol/x402-server";
 import express from "express";
 import supertest from "supertest";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { parseSignature } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 
@@ -293,6 +294,33 @@ describe("mountX402b — convenience routes", () => {
     // commit-time settlement responses (and the future deposit-paying
     // `escalateDispute` flow).
     expect(res.headers["x-payment-response"]).toBeUndefined();
+  });
+
+  it("POST /x402b/redeem forwards optional fulfillment data", async () => {
+    const redeem = vi.fn(async () => ({
+      ok: true as const,
+      status: 200 as const,
+      body: { txHash: "0xfed", nextActions: { next: [] } },
+    }));
+    const server = { handlers: { redeem } } as unknown as X402bServer;
+
+    const app = express();
+    app.use(express.json());
+    app.use(mountX402b(server, { resolveRequirements: () => ({}) as never }));
+
+    const fulfillment = { option: "email", data: { email: "new@example.com" } };
+    const res = await supertest(app).post("/x402b/redeem").send({
+      exchangeId: "42",
+      signedPayload: "0xc0ffee",
+      fulfillment,
+    });
+
+    expect(res.status).toBe(200);
+    expect(redeem).toHaveBeenCalledWith({
+      exchangeId: "42",
+      signedPayload: "0xc0ffee",
+      fulfillment,
+    });
   });
 
   it("POST /x402b/complete rejects malformed body with 400", async () => {

--- a/typescript/packages/server-express/test/express.test.ts
+++ b/typescript/packages/server-express/test/express.test.ts
@@ -323,6 +323,23 @@ describe("mountX402b — convenience routes", () => {
     });
   });
 
+  it("POST /x402b/redeem rejects a non-hex signedPayload with 400", async () => {
+    const redeem = vi.fn();
+    const server = { handlers: { redeem } } as unknown as X402bServer;
+    const app = express();
+    app.use(express.json());
+    app.use(mountX402b(server, { resolveRequirements: () => ({}) as never }));
+
+    const res = await supertest(app).post("/x402b/redeem").send({
+      exchangeId: "42",
+      signedPayload: "not-hex",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_REQUEST_BODY");
+    expect(redeem).not.toHaveBeenCalled();
+  });
+
   it("POST /x402b/redeem rejects malformed fulfillment payload with 400", async () => {
     const redeem = vi.fn();
     const server = { handlers: { redeem } } as unknown as X402bServer;

--- a/typescript/packages/server-express/test/express.test.ts
+++ b/typescript/packages/server-express/test/express.test.ts
@@ -323,6 +323,24 @@ describe("mountX402b — convenience routes", () => {
     });
   });
 
+  it("POST /x402b/redeem rejects malformed fulfillment payload with 400", async () => {
+    const redeem = vi.fn();
+    const server = { handlers: { redeem } } as unknown as X402bServer;
+    const app = express();
+    app.use(express.json());
+    app.use(mountX402b(server, { resolveRequirements: () => ({}) as never }));
+
+    const res = await supertest(app).post("/x402b/redeem").send({
+      exchangeId: "42",
+      signedPayload: "0xc0ffee",
+      fulfillment: "not-an-object",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_REQUEST_BODY");
+    expect(redeem).not.toHaveBeenCalled();
+  });
+
   it("POST /x402b/complete rejects malformed body with 400", async () => {
     const server = await buildServer(makeStubFetch(() => ({ ok: true, txHash: "0x" })));
     const app = express();

--- a/typescript/packages/server-express/test/express.test.ts
+++ b/typescript/packages/server-express/test/express.test.ts
@@ -19,7 +19,7 @@ import { describe, expect, it, vi } from "vitest";
 import { parseSignature } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 
-import { expressMiddleware, mountX402b } from "../src/index.js";
+import { expressMiddleware, INVALID_REQUEST_BODY, mountX402b } from "../src/index.js";
 
 const ESCROW = "0xdddddddddddddddddddddddddddddddddddddddd" as const;
 const TOKEN = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" as const;
@@ -336,7 +336,7 @@ describe("mountX402b — convenience routes", () => {
     });
 
     expect(res.status).toBe(400);
-    expect(res.body.code).toBe("INVALID_REQUEST_BODY");
+    expect(res.body.code).toBe(INVALID_REQUEST_BODY);
     expect(redeem).not.toHaveBeenCalled();
   });
 
@@ -354,7 +354,7 @@ describe("mountX402b — convenience routes", () => {
     });
 
     expect(res.status).toBe(400);
-    expect(res.body.code).toBe("INVALID_REQUEST_BODY");
+    expect(res.body.code).toBe(INVALID_REQUEST_BODY);
     expect(redeem).not.toHaveBeenCalled();
   });
 
@@ -366,7 +366,7 @@ describe("mountX402b — convenience routes", () => {
 
     const res = await supertest(app).post("/x402b/complete").send({ foo: "bar" });
     expect(res.status).toBe(400);
-    expect(res.body.code).toBe("INVALID_REQUEST_BODY");
+    expect(res.body.code).toBe(INVALID_REQUEST_BODY);
   });
 
   it.each([["/x402b/commit"], ["/x402b/commit-and-redeem"]])(

--- a/typescript/packages/server/src/config.ts
+++ b/typescript/packages/server/src/config.ts
@@ -158,7 +158,25 @@ export const x402bServerConfigSchema = z
     channelRegistry: channelRegistryZodSchema,
     exchangeReader: exchangeReaderShallowSchema.optional(),
     exchangeBuyerStore: z.instanceof(Map).optional(),
-    fulfillmentChannels: z.array(fulfillmentChannelShallowSchema).optional(),
+    fulfillmentChannels: z
+      .array(fulfillmentChannelShallowSchema)
+      .superRefine((channels, ctx) => {
+        // Duplicate ids would let one channel silently shadow another
+        // (the redeem handler picks via `find(c => c.id === option)`).
+        const seen = new Set<string>();
+        const duplicates = new Set<string>();
+        for (const c of channels) {
+          if (seen.has(c.id)) duplicates.add(c.id);
+          seen.add(c.id);
+        }
+        if (duplicates.size > 0) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `fulfillmentChannels has duplicate id(s): ${[...duplicates].join(", ")}`,
+          });
+        }
+      })
+      .optional(),
   })
   .strict()
   .superRefine((cfg, ctx) => {

--- a/typescript/packages/server/src/config.ts
+++ b/typescript/packages/server/src/config.ts
@@ -80,6 +80,26 @@ export interface X402bServerConfig {
    */
   exchangeBuyerStore?: Map<string, Address>;
   /**
+   * Server-side store of the fulfillment option ids advertised for
+   * each Flow A exchange (keyed by `exchangeId`). Populated from the
+   * original `PaymentRequirements` after commit verification and read
+   * at redeem time so re-submitted fulfillment data cannot switch to a
+   * channel the offer never advertised.
+   *
+   * Optional in the config: when omitted, `createX402bServer` wires up
+   * an in-memory `Map`. Hosts that provide `exchangeBuyerStore` for
+   * cross-process tracking should normally provide this store too.
+   */
+  exchangeFulfillmentOptionStore?: Map<string, readonly string[]>;
+  /**
+   * Pending fulfillment updates that reached REDEEMED on-chain but
+   * failed the server-side `channel.onCommit(...)` upsert. The redeem
+   * handler records the update here before attempting the channel write,
+   * deletes it on success, and leaves it behind with the error message
+   * on failure so the host can replay/reconcile out of band.
+   */
+  redeemFulfillmentUpdateStore?: Map<string, RedeemFulfillmentUpdate>;
+  /**
    * Fulfillment channels the server accepts at redeem time when the
    * client re-submits delivery data. Structurally a subset of
    * `@bosonprotocol/x402-fulfillment`'s `FulfillmentChannel` — only
@@ -103,6 +123,15 @@ export interface RedeemFulfillmentChannel {
   readonly id: string;
   validate(data: Record<string, unknown> | null): { ok: true } | { ok: false; reason: string };
   onCommit(exchangeId: string, data: Record<string, unknown> | null): Promise<void>;
+}
+
+export interface RedeemFulfillmentUpdate {
+  exchangeId: string;
+  option: string;
+  data: Record<string, unknown> | null;
+  redeemer: Address;
+  recordedAt: number;
+  error?: string;
 }
 
 const httpUrlSchema = z
@@ -158,6 +187,8 @@ export const x402bServerConfigSchema = z
     channelRegistry: channelRegistryZodSchema,
     exchangeReader: exchangeReaderShallowSchema.optional(),
     exchangeBuyerStore: z.instanceof(Map).optional(),
+    exchangeFulfillmentOptionStore: z.instanceof(Map).optional(),
+    redeemFulfillmentUpdateStore: z.instanceof(Map).optional(),
     fulfillmentChannels: z
       .array(fulfillmentChannelShallowSchema)
       .superRefine((channels, ctx) => {

--- a/typescript/packages/server/src/config.ts
+++ b/typescript/packages/server/src/config.ts
@@ -67,6 +67,42 @@ export interface X402bServerConfig {
    * for the interface.
    */
   exchangeReader?: ExchangeReader;
+  /**
+   * Server-side store of the buyer wallet that originally committed
+   * each exchange (keyed by `exchangeId`). Populated on Flow A commit
+   * acceptance and read at redeem time to detect voucher transfers —
+   * a redeemer whose wallet differs from the recorded committer MUST
+   * supply fresh `fulfillment` data; same-wallet redeemers MAY.
+   *
+   * Optional in the config: when omitted, `createX402bServer` wires up
+   * an in-memory `Map`. Hosts that need cross-process / persistent
+   * tracking supply their own `Map`-shaped backing store.
+   */
+  exchangeBuyerStore?: Map<string, Address>;
+  /**
+   * Fulfillment channels the server accepts at redeem time when the
+   * client re-submits delivery data. Structurally a subset of
+   * `@bosonprotocol/x402-fulfillment`'s `FulfillmentChannel` — only
+   * `id`, `validate`, and `onCommit` are read here, so existing
+   * channel instances pass through directly. Required iff a host
+   * wants to accept redeem-time fulfillment updates; absent means
+   * redeem requests carrying `fulfillment` are rejected with
+   * `FULFILLMENT_CHANNELS_NOT_CONFIGURED`.
+   */
+  fulfillmentChannels?: readonly RedeemFulfillmentChannel[];
+}
+
+/**
+ * Minimal structural slice of `FulfillmentChannel` the redeem
+ * handler needs. Kept inline so `@bosonprotocol/x402-server` does
+ * not depend on `@bosonprotocol/x402-fulfillment` (avoids a hard
+ * coupling between the resource-server SDK and a specific channel
+ * package); any real channel implementation is type-compatible.
+ */
+export interface RedeemFulfillmentChannel {
+  readonly id: string;
+  validate(data: Record<string, unknown> | null): { ok: true } | { ok: false; reason: string };
+  onCommit(exchangeId: string, data: Record<string, unknown> | null): Promise<void>;
 }
 
 const httpUrlSchema = z
@@ -93,6 +129,14 @@ const exchangeReaderShallowSchema = z
   })
   .passthrough();
 
+const fulfillmentChannelShallowSchema = z
+  .object({
+    id: z.string().min(1),
+    validate: z.function(),
+    onCommit: z.function(),
+  })
+  .passthrough();
+
 /**
  * zod validator for `X402bServerConfig`. Shallow on the signer +
  * exchange reader (viem account types bring their own structural
@@ -113,6 +157,8 @@ export const x402bServerConfigSchema = z
       .strict(),
     channelRegistry: channelRegistryZodSchema,
     exchangeReader: exchangeReaderShallowSchema.optional(),
+    exchangeBuyerStore: z.instanceof(Map).optional(),
+    fulfillmentChannels: z.array(fulfillmentChannelShallowSchema).optional(),
   })
   .strict()
   .superRefine((cfg, ctx) => {

--- a/typescript/packages/server/src/handlers/commit-and-redeem.ts
+++ b/typescript/packages/server/src/handlers/commit-and-redeem.ts
@@ -40,6 +40,12 @@ export interface CommitHandlerContext {
    * the write — the redeem step has already happened on-chain.
    */
   exchangeBuyerStore: Map<string, Address>;
+  /**
+   * Per-exchange fulfillment option policy. Flow A writes the ids
+   * advertised by the original requirements so redeem-time updates are
+   * constrained to the offer's own channel set.
+   */
+  exchangeFulfillmentOptionStore: Map<string, readonly string[]>;
 }
 
 export interface CommitOk {
@@ -162,6 +168,10 @@ async function handleCommitImpl(
   // is already in REDEEMED — there is no later redeem step to gate.
   if (expected.expectedState === ExchangeState.COMMITTED) {
     ctx.exchangeBuyerStore.set(settleResult.exchangeId, decoded.payload.payload.buyer);
+    ctx.exchangeFulfillmentOptionStore.set(
+      settleResult.exchangeId,
+      input.requirements.fulfillment?.options.map((option) => option.id) ?? [],
+    );
   }
 
   // Both commit-side actions transition to non-DISPUTED states

--- a/typescript/packages/server/src/handlers/commit-and-redeem.ts
+++ b/typescript/packages/server/src/handlers/commit-and-redeem.ts
@@ -6,7 +6,7 @@
 // envelope.
 
 import { ExchangeState } from "@bosonprotocol/x402-actions";
-import type { EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
+import type { Address, EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { ActionId } from "@bosonprotocol/x402-core/state-machine";
 
 import { emitNextActions } from "./next-actions.js";
@@ -33,6 +33,13 @@ export interface CommitHandlerContext {
   config: X402bServerConfig;
   facilitator: FacilitatorClient;
   exchangeReader: ExchangeReader;
+  /**
+   * Committer-wallet store. Flow A writes the buyer address keyed by
+   * the new `exchangeId` so the redeem handler can detect
+   * voucher-transfer mid-flight. Flow B (atomic commit+redeem) skips
+   * the write — the redeem step has already happened on-chain.
+   */
+  exchangeBuyerStore: Map<string, Address>;
 }
 
 export interface CommitOk {
@@ -148,6 +155,13 @@ async function handleCommitImpl(
         got: verifyResult.got,
       },
     );
+  }
+
+  // Flow A only: persist the committer wallet so the redeem handler
+  // can detect a voucher transfer between commit and redeem. Flow B
+  // is already in REDEEMED — there is no later redeem step to gate.
+  if (expected.expectedState === ExchangeState.COMMITTED) {
+    ctx.exchangeBuyerStore.set(settleResult.exchangeId, decoded.payload.payload.buyer);
   }
 
   // Both commit-side actions transition to non-DISPUTED states

--- a/typescript/packages/server/src/handlers/index.ts
+++ b/typescript/packages/server/src/handlers/index.ts
@@ -32,4 +32,5 @@ export {
   type HandlerErrorBody,
   type HandlerResult,
   type HandlerStatus,
+  type HandlerWarning,
 } from "./types.js";

--- a/typescript/packages/server/src/handlers/index.ts
+++ b/typescript/packages/server/src/handlers/index.ts
@@ -22,6 +22,8 @@ export {
   type PerformActionContext,
   type PerformActionInput,
   type PerformActionOk,
+  type RedeemHandlerContext,
+  type RedeemHandlerInput,
 } from "./perform-action.js";
 export { emitNextActions, type EmitNextActionsInput } from "./next-actions.js";
 export {

--- a/typescript/packages/server/src/handlers/perform-action.ts
+++ b/typescript/packages/server/src/handlers/perform-action.ts
@@ -6,7 +6,9 @@
 // fresh `nextActions`.
 
 import { ExchangeState } from "@bosonprotocol/x402-actions";
+import type { Address } from "@bosonprotocol/x402-core/schemes/escrow";
 import { ACTION_POST_STATE, type ActionId } from "@bosonprotocol/x402-core/state-machine";
+import { decodeSignedPayload } from "@bosonprotocol/x402-evm";
 import type { Hex } from "viem";
 
 import { emitNextActions } from "./next-actions.js";
@@ -27,10 +29,25 @@ export interface PerformActionInput {
   signedPayload: Hex;
 }
 
+/**
+ * Redeem-time variant of `PerformActionInput`. Carries an optional
+ * `fulfillment` update so a redeemer can revise the delivery target
+ * between Flow A commit and redeem. Required when the redeeming
+ * wallet differs from the committing wallet (voucher transfer);
+ * optional when they match.
+ */
+export interface RedeemHandlerInput extends PerformActionInput {
+  fulfillment?: { option: string; data: Record<string, unknown> | null };
+}
+
 export interface PerformActionContext {
   config: X402bServerConfig;
   facilitator: FacilitatorClient;
   exchangeReader: ExchangeReader;
+}
+
+export interface RedeemHandlerContext extends PerformActionContext {
+  exchangeBuyerStore: Map<string, Address>;
 }
 
 export interface PerformActionOk {
@@ -130,9 +147,85 @@ export async function handlePerformAction(
   return handlerOk({ txHash: result.txHash, nextActions });
 }
 
+/**
+ * Redeem handler. Before forwarding to the facilitator, runs a
+ * wallet-rebinding check against `exchangeBuyerStore`:
+ *
+ * - If a committer wallet is on file and differs from the recovered
+ *   redeemer wallet, the client MUST supply `fulfillment` (so the
+ *   new holder's delivery target replaces the original committer's).
+ * - If a committer wallet is on file and matches the redeemer, the
+ *   client MAY omit `fulfillment` — existing data stays in place.
+ * - If no committer record exists (legacy exchange / atomic flow
+ *   that never wrote one), the wallet check is skipped.
+ *
+ * When `fulfillment` is supplied (either branch), the matching
+ * channel's `validate` runs and `onCommit(exchangeId, data)` is
+ * called to upsert the stored delivery target. Channels already
+ * treat `onCommit` as an upsert.
+ */
+export async function handleRedeem(
+  input: RedeemHandlerInput,
+  ctx: RedeemHandlerContext,
+): Promise<HandlerResult<PerformActionOk>> {
+  let redeemer: Address;
+  try {
+    redeemer = decodeSignedPayload(input.signedPayload).from as Address;
+  } catch (e) {
+    return handlerErr(
+      400,
+      "SIGNED_PAYLOAD_DECODE_FAILED",
+      e instanceof Error ? e.message : "signedPayload could not be decoded",
+    );
+  }
+
+  const committer = ctx.exchangeBuyerStore.get(input.exchangeId);
+  const walletChanged = committer !== undefined && !addressesEqual(committer, redeemer);
+
+  if (walletChanged && input.fulfillment === undefined) {
+    return handlerErr(
+      400,
+      "FULFILLMENT_REQUIRED_ON_WALLET_CHANGE",
+      "redeemer wallet differs from committer — new fulfillment data is required",
+      { exchangeId: input.exchangeId, committer, redeemer },
+    );
+  }
+
+  if (input.fulfillment !== undefined) {
+    const channels = ctx.config.fulfillmentChannels;
+    if (channels === undefined) {
+      return handlerErr(
+        400,
+        "FULFILLMENT_CHANNELS_NOT_CONFIGURED",
+        "server received redeem-time fulfillment data but has no fulfillmentChannels registered",
+      );
+    }
+    const channel = channels.find((c) => c.id === input.fulfillment!.option);
+    if (channel === undefined) {
+      return handlerErr(
+        400,
+        "FULFILLMENT_OPTION_UNKNOWN",
+        `fulfillment.option '${input.fulfillment.option}' is not registered with the server`,
+        { option: input.fulfillment.option, registered: channels.map((c) => c.id) },
+      );
+    }
+    const validation = channel.validate(input.fulfillment.data);
+    if (!validation.ok) {
+      return handlerErr(400, "FULFILLMENT_DATA_INVALID", validation.reason, {
+        option: input.fulfillment.option,
+      });
+    }
+    await channel.onCommit(input.exchangeId, input.fulfillment.data);
+  }
+
+  return handlePerformAction("boson-redeem", input, ctx);
+}
+
+function addressesEqual(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
 /** Per-action sugar — preserves the action id at the type level. */
-export const handleRedeem = (input: PerformActionInput, ctx: PerformActionContext) =>
-  handlePerformAction("boson-redeem", input, ctx);
 export const handleComplete = (input: PerformActionInput, ctx: PerformActionContext) =>
   handlePerformAction("boson-completeExchange", input, ctx);
 export const handleDisputeRaise = (input: PerformActionInput, ctx: PerformActionContext) =>

--- a/typescript/packages/server/src/handlers/perform-action.ts
+++ b/typescript/packages/server/src/handlers/perform-action.ts
@@ -239,7 +239,17 @@ export async function handleRedeem(
         { option: input.fulfillment.option, registered: channels.map((c) => c.id) },
       );
     }
-    const validation = channel.validate(input.fulfillment.data);
+    // Host-supplied `validate` callbacks are arbitrary code — treat a
+    // thrown error the same as `{ ok: false }` so a buggy / strict
+    // adapter surfaces as a 400 the buyer can correct, not a 500.
+    let validation: ReturnType<RedeemFulfillmentChannel["validate"]>;
+    try {
+      validation = channel.validate(input.fulfillment.data);
+    } catch (e) {
+      return handlerErr(400, "FULFILLMENT_DATA_INVALID", errorMessage(e), {
+        option: input.fulfillment.option,
+      });
+    }
     if (!validation.ok) {
       return handlerErr(400, "FULFILLMENT_DATA_INVALID", validation.reason, {
         option: input.fulfillment.option,

--- a/typescript/packages/server/src/handlers/perform-action.ts
+++ b/typescript/packages/server/src/handlers/perform-action.ts
@@ -12,10 +12,14 @@ import { decodeSignedPayload } from "@bosonprotocol/x402-evm";
 import type { Hex } from "viem";
 
 import { emitNextActions } from "./next-actions.js";
-import { handlerErr, handlerOk, type HandlerResult } from "./types.js";
+import { handlerErr, handlerOk, type HandlerResult, type HandlerWarning } from "./types.js";
 import type { FacilitatorClient } from "../facilitator/client.js";
 import { FacilitatorHttpError } from "../facilitator/errors.js";
-import type { RedeemFulfillmentChannel, X402bServerConfig } from "../config.js";
+import type {
+  RedeemFulfillmentChannel,
+  RedeemFulfillmentUpdate,
+  X402bServerConfig,
+} from "../config.js";
 import {
   verifyExchange,
   type ExchangeReader,
@@ -48,10 +52,13 @@ export interface PerformActionContext {
 
 export interface RedeemHandlerContext extends PerformActionContext {
   exchangeBuyerStore: Map<string, Address>;
+  exchangeFulfillmentOptionStore: Map<string, readonly string[]>;
+  redeemFulfillmentUpdateStore: Map<string, RedeemFulfillmentUpdate>;
 }
 
 export interface PerformActionOk {
   txHash: string;
+  warnings?: HandlerWarning[];
 }
 
 /** Generic post-commit handler — wired from each of the per-action wrappers below. */
@@ -197,6 +204,27 @@ export async function handleRedeem(
 
   let resolvedChannel: RedeemFulfillmentChannel | undefined;
   if (input.fulfillment !== undefined) {
+    const advertisedOptions = ctx.exchangeFulfillmentOptionStore.get(input.exchangeId);
+    if (committer !== undefined && advertisedOptions === undefined) {
+      return handlerErr(
+        500,
+        "FULFILLMENT_OPTIONS_NOT_TRACKED",
+        "server has a committer record for this exchange but no fulfillment option policy",
+        { exchangeId: input.exchangeId },
+      );
+    }
+    if (
+      advertisedOptions !== undefined &&
+      !advertisedOptions.includes(input.fulfillment.option)
+    ) {
+      return handlerErr(
+        400,
+        "FULFILLMENT_OPTION_NOT_ADVERTISED",
+        `fulfillment.option '${input.fulfillment.option}' was not advertised for this exchange`,
+        { option: input.fulfillment.option, advertised: advertisedOptions },
+      );
+    }
+
     const channels = ctx.config.fulfillmentChannels;
     if (channels === undefined) {
       return handlerErr(
@@ -227,18 +255,62 @@ export async function handleRedeem(
   if (!result.ok) return result;
 
   // Redeem confirmed REDEEMED on-chain — only now is it safe to
-  // upsert the channel's delivery-target store and free the
-  // committer-wallet entry (the rebinding rule no longer applies).
+  // upsert the channel's delivery-target store. Record a pending
+  // update first so a failing channel write leaves the host with an
+  // explicit recovery item instead of losing the buyer's new target.
+  let warning: HandlerWarning | undefined;
   if (resolvedChannel !== undefined && input.fulfillment !== undefined) {
-    await resolvedChannel.onCommit(input.exchangeId, input.fulfillment.data);
+    const pending: RedeemFulfillmentUpdate = {
+      exchangeId: input.exchangeId,
+      option: input.fulfillment.option,
+      data: input.fulfillment.data,
+      redeemer,
+      recordedAt: Date.now(),
+    };
+    ctx.redeemFulfillmentUpdateStore.set(input.exchangeId, pending);
+    try {
+      await resolvedChannel.onCommit(input.exchangeId, input.fulfillment.data);
+      ctx.redeemFulfillmentUpdateStore.delete(input.exchangeId);
+    } catch (e) {
+      const reason = errorMessage(e);
+      ctx.redeemFulfillmentUpdateStore.set(input.exchangeId, { ...pending, error: reason });
+      warning = {
+        code: "FULFILLMENT_UPDATE_DEFERRED",
+        reason:
+          "redeem succeeded on-chain, but the server could not persist the fulfillment update",
+        details: {
+          exchangeId: input.exchangeId,
+          option: input.fulfillment.option,
+          error: reason,
+        },
+      };
+    }
   }
+
+  // The exchange is REDEEMED even if the fulfillment write is deferred,
+  // so the wallet-rebinding gate no longer applies to this exchange.
   ctx.exchangeBuyerStore.delete(input.exchangeId);
+  ctx.exchangeFulfillmentOptionStore.delete(input.exchangeId);
+
+  if (warning !== undefined) {
+    return {
+      ...result,
+      body: {
+        ...result.body,
+        warnings: [...(result.body.warnings ?? []), warning],
+      },
+    };
+  }
 
   return result;
 }
 
 function addressesEqual(a: string, b: string): boolean {
   return a.toLowerCase() === b.toLowerCase();
+}
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
 }
 
 /** Per-action sugar — preserves the action id at the type level. */

--- a/typescript/packages/server/src/handlers/perform-action.ts
+++ b/typescript/packages/server/src/handlers/perform-action.ts
@@ -15,7 +15,7 @@ import { emitNextActions } from "./next-actions.js";
 import { handlerErr, handlerOk, type HandlerResult } from "./types.js";
 import type { FacilitatorClient } from "../facilitator/client.js";
 import { FacilitatorHttpError } from "../facilitator/errors.js";
-import type { X402bServerConfig } from "../config.js";
+import type { RedeemFulfillmentChannel, X402bServerConfig } from "../config.js";
 import {
   verifyExchange,
   type ExchangeReader,
@@ -160,9 +160,13 @@ export async function handlePerformAction(
  *   that never wrote one), the wallet check is skipped.
  *
  * When `fulfillment` is supplied (either branch), the matching
- * channel's `validate` runs and `onCommit(exchangeId, data)` is
- * called to upsert the stored delivery target. Channels already
- * treat `onCommit` as an upsert.
+ * channel's `validate` runs up-front; the corresponding
+ * `onCommit(exchangeId, data)` upsert is deferred until *after* the
+ * facilitator + state verification confirm the exchange reached
+ * `REDEEMED`, so a failed redeem leaves the stored delivery target
+ * unchanged. On success the committer-wallet entry is also dropped
+ * from `exchangeBuyerStore` — the rebinding check is moot once the
+ * voucher is burned.
  */
 export async function handleRedeem(
   input: RedeemHandlerInput,
@@ -191,6 +195,7 @@ export async function handleRedeem(
     );
   }
 
+  let resolvedChannel: RedeemFulfillmentChannel | undefined;
   if (input.fulfillment !== undefined) {
     const channels = ctx.config.fulfillmentChannels;
     if (channels === undefined) {
@@ -215,10 +220,21 @@ export async function handleRedeem(
         option: input.fulfillment.option,
       });
     }
-    await channel.onCommit(input.exchangeId, input.fulfillment.data);
+    resolvedChannel = channel;
   }
 
-  return handlePerformAction("boson-redeem", input, ctx);
+  const result = await handlePerformAction("boson-redeem", input, ctx);
+  if (!result.ok) return result;
+
+  // Redeem confirmed REDEEMED on-chain — only now is it safe to
+  // upsert the channel's delivery-target store and free the
+  // committer-wallet entry (the rebinding rule no longer applies).
+  if (resolvedChannel !== undefined && input.fulfillment !== undefined) {
+    await resolvedChannel.onCommit(input.exchangeId, input.fulfillment.data);
+  }
+  ctx.exchangeBuyerStore.delete(input.exchangeId);
+
+  return result;
 }
 
 function addressesEqual(a: string, b: string): boolean {

--- a/typescript/packages/server/src/handlers/perform-action.ts
+++ b/typescript/packages/server/src/handlers/perform-action.ts
@@ -213,10 +213,7 @@ export async function handleRedeem(
         { exchangeId: input.exchangeId },
       );
     }
-    if (
-      advertisedOptions !== undefined &&
-      !advertisedOptions.includes(input.fulfillment.option)
-    ) {
+    if (advertisedOptions !== undefined && !advertisedOptions.includes(input.fulfillment.option)) {
       return handlerErr(
         400,
         "FULFILLMENT_OPTION_NOT_ADVERTISED",

--- a/typescript/packages/server/src/handlers/types.ts
+++ b/typescript/packages/server/src/handlers/types.ts
@@ -22,6 +22,14 @@ export interface HandlerErrorBody {
   details?: unknown;
 }
 
+export interface HandlerWarning {
+  /** Stable identifier — caller branches on this rather than the human-readable `reason`. */
+  code: string;
+  reason: string;
+  /** Optional rich detail — tx hash, exchange id, deferred operation, etc. */
+  details?: unknown;
+}
+
 export function handlerOk<TBody>(
   body: TBody & { nextActions: EscrowNextActions },
 ): HandlerResult<TBody> {

--- a/typescript/packages/server/src/index.ts
+++ b/typescript/packages/server/src/index.ts
@@ -11,6 +11,7 @@ export {
   assertChannelRegistryEscrowMatch,
   x402bServerConfigSchema,
   type RedeemFulfillmentChannel,
+  type RedeemFulfillmentUpdate,
   type SellerSigner,
   type X402bServerConfig,
 } from "./config.js";
@@ -65,6 +66,7 @@ export {
   type HandlerErrorBody,
   type HandlerResult,
   type HandlerStatus,
+  type HandlerWarning,
   type PerformActionContext,
   type PerformActionInput,
   type PerformActionOk,

--- a/typescript/packages/server/src/index.ts
+++ b/typescript/packages/server/src/index.ts
@@ -10,6 +10,7 @@ export { createX402bServer, type BuildRequirementsInput, type X402bServer } from
 export {
   assertChannelRegistryEscrowMatch,
   x402bServerConfigSchema,
+  type RedeemFulfillmentChannel,
   type SellerSigner,
   type X402bServerConfig,
 } from "./config.js";
@@ -67,6 +68,8 @@ export {
   type PerformActionContext,
   type PerformActionInput,
   type PerformActionOk,
+  type RedeemHandlerContext,
+  type RedeemHandlerInput,
 } from "./handlers/index.js";
 export {
   verifyExchange,

--- a/typescript/packages/server/src/server.ts
+++ b/typescript/packages/server/src/server.ts
@@ -5,6 +5,7 @@
 
 import type { UnsignedFullOffer } from "@bosonprotocol/x402-core/eip712";
 import type {
+  Address,
   BosonOfferRef,
   EscrowPaymentRequirements,
 } from "@bosonprotocol/x402-core/schemes/escrow";
@@ -31,6 +32,7 @@ import {
   type HandlerResult,
   type PerformActionInput,
   type PerformActionOk,
+  type RedeemHandlerInput,
 } from "./handlers/index.js";
 import { stampFacilitatorEndpoints } from "./internal/facilitator-endpoints.js";
 import type { ExchangeReader } from "./onchain/verify-exchange.js";
@@ -60,7 +62,7 @@ export interface X402bServer {
   readonly handlers: {
     commit(input: CommitHandlerInput): Promise<HandlerResult<CommitOk>>;
     commitAndRedeem(input: CommitHandlerInput): Promise<HandlerResult<CommitOk>>;
-    redeem(input: PerformActionInput): Promise<HandlerResult<PerformActionOk>>;
+    redeem(input: RedeemHandlerInput): Promise<HandlerResult<PerformActionOk>>;
     complete(input: PerformActionInput): Promise<HandlerResult<PerformActionOk>>;
     disputeRaise(input: PerformActionInput): Promise<HandlerResult<PerformActionOk>>;
     disputeResolve(input: PerformActionInput): Promise<HandlerResult<PerformActionOk>>;
@@ -93,6 +95,10 @@ export function createX402bServer(config: X402bServerConfig): X402bServer {
   assertChannelRegistryEscrowMatch(validated);
 
   const facilitator = createFacilitatorClient({ url: validated.facilitator.url });
+  // Default to a fresh in-memory store when the host doesn't supply
+  // one. Single shared reference for the lifetime of this server — so
+  // commit-time writes and redeem-time reads observe the same Map.
+  const exchangeBuyerStore: Map<string, Address> = validated.exchangeBuyerStore ?? new Map();
 
   const signOffer = (unsigned: UnsignedFullOffer): Promise<BosonOfferRef> =>
     signFullOffer({
@@ -137,18 +143,21 @@ export function createX402bServer(config: X402bServerConfig): X402bServer {
           config: validated,
           facilitator,
           exchangeReader: await requireReader("commit"),
+          exchangeBuyerStore,
         }),
       commitAndRedeem: async (input) =>
         handleCommitAndRedeem(input, {
           config: validated,
           facilitator,
           exchangeReader: await requireReader("commitAndRedeem"),
+          exchangeBuyerStore,
         }),
       redeem: async (input) =>
         handleRedeem(input, {
           config: validated,
           facilitator,
           exchangeReader: await requireReader("redeem"),
+          exchangeBuyerStore,
         }),
       complete: async (input) =>
         handleComplete(input, {

--- a/typescript/packages/server/src/server.ts
+++ b/typescript/packages/server/src/server.ts
@@ -15,6 +15,7 @@ import { signFullOffer } from "./challenge/sign-full-offer.js";
 import {
   assertChannelRegistryEscrowMatch,
   x402bServerConfigSchema,
+  type RedeemFulfillmentUpdate,
   type X402bServerConfig,
 } from "./config.js";
 import { createFacilitatorClient, type FacilitatorClient } from "./facilitator/client.js";
@@ -99,6 +100,13 @@ export function createX402bServer(config: X402bServerConfig): X402bServer {
   // one. Single shared reference for the lifetime of this server — so
   // commit-time writes and redeem-time reads observe the same Map.
   const exchangeBuyerStore: Map<string, Address> = validated.exchangeBuyerStore ?? new Map();
+  const exchangeFulfillmentOptionStore: Map<string, readonly string[]> =
+    validated.exchangeFulfillmentOptionStore ?? new Map();
+  const redeemFulfillmentUpdateStore: Map<string, RedeemFulfillmentUpdate> =
+    validated.redeemFulfillmentUpdateStore ?? new Map();
+  validated.exchangeBuyerStore = exchangeBuyerStore;
+  validated.exchangeFulfillmentOptionStore = exchangeFulfillmentOptionStore;
+  validated.redeemFulfillmentUpdateStore = redeemFulfillmentUpdateStore;
 
   const signOffer = (unsigned: UnsignedFullOffer): Promise<BosonOfferRef> =>
     signFullOffer({
@@ -144,6 +152,7 @@ export function createX402bServer(config: X402bServerConfig): X402bServer {
           facilitator,
           exchangeReader: await requireReader("commit"),
           exchangeBuyerStore,
+          exchangeFulfillmentOptionStore,
         }),
       commitAndRedeem: async (input) =>
         handleCommitAndRedeem(input, {
@@ -151,6 +160,7 @@ export function createX402bServer(config: X402bServerConfig): X402bServer {
           facilitator,
           exchangeReader: await requireReader("commitAndRedeem"),
           exchangeBuyerStore,
+          exchangeFulfillmentOptionStore,
         }),
       redeem: async (input) =>
         handleRedeem(input, {
@@ -158,6 +168,8 @@ export function createX402bServer(config: X402bServerConfig): X402bServer {
           facilitator,
           exchangeReader: await requireReader("redeem"),
           exchangeBuyerStore,
+          exchangeFulfillmentOptionStore,
+          redeemFulfillmentUpdateStore,
         }),
       complete: async (input) =>
         handleComplete(input, {

--- a/typescript/packages/server/test/handlers.test.ts
+++ b/typescript/packages/server/test/handlers.test.ts
@@ -16,6 +16,7 @@ import {
   type ExchangeSnapshot,
   type FetchLike,
   type RedeemFulfillmentChannel,
+  type RedeemFulfillmentUpdate,
 } from "../src/index.js";
 import {
   CHAIN_ID,
@@ -436,17 +437,20 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
     validations: Array<Record<string, unknown> | null>;
     commits: Array<{ exchangeId: string; data: Record<string, unknown> | null }>;
     failNext: boolean;
+    throwOnCommit: boolean;
   } {
     const spy: ReturnType<typeof makeSpyChannel> = {
       id,
       validations: [],
       commits: [],
       failNext: false,
+      throwOnCommit: false,
       validate(data) {
         spy.validations.push(data);
         return spy.failNext ? { ok: false, reason: "bad data" } : { ok: true };
       },
       async onCommit(exchangeId, data) {
+        if (spy.throwOnCommit) throw new Error("store unavailable");
         spy.commits.push({ exchangeId, data });
       },
     };
@@ -457,6 +461,8 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
     facilitator?: (path: string) => unknown;
     reader: ExchangeReader;
     buyerStore: Map<string, `0x${string}`>;
+    optionStore?: Map<string, readonly string[]>;
+    pendingStore?: Map<string, RedeemFulfillmentUpdate>;
     channels?: readonly RedeemFulfillmentChannel[];
   }) {
     const seller = privateKeyToAccount(TEST_SELLER_PK);
@@ -475,6 +481,12 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
         channelRegistry: { channels: ["server", "facilitator", "onchain"], escrow: ESCROW },
         exchangeReader: opts.reader,
         exchangeBuyerStore: opts.buyerStore,
+        ...(opts.optionStore !== undefined
+          ? { exchangeFulfillmentOptionStore: opts.optionStore }
+          : {}),
+        ...(opts.pendingStore !== undefined
+          ? { redeemFulfillmentUpdateStore: opts.pendingStore }
+          : {}),
         ...(opts.channels !== undefined ? { fulfillmentChannels: opts.channels } : {}),
       });
       return { server, stub, restore: () => (globalThis.fetch = originalFetch) };
@@ -523,6 +535,61 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
     }
   });
 
+  it("Flow A commit writes advertised fulfillment option ids for redeem-time policy", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>();
+    const optionStore = new Map<string, readonly string[]>();
+    const reader = makeReader({
+      state: ExchangeState.COMMITTED,
+      seller: fx.requirements.offer.creator,
+      exchangeToken: TOKEN,
+      price: fx.requirements.amount,
+    });
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+    const stub = makeStubFacilitatorFetch((path) =>
+      path === "/settle"
+        ? { ok: true, exchangeId: "42", txHash: "0xabc" }
+        : { ok: false, code: "INTERNAL_ERROR", reason: "unexpected" },
+    );
+    const requirements = {
+      ...fx.requirements,
+      fulfillment: {
+        required: true,
+        options: [
+          { id: "email", schema: null },
+          { id: "xmtp", schema: null },
+        ],
+      },
+    };
+    const payload = {
+      ...fx.payload,
+      fulfillment: { option: "email", data: { email: "buyer@example.com" } },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = stub.fetch as unknown as typeof globalThis.fetch;
+    try {
+      const server = createX402bServer({
+        network: NETWORK,
+        chainId: CHAIN_ID,
+        escrow: ESCROW,
+        signer: seller,
+        facilitator: { url: facilitatorUrl },
+        channelRegistry: { channels: ["server", "facilitator", "onchain"], escrow: ESCROW },
+        exchangeReader: reader,
+        exchangeBuyerStore: buyerStore,
+        exchangeFulfillmentOptionStore: optionStore,
+      });
+      const result = await server.handlers.commit({
+        paymentHeader: makeBuyerHeader(payload),
+        requirements,
+      });
+      expect(result.ok).toBe(true);
+      expect(optionStore.get("42")).toEqual(["email", "xmtp"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("same-wallet redeemer without fulfillment → 200, no channel calls", async () => {
     const fx = await makePaymentFixture();
     const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
@@ -548,10 +615,12 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
   it("same-wallet redeemer with valid fulfillment → 200, channel.onCommit called", async () => {
     const fx = await makePaymentFixture();
     const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const optionStore = new Map<string, readonly string[]>([["42", ["email"]]]);
     const channel = makeSpyChannel();
     const { server, restore } = await buildRedeemServer({
       reader: makeRedeemReader(fx),
       buyerStore,
+      optionStore,
       channels: [channel],
     });
     try {
@@ -597,10 +666,12 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
   it("different-wallet redeemer with valid fulfillment → 200, channel.onCommit called", async () => {
     const fx = await makePaymentFixture();
     const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const optionStore = new Map<string, readonly string[]>([["42", ["email"]]]);
     const channel = makeSpyChannel();
     const { server, restore } = await buildRedeemServer({
       reader: makeRedeemReader(fx),
       buyerStore,
+      optionStore,
       channels: [channel],
     });
     try {
@@ -618,13 +689,73 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
     }
   });
 
+  it("fulfillment option not advertised for the exchange → 400 FULFILLMENT_OPTION_NOT_ADVERTISED", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const optionStore = new Map<string, readonly string[]>([["42", ["email"]]]);
+    const email = makeSpyChannel("email");
+    const webhook = makeSpyChannel("webhook");
+    const { server, stub, restore } = await buildRedeemServer({
+      reader: makeRedeemReader(fx),
+      buyerStore,
+      optionStore,
+      channels: [email, webhook],
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload(fx.buyer.address),
+        fulfillment: { option: "webhook", data: { url: "https://buyer.example/hook" } },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.status).toBe(400);
+        expect(result.body.code).toBe("FULFILLMENT_OPTION_NOT_ADVERTISED");
+      }
+      expect(stub.calls).toHaveLength(0);
+      expect(webhook.validations).toHaveLength(0);
+      expect(webhook.commits).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it("fulfillment with committer record but no option policy → 500 FULFILLMENT_OPTIONS_NOT_TRACKED", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const channel = makeSpyChannel("email");
+    const { server, stub, restore } = await buildRedeemServer({
+      reader: makeRedeemReader(fx),
+      buyerStore,
+      channels: [channel],
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload(fx.buyer.address),
+        fulfillment: { option: "email", data: { email: "new@example.com" } },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.status).toBe(500);
+        expect(result.body.code).toBe("FULFILLMENT_OPTIONS_NOT_TRACKED");
+      }
+      expect(stub.calls).toHaveLength(0);
+      expect(channel.validations).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
   it("fulfillment with unknown option → 400 FULFILLMENT_OPTION_UNKNOWN", async () => {
     const fx = await makePaymentFixture();
     const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const optionStore = new Map<string, readonly string[]>([["42", ["ipfs-pointer"]]]);
     const channel = makeSpyChannel("email");
     const { server, restore } = await buildRedeemServer({
       reader: makeRedeemReader(fx),
       buyerStore,
+      optionStore,
       channels: [channel],
     });
     try {
@@ -645,11 +776,13 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
   it("fulfillment that fails channel.validate → 400 FULFILLMENT_DATA_INVALID", async () => {
     const fx = await makePaymentFixture();
     const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const optionStore = new Map<string, readonly string[]>([["42", ["email"]]]);
     const channel = makeSpyChannel();
     channel.failNext = true;
     const { server, restore } = await buildRedeemServer({
       reader: makeRedeemReader(fx),
       buyerStore,
+      optionStore,
       channels: [channel],
     });
     try {
@@ -671,9 +804,11 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
   it("fulfillment without fulfillmentChannels configured → 400 FULFILLMENT_CHANNELS_NOT_CONFIGURED", async () => {
     const fx = await makePaymentFixture();
     const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const optionStore = new Map<string, readonly string[]>([["42", ["email"]]]);
     const { server, restore } = await buildRedeemServer({
       reader: makeRedeemReader(fx),
       buyerStore,
+      optionStore,
     });
     try {
       const result = await server.handlers.redeem({
@@ -711,9 +846,11 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
   it("successful redeem clears the committer entry from exchangeBuyerStore", async () => {
     const fx = await makePaymentFixture();
     const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const optionStore = new Map<string, readonly string[]>([["42", ["email"]]]);
     const { server, restore } = await buildRedeemServer({
       reader: makeRedeemReader(fx),
       buyerStore,
+      optionStore,
     });
     try {
       const result = await server.handlers.redeem({
@@ -722,6 +859,45 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
       });
       expect(result.ok).toBe(true);
       expect(buyerStore.has("42")).toBe(false);
+      expect(optionStore.has("42")).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("onCommit failure after confirmed redeem returns 200 with a pending recovery update", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const optionStore = new Map<string, readonly string[]>([["42", ["email"]]]);
+    const pendingStore = new Map<string, RedeemFulfillmentUpdate>();
+    const channel = makeSpyChannel();
+    channel.throwOnCommit = true;
+    const { server, restore } = await buildRedeemServer({
+      reader: makeRedeemReader(fx),
+      buyerStore,
+      optionStore,
+      pendingStore,
+      channels: [channel],
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload(fx.buyer.address),
+        fulfillment: { option: "email", data: { email: "new@example.com" } },
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.body.warnings?.[0]?.code).toBe("FULFILLMENT_UPDATE_DEFERRED");
+      }
+      expect(pendingStore.get("42")).toMatchObject({
+        exchangeId: "42",
+        option: "email",
+        data: { email: "new@example.com" },
+        redeemer: fx.buyer.address,
+        error: "store unavailable",
+      });
+      expect(buyerStore.has("42")).toBe(false);
+      expect(optionStore.has("42")).toBe(false);
     } finally {
       restore();
     }
@@ -730,6 +906,7 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
   it("failed redeem (state-verify mismatch) leaves the committer entry AND channel store untouched", async () => {
     const fx = await makePaymentFixture();
     const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const optionStore = new Map<string, readonly string[]>([["42", ["email"]]]);
     const channel = makeSpyChannel();
     // Sequence: pre-action read finds COMMITTED, post-action read
     // returns COMMITTED again (facilitator lied about REDEEMED).
@@ -750,6 +927,7 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
     const { server, restore } = await buildRedeemServer({
       reader: stuckReader,
       buyerStore,
+      optionStore,
       channels: [channel],
     });
     try {

--- a/typescript/packages/server/test/handlers.test.ts
+++ b/typescript/packages/server/test/handlers.test.ts
@@ -465,18 +465,23 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
     );
     const originalFetch = globalThis.fetch;
     globalThis.fetch = stub.fetch as unknown as typeof globalThis.fetch;
-    const server = createX402bServer({
-      network: NETWORK,
-      chainId: CHAIN_ID,
-      escrow: ESCROW,
-      signer: seller,
-      facilitator: { url: facilitatorUrl },
-      channelRegistry: { channels: ["server", "facilitator", "onchain"], escrow: ESCROW },
-      exchangeReader: opts.reader,
-      exchangeBuyerStore: opts.buyerStore,
-      ...(opts.channels !== undefined ? { fulfillmentChannels: opts.channels } : {}),
-    });
-    return { server, stub, restore: () => (globalThis.fetch = originalFetch) };
+    try {
+      const server = createX402bServer({
+        network: NETWORK,
+        chainId: CHAIN_ID,
+        escrow: ESCROW,
+        signer: seller,
+        facilitator: { url: facilitatorUrl },
+        channelRegistry: { channels: ["server", "facilitator", "onchain"], escrow: ESCROW },
+        exchangeReader: opts.reader,
+        exchangeBuyerStore: opts.buyerStore,
+        ...(opts.channels !== undefined ? { fulfillmentChannels: opts.channels } : {}),
+      });
+      return { server, stub, restore: () => (globalThis.fetch = originalFetch) };
+    } catch (e) {
+      globalThis.fetch = originalFetch;
+      throw e;
+    }
   }
 
   it("Flow A commit writes committer wallet into exchangeBuyerStore", async () => {
@@ -701,6 +706,86 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
     } finally {
       restore();
     }
+  });
+
+  it("successful redeem clears the committer entry from exchangeBuyerStore", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const { server, restore } = await buildRedeemServer({
+      reader: makeRedeemReader(fx),
+      buyerStore,
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload(fx.buyer.address),
+      });
+      expect(result.ok).toBe(true);
+      expect(buyerStore.has("42")).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("failed redeem (state-verify mismatch) leaves the committer entry AND channel store untouched", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const channel = makeSpyChannel();
+    // Sequence: pre-action read finds COMMITTED, post-action read
+    // returns COMMITTED again (facilitator lied about REDEEMED).
+    const stuckReader = makeSequenceReader([
+      {
+        state: ExchangeState.COMMITTED,
+        seller: fx.requirements.offer.creator,
+        exchangeToken: TOKEN,
+        price: fx.requirements.amount,
+      },
+      {
+        state: ExchangeState.COMMITTED,
+        seller: fx.requirements.offer.creator,
+        exchangeToken: TOKEN,
+        price: fx.requirements.amount,
+      },
+    ]);
+    const { server, restore } = await buildRedeemServer({
+      reader: stuckReader,
+      buyerStore,
+      channels: [channel],
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload(fx.buyer.address),
+        fulfillment: { option: "email", data: { email: "new@example.com" } },
+      });
+      expect(result.ok).toBe(false);
+      expect(channel.commits).toHaveLength(0);
+      expect(buyerStore.get("42")).toBe(fx.buyer.address);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("config validation — fulfillmentChannels", () => {
+  it("rejects duplicate channel ids at createX402bServer time", async () => {
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+    const duplicate = {
+      id: "email",
+      validate: () => ({ ok: true as const }),
+      onCommit: async () => undefined,
+    };
+    expect(() =>
+      createX402bServer({
+        network: NETWORK,
+        chainId: CHAIN_ID,
+        escrow: ESCROW,
+        signer: seller,
+        facilitator: { url: facilitatorUrl },
+        channelRegistry: { channels: ["server", "facilitator", "onchain"], escrow: ESCROW },
+        fulfillmentChannels: [duplicate, duplicate],
+      }),
+    ).toThrow(/duplicate id/);
   });
 });
 

--- a/typescript/packages/server/test/handlers.test.ts
+++ b/typescript/packages/server/test/handlers.test.ts
@@ -801,6 +801,42 @@ describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
     }
   });
 
+  it("fulfillment whose channel.validate throws → 400 FULFILLMENT_DATA_INVALID (not 500)", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const optionStore = new Map<string, readonly string[]>([["42", ["email"]]]);
+    const throwingChannel: RedeemFulfillmentChannel = {
+      id: "email",
+      validate() {
+        throw new Error("adapter blew up");
+      },
+      async onCommit() {
+        // never reached — validate throws first
+      },
+    };
+    const { server, restore } = await buildRedeemServer({
+      reader: makeRedeemReader(fx),
+      buyerStore,
+      optionStore,
+      channels: [throwingChannel],
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload(fx.buyer.address),
+        fulfillment: { option: "email", data: { email: "x@example.com" } },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.status).toBe(400);
+        expect(result.body.code).toBe("FULFILLMENT_DATA_INVALID");
+        expect(result.body.reason).toContain("adapter blew up");
+      }
+    } finally {
+      restore();
+    }
+  });
+
   it("fulfillment without fulfillmentChannels configured → 400 FULFILLMENT_CHANNELS_NOT_CONFIGURED", async () => {
     const fx = await makePaymentFixture();
     const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);

--- a/typescript/packages/server/test/handlers.test.ts
+++ b/typescript/packages/server/test/handlers.test.ts
@@ -4,6 +4,9 @@
 // can drive both the happy path and the state-verification mismatch.
 
 import { DisputeState, ExchangeState } from "@bosonprotocol/x402-actions";
+import type { BosonMetaTx } from "@bosonprotocol/x402-core/schemes/escrow";
+import { encodeSignedPayload } from "@bosonprotocol/x402-evm";
+import type { Hex } from "viem";
 import { describe, expect, it } from "vitest";
 import { privateKeyToAccount } from "viem/accounts";
 
@@ -12,6 +15,7 @@ import {
   type ExchangeReader,
   type ExchangeSnapshot,
   type FetchLike,
+  type RedeemFulfillmentChannel,
 } from "../src/index.js";
 import {
   CHAIN_ID,
@@ -391,6 +395,311 @@ describe("handlers.disputeRaise — DISPUTED post-state path", () => {
       }
     } finally {
       globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("handlers.redeem — wallet-rebinding + fulfillment update", () => {
+  function makeRedeemSignedPayload(from: string): Hex {
+    const metaTx: BosonMetaTx = {
+      from,
+      nonce: "1",
+      functionName: "redeemVoucher(uint256)",
+      functionSignature: `0x${"ab".repeat(36)}`,
+      sig: { v: 28, r: `0x${"11".repeat(32)}`, s: `0x${"22".repeat(32)}` },
+    };
+    return encodeSignedPayload(metaTx);
+  }
+
+  function makeRedeemReader(fx: { requirements: { offer: { creator: string }; amount: string } }) {
+    return makeSequenceReader([
+      {
+        state: ExchangeState.COMMITTED,
+        seller: fx.requirements.offer.creator,
+        exchangeToken: TOKEN,
+        price: fx.requirements.amount,
+      },
+      {
+        state: ExchangeState.REDEEMED,
+        seller: fx.requirements.offer.creator,
+        exchangeToken: TOKEN,
+        price: fx.requirements.amount,
+      },
+    ]);
+  }
+
+  /**
+   * Spy channel that records every `validate` and `onCommit` call.
+   * `validate` flips to `{ ok: false }` when `failNext` is set.
+   */
+  function makeSpyChannel(id = "email"): RedeemFulfillmentChannel & {
+    validations: Array<Record<string, unknown> | null>;
+    commits: Array<{ exchangeId: string; data: Record<string, unknown> | null }>;
+    failNext: boolean;
+  } {
+    const spy: ReturnType<typeof makeSpyChannel> = {
+      id,
+      validations: [],
+      commits: [],
+      failNext: false,
+      validate(data) {
+        spy.validations.push(data);
+        return spy.failNext ? { ok: false, reason: "bad data" } : { ok: true };
+      },
+      async onCommit(exchangeId, data) {
+        spy.commits.push({ exchangeId, data });
+      },
+    };
+    return spy;
+  }
+
+  async function buildRedeemServer(opts: {
+    facilitator?: (path: string) => unknown;
+    reader: ExchangeReader;
+    buyerStore: Map<string, `0x${string}`>;
+    channels?: readonly RedeemFulfillmentChannel[];
+  }) {
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+    const stub = makeStubFacilitatorFetch(
+      opts.facilitator ?? (() => ({ ok: true, txHash: "0xfed", newExchangeState: "REDEEMED" })),
+    );
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = stub.fetch as unknown as typeof globalThis.fetch;
+    const server = createX402bServer({
+      network: NETWORK,
+      chainId: CHAIN_ID,
+      escrow: ESCROW,
+      signer: seller,
+      facilitator: { url: facilitatorUrl },
+      channelRegistry: { channels: ["server", "facilitator", "onchain"], escrow: ESCROW },
+      exchangeReader: opts.reader,
+      exchangeBuyerStore: opts.buyerStore,
+      ...(opts.channels !== undefined ? { fulfillmentChannels: opts.channels } : {}),
+    });
+    return { server, stub, restore: () => (globalThis.fetch = originalFetch) };
+  }
+
+  it("Flow A commit writes committer wallet into exchangeBuyerStore", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>();
+    const reader = makeReader({
+      state: ExchangeState.COMMITTED,
+      seller: fx.requirements.offer.creator,
+      exchangeToken: TOKEN,
+      price: fx.requirements.amount,
+    });
+    const seller = privateKeyToAccount(TEST_SELLER_PK);
+    const stub = makeStubFacilitatorFetch((path) =>
+      path === "/settle"
+        ? { ok: true, exchangeId: "42", txHash: "0xabc" }
+        : { ok: false, code: "INTERNAL_ERROR", reason: "unexpected" },
+    );
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = stub.fetch as unknown as typeof globalThis.fetch;
+    try {
+      const server = createX402bServer({
+        network: NETWORK,
+        chainId: CHAIN_ID,
+        escrow: ESCROW,
+        signer: seller,
+        facilitator: { url: facilitatorUrl },
+        channelRegistry: { channels: ["server", "facilitator", "onchain"], escrow: ESCROW },
+        exchangeReader: reader,
+        exchangeBuyerStore: buyerStore,
+      });
+      const result = await server.handlers.commit({
+        paymentHeader: makeBuyerHeader(fx.payload),
+        requirements: fx.requirements,
+      });
+      expect(result.ok).toBe(true);
+      expect(buyerStore.get("42")).toBe(fx.buyer.address);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("same-wallet redeemer without fulfillment → 200, no channel calls", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const channel = makeSpyChannel();
+    const { server, restore } = await buildRedeemServer({
+      reader: makeRedeemReader(fx),
+      buyerStore,
+      channels: [channel],
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload(fx.buyer.address),
+      });
+      expect(result.ok).toBe(true);
+      expect(channel.validations).toHaveLength(0);
+      expect(channel.commits).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it("same-wallet redeemer with valid fulfillment → 200, channel.onCommit called", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const channel = makeSpyChannel();
+    const { server, restore } = await buildRedeemServer({
+      reader: makeRedeemReader(fx),
+      buyerStore,
+      channels: [channel],
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload(fx.buyer.address),
+        fulfillment: { option: "email", data: { email: "new@example.com" } },
+      });
+      expect(result.ok).toBe(true);
+      expect(channel.commits).toEqual([{ exchangeId: "42", data: { email: "new@example.com" } }]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("different-wallet redeemer without fulfillment → 400 FULFILLMENT_REQUIRED_ON_WALLET_CHANGE", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const channel = makeSpyChannel();
+    const { server, stub, restore } = await buildRedeemServer({
+      reader: makeRedeemReader(fx),
+      buyerStore,
+      channels: [channel],
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload("0x9999999999999999999999999999999999999999"),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.status).toBe(400);
+        expect(result.body.code).toBe("FULFILLMENT_REQUIRED_ON_WALLET_CHANGE");
+      }
+      // Must short-circuit before contacting the facilitator.
+      expect(stub.calls).toHaveLength(0);
+      expect(channel.commits).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it("different-wallet redeemer with valid fulfillment → 200, channel.onCommit called", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const channel = makeSpyChannel();
+    const { server, restore } = await buildRedeemServer({
+      reader: makeRedeemReader(fx),
+      buyerStore,
+      channels: [channel],
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload("0x9999999999999999999999999999999999999999"),
+        fulfillment: { option: "email", data: { email: "new-owner@example.com" } },
+      });
+      expect(result.ok).toBe(true);
+      expect(channel.commits).toEqual([
+        { exchangeId: "42", data: { email: "new-owner@example.com" } },
+      ]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("fulfillment with unknown option → 400 FULFILLMENT_OPTION_UNKNOWN", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const channel = makeSpyChannel("email");
+    const { server, restore } = await buildRedeemServer({
+      reader: makeRedeemReader(fx),
+      buyerStore,
+      channels: [channel],
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload(fx.buyer.address),
+        fulfillment: { option: "ipfs-pointer", data: null },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.body.code).toBe("FULFILLMENT_OPTION_UNKNOWN");
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it("fulfillment that fails channel.validate → 400 FULFILLMENT_DATA_INVALID", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const channel = makeSpyChannel();
+    channel.failNext = true;
+    const { server, restore } = await buildRedeemServer({
+      reader: makeRedeemReader(fx),
+      buyerStore,
+      channels: [channel],
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload(fx.buyer.address),
+        fulfillment: { option: "email", data: { email: "" } },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.body.code).toBe("FULFILLMENT_DATA_INVALID");
+      }
+      expect(channel.commits).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it("fulfillment without fulfillmentChannels configured → 400 FULFILLMENT_CHANNELS_NOT_CONFIGURED", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>([["42", fx.buyer.address]]);
+    const { server, restore } = await buildRedeemServer({
+      reader: makeRedeemReader(fx),
+      buyerStore,
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload(fx.buyer.address),
+        fulfillment: { option: "email", data: { email: "x@example.com" } },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.body.code).toBe("FULFILLMENT_CHANNELS_NOT_CONFIGURED");
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it("redeem against an exchange with no committer record → wallet check skipped", async () => {
+    const fx = await makePaymentFixture();
+    const buyerStore = new Map<string, `0x${string}`>(); // empty — legacy
+    const { server, restore } = await buildRedeemServer({
+      reader: makeRedeemReader(fx),
+      buyerStore,
+    });
+    try {
+      const result = await server.handlers.redeem({
+        exchangeId: "42",
+        signedPayload: makeRedeemSignedPayload("0x9999999999999999999999999999999999999999"),
+      });
+      expect(result.ok).toBe(true);
+    } finally {
+      restore();
     }
   });
 });


### PR DESCRIPTION
## Summary

- Track the committer wallet at Flow A (`boson-createOfferAndCommit`) commit time, keyed by `exchangeId`, via a new `exchangeBuyerStore` on `X402bServerConfig` (defaulted to an in-memory `Map`).
- On `boson-redeem`, recover the redeemer wallet from the decoded `signedPayload` and compare against the stored committer. Different wallet (voucher transferred) ⇒ fresh `fulfillment` MUST be supplied; same wallet ⇒ optional update. No stored record (legacy / atomic) ⇒ skip the check.
- When `fulfillment` is supplied (either branch), run the matching channel's `validate` and `onCommit(exchangeId, data)` to upsert the delivery target.

Channel wiring stays decoupled from `@bosonprotocol/x402-fulfillment` — the server accepts a structural `RedeemFulfillmentChannel` (`id` / `validate` / `onCommit`), which existing channel instances satisfy without a cast.

Docs: new "Re-submission at redeem" section in [`docs/boson-impl-03-fulfillment-channels.md`](https://github.com/bosonprotocol/x402b/blob/allow-redeem-fulfillment-update/docs/boson-impl-03-fulfillment-channels.md) with the wallet-vs-fulfillment matrix; cross-link from the `boson-redeem` action in [`docs/boson-impl-04-state-machine-and-next-actions.md`](https://github.com/bosonprotocol/x402b/blob/allow-redeem-fulfillment-update/docs/boson-impl-04-state-machine-and-next-actions.md).

## Test plan

- [x] `pnpm build` — all 10 workspace packages green
- [x] `pnpm test` — server suite now 73 tests (was 64); 9 new redeem cases cover the wallet matrix, `FULFILLMENT_REQUIRED_ON_WALLET_CHANGE`, `FULFILLMENT_OPTION_UNKNOWN`, `FULFILLMENT_DATA_INVALID`, `FULFILLMENT_CHANNELS_NOT_CONFIGURED`, and the legacy/no-record skip
- [x] `pnpm lint`
- [x] `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified fulfillment re‑submission at redeem, voucher‑transfer redeem behavior, validation/upsert semantics, and deferred update handling.

* **New Features**
  * Redeem may include fulfillment data; servers can enforce it when the redeemer wallet differs and defer persistence with a warning.
  * Server config and public API now allow tracking commit→redeem buyer/options and registering fulfillment adapters; new warning and request‑validation exports added.

* **Tests**
  * Added end‑to‑end tests for wallet rebinding, fulfillment validation, deferred commits, warnings, and related flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/58)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->