### PR TITLE
fix(client): parse nested nextActions.exchangeState in X-PAYMENT-RESPONSE

### DIFF
--- a/.changeset/response-parser-nested-state.md
+++ b/.changeset/response-parser-nested-state.md
@@ -1,0 +1,9 @@
+---
+"@bosonprotocol/x402-client": patch
+---
+
+Fix `parsePaymentResponse` to read the nested `nextActions.exchangeState`
+(and `nextActions.disputeState` when present) from the
+`X-PAYMENT-RESPONSE` header. The server emits exchange state under the
+nested path, so the prior top-level-only lookup always returned an
+undefined `summary.state`. Top-level `state` still wins when present.

--- a/.changeset/response-parser-nested-state.md
+++ b/.changeset/response-parser-nested-state.md
@@ -2,8 +2,8 @@
 "@bosonprotocol/x402-client": patch
 ---
 
-Fix `parsePaymentResponse` to read the nested `nextActions.exchangeState`
-(and `nextActions.disputeState` when present) from the
-`X-PAYMENT-RESPONSE` header. The server emits exchange state under the
-nested path, so the prior top-level-only lookup always returned an
+Fix `parsePaymentResponse` to read and normalize the nested
+`nextActions.exchangeState` (and `nextActions.disputeState` when present)
+from the `X-PAYMENT-RESPONSE` header. The server emits exchange state under
+the nested path, so the prior top-level-only lookup always returned an
 undefined `summary.state`. Top-level `state` still wins when present.

--- a/typescript/packages/client/src/response.ts
+++ b/typescript/packages/client/src/response.ts
@@ -61,10 +61,15 @@ export function parsePaymentResponse(response: ResponseLike): ExchangeSummary | 
       !Array.isArray(obj.nextActions)
     ) {
       const na = obj.nextActions as Record<string, unknown>;
-      const exchange = typeof na.exchangeState === "string" ? na.exchangeState : undefined;
-      const dispute = typeof na.disputeState === "string" ? na.disputeState : undefined;
+      const exchange = pickString(na, ["exchangeState"]);
+      const dispute = pickString(na, ["disputeState"]);
       if (exchange !== undefined) {
-        const candidate = dispute !== undefined ? { exchange, dispute } : exchange;
+        let candidate: unknown;
+        if (exchange === "DISPUTED") {
+          candidate = dispute !== undefined ? { exchange, dispute } : undefined;
+        } else {
+          candidate = { exchange };
+        }
         if (isClientStateShape(candidate)) {
           summary.state = candidate;
         }
@@ -89,7 +94,7 @@ function isClientStateShape(v: unknown): v is NonNullable<ExchangeSummary["state
   if (typeof v === "string") return v.length > 0;
   if (typeof v !== "object" || v === null || Array.isArray(v)) return false;
   const rec = v as Record<string, unknown>;
-  if (typeof rec.exchange !== "string") return false;
+  if (typeof rec.exchange !== "string" || rec.exchange.length === 0) return false;
   if ("dispute" in rec && rec.dispute !== undefined && typeof rec.dispute !== "string") {
     return false;
   }

--- a/typescript/packages/client/src/response.ts
+++ b/typescript/packages/client/src/response.ts
@@ -48,6 +48,28 @@ export function parsePaymentResponse(response: ResponseLike): ExchangeSummary | 
     if (isClientStateShape(obj.state)) {
       summary.state = obj.state;
     }
+
+    // Fallback for the server-emitted shape, which carries exchange state
+    // under `nextActions.exchangeState` (and optionally `disputeState`)
+    // rather than a top-level `state` field. The top-level lookup above
+    // still wins when present, preserving forward-compat with external
+    // servers that publish the flatter shape.
+    if (
+      summary.state === undefined &&
+      typeof obj.nextActions === "object" &&
+      obj.nextActions !== null &&
+      !Array.isArray(obj.nextActions)
+    ) {
+      const na = obj.nextActions as Record<string, unknown>;
+      const exchange = typeof na.exchangeState === "string" ? na.exchangeState : undefined;
+      const dispute = typeof na.disputeState === "string" ? na.disputeState : undefined;
+      if (exchange !== undefined) {
+        const candidate = dispute !== undefined ? { exchange, dispute } : exchange;
+        if (isClientStateShape(candidate)) {
+          summary.state = candidate;
+        }
+      }
+    }
   }
 
   return summary;

--- a/typescript/packages/client/test/response.test.ts
+++ b/typescript/packages/client/test/response.test.ts
@@ -32,7 +32,7 @@ describe("parsePaymentResponse", () => {
     });
   });
 
-  it("lifts state from nextActions.exchangeState when top-level state is absent", () => {
+  it("lifts a non-DISPUTED { exchange } shape from nextActions", () => {
     const payload = {
       exchangeId: "42",
       txHash: "0xabc",
@@ -50,7 +50,7 @@ describe("parsePaymentResponse", () => {
     });
 
     expect(parsed?.exchangeId).toBe("42");
-    expect(parsed?.state).toBe("REDEEMED");
+    expect(parsed?.state).toEqual({ exchange: "REDEEMED" });
   });
 
   it("lifts a DISPUTED { exchange, dispute } shape from nextActions", () => {
@@ -72,6 +72,26 @@ describe("parsePaymentResponse", () => {
     });
 
     expect(parsed?.state).toEqual({ exchange: "DISPUTED", dispute: "RESOLVING" });
+  });
+
+  it("does not lift DISPUTED nextActions without a disputeState", () => {
+    const payload = {
+      exchangeId: "8",
+      txHash: "0xaaa",
+      nextActions: {
+        exchangeId: "8",
+        exchangeState: "DISPUTED",
+        next: [],
+      },
+    };
+    const header = Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
+
+    const parsed = parsePaymentResponse({
+      headers: { get: () => header },
+    });
+
+    expect(parsed?.exchangeId).toBe("8");
+    expect(parsed?.state).toBeUndefined();
   });
 
   it("prefers top-level state over nextActions.exchangeState", () => {

--- a/typescript/packages/client/test/response.test.ts
+++ b/typescript/packages/client/test/response.test.ts
@@ -31,4 +31,80 @@ describe("parsePaymentResponse", () => {
       state: "COMMITTED",
     });
   });
+
+  it("lifts state from nextActions.exchangeState when top-level state is absent", () => {
+    const payload = {
+      exchangeId: "42",
+      txHash: "0xabc",
+      nextActions: {
+        exchangeId: "42",
+        exchangeState: "REDEEMED",
+        next: [],
+        fallback: { channel: "facilitator" },
+      },
+    };
+    const header = Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
+
+    const parsed = parsePaymentResponse({
+      headers: { get: () => header },
+    });
+
+    expect(parsed?.exchangeId).toBe("42");
+    expect(parsed?.state).toBe("REDEEMED");
+  });
+
+  it("lifts a DISPUTED { exchange, dispute } shape from nextActions", () => {
+    const payload = {
+      exchangeId: "7",
+      txHash: "0xdef",
+      nextActions: {
+        exchangeId: "7",
+        exchangeState: "DISPUTED",
+        disputeState: "RESOLVING",
+        next: [],
+        fallback: { channel: "facilitator" },
+      },
+    };
+    const header = Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
+
+    const parsed = parsePaymentResponse({
+      headers: { get: () => header },
+    });
+
+    expect(parsed?.state).toEqual({ exchange: "DISPUTED", dispute: "RESOLVING" });
+  });
+
+  it("prefers top-level state over nextActions.exchangeState", () => {
+    const payload = {
+      exchangeId: "1",
+      state: "COMMITTED",
+      nextActions: {
+        exchangeId: "1",
+        exchangeState: "REDEEMED",
+        next: [],
+      },
+    };
+    const header = Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
+
+    const parsed = parsePaymentResponse({
+      headers: { get: () => header },
+    });
+
+    expect(parsed?.state).toBe("COMMITTED");
+  });
+
+  it("does not crash on a garbage nextActions value", () => {
+    const payload = {
+      exchangeId: "9",
+      nextActions: 42,
+    };
+    const header = Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
+
+    const parsed = parsePaymentResponse({
+      headers: { get: () => header },
+    });
+
+    expect(parsed?.exchangeId).toBe("9");
+    expect(parsed?.state).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

The server's commit success body carries exchange state under `body.nextActions.exchangeState` (sometimes also `disputeState`), but `parsePaymentResponse` only looked at top-level `state`. Result: `summary.state` was always `undefined` for the current server shape.

Fix: after the existing top-level lookup, fall back to `nextActions.exchangeState` (and `nextActions.disputeState` when present). The parser stays permissive — bad shapes still don't crash, top-level `state` still wins when present (for forward-compat).

## Test plan

- [x] New tests in `response.test.ts` cover (a) nested-only state, (b) nested DISPUTED with disputeState, (c) top-level wins over nested, (d) garbage `nextActions` doesn't crash
- [x] `pnpm build && pnpm test && pnpm lint && pnpm format:check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved payment response handling so exchange and dispute states are correctly recognized when provided in nested server responses, while preserving top-level state precedence.

* **Tests**
  * Added tests covering nested state extraction, disputed-state mapping, precedence of top-level state, and resilient handling of malformed responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/62)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->