### PR TITLE
refactor(client): drop MetaTx suffix from pre-commit signer names

### DIFF
--- a/typescript/packages/client/src/client.ts
+++ b/typescript/packages/client/src/client.ts
@@ -20,10 +20,7 @@ import { pickAction } from "./action.js";
 import { createCoreSdkFactory } from "./core-sdk-factory.js";
 import { resolveFulfillment } from "./fulfillment.js";
 import { assembleAndEncodePayload } from "./payload.js";
-import {
-  signCreateOfferAndCommitMetaTx,
-  signCreateOfferCommitAndRedeemMetaTx,
-} from "./pre-commit.js";
+import { signCreateOfferAndCommit, signCreateOfferCommitAndRedeem } from "./pre-commit.js";
 import {
   signPostCommitAction,
   type SignActionArgs,
@@ -128,8 +125,8 @@ export function createX402bClient(config: X402bClientConfig): X402bClient {
 
       const signMetaTx =
         action === "boson-createOfferCommitAndRedeem"
-          ? signCreateOfferCommitAndRedeemMetaTx
-          : signCreateOfferAndCommitMetaTx;
+          ? signCreateOfferCommitAndRedeem
+          : signCreateOfferAndCommit;
       const metaTx = await signMetaTx({ requirements, coreSdk, buyer });
 
       return assembleAndEncodePayload({

--- a/typescript/packages/client/src/pre-commit.ts
+++ b/typescript/packages/client/src/pre-commit.ts
@@ -23,7 +23,7 @@ import type { Address, Hex } from "viem";
 
 import { randomUint256 } from "./utils/crypto.js";
 
-export interface SignCreateOfferAndCommitMetaTxArgs {
+export interface SignCreateOfferAndCommitArgs {
   requirements: EscrowPaymentRequirements;
   coreSdk: CoreSDK;
   buyer: Address;
@@ -43,11 +43,11 @@ export interface SignCreateOfferAndCommitMetaTxArgs {
  * `createOfferAndCommitArgsSchema.validateSync` — propagate it rather than
  * patch silently (CLAUDE.md "Production over spec when they diverge").
  */
-export async function signCreateOfferAndCommitMetaTx({
+export async function signCreateOfferAndCommit({
   requirements,
   coreSdk,
   buyer,
-}: SignCreateOfferAndCommitMetaTxArgs): Promise<BosonMetaTx> {
+}: SignCreateOfferAndCommitArgs): Promise<BosonMetaTx> {
   const nonce = randomUint256();
 
   const createOfferAndCommitArgs = buildCreateOfferAndCommitArgs(requirements, buyer);
@@ -61,17 +61,17 @@ export async function signCreateOfferAndCommitMetaTx({
 }
 
 /**
- * Flow B counterpart to {@link signCreateOfferAndCommitMetaTx} — signs
+ * Flow B counterpart to {@link signCreateOfferAndCommit} — signs
  * the meta-tx that drives `OrchestrationHandlerFacet2.createOfferCommitAndRedeem`.
  * The argument shape is identical (the protocol uses the same
  * `FullOfferArgs` struct); only the resulting function selector and
  * post-state differ.
  */
-export async function signCreateOfferCommitAndRedeemMetaTx({
+export async function signCreateOfferCommitAndRedeem({
   requirements,
   coreSdk,
   buyer,
-}: SignCreateOfferAndCommitMetaTxArgs): Promise<BosonMetaTx> {
+}: SignCreateOfferAndCommitArgs): Promise<BosonMetaTx> {
   const nonce = randomUint256();
 
   const createOfferAndCommitArgs = buildCreateOfferAndCommitArgs(requirements, buyer);


### PR DESCRIPTION
## Summary

- In `client.ts`, the two pre-commit signer helpers were named with an explicit `MetaTx` suffix (`signCreateOfferAndCommitMetaTx`, `signCreateOfferCommitAndRedeemMetaTx`), while the post-commit and withdraw signers — which also produce meta-transactions — were not (`signPostCommitAction`, `signWithdrawFunds`, `signWithdrawAllAvailableFunds`).
- Every action the client signs in this version is a meta-tx, so the suffix carried no information and only made the surface read inconsistently. This PR drops it.

Renames in [`pre-commit.ts`](typescript/packages/client/src/pre-commit.ts):

- `signCreateOfferAndCommitMetaTx` → `signCreateOfferAndCommit`
- `signCreateOfferCommitAndRedeemMetaTx` → `signCreateOfferCommitAndRedeem`
- `SignCreateOfferAndCommitMetaTxArgs` → `SignCreateOfferAndCommitArgs`
- `{@link …}` JSDoc reference updated

Updated the imports and call site in [`client.ts`](typescript/packages/client/src/client.ts). Neither symbol is re-exported from `index.ts`, so there are no public-API consumers to update.

## Test plan

- [x] `pnpm --filter @bosonprotocol/x402-client lint` — clean
- [x] `pnpm format:check` — clean
- [x] Client unit tests not blocked by the pre-existing `@bosonprotocol/x402-evm/codec` resolution issue all pass (38/38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Signing function names have been updated for API consistency. Update your integration code if using the affected functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/61)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->