### PR TITLE
feat(client): capability-aware token-auth strategy fallback

### DIFF
--- a/.changeset/token-auth-capability-aware-fallback.md
+++ b/.changeset/token-auth-capability-aware-fallback.md
@@ -1,0 +1,18 @@
+---
+"@bosonprotocol/x402-client": patch
+---
+
+Make the token-auth strategy picker capability-aware.
+
+When the server advertises multiple strategies (e.g. `["erc3009", "permit2"]`)
+and the client lacks the runtime prerequisites for the preferred one
+(e.g. no `tokenDomainResolver` in `X402bClientConfig`), the picker now
+falls back to the next advertised strategy it can actually sign instead
+of throwing. Permit2 in particular requires no extra configuration, so a
+client configured without `tokenDomainResolver` will silently use Permit2
+whenever the server lists it as an alternative.
+
+`UnsupportedTokenAuthError` is now thrown only when the intersection
+(advertised) ∩ (preferred) ∩ (client-capable) is empty. The error message
+lists what's advertised and which client-side prerequisite is missing so
+deployments without `tokenDomainResolver` can diagnose the gap.

--- a/typescript/packages/client/src/token-auth/index.ts
+++ b/typescript/packages/client/src/token-auth/index.ts
@@ -46,17 +46,47 @@ export interface BuiltTokenAuth {
 
 const STRATEGY_PREFERENCE: readonly TokenAuthStrategy[] = ["erc3009", "permit2", "permit"];
 
+function strategyIsAvailable(s: TokenAuthStrategy, args: BuildTokenAuthArgs): boolean {
+  switch (s) {
+    case "erc3009":
+      return args.tokenDomainResolver !== undefined;
+    case "permit":
+      return args.tokenDomainResolver !== undefined && args.publicClient !== undefined;
+    case "permit2":
+      return true;
+    case "none":
+      return false;
+    default: {
+      const _exhaustive: never = s;
+      void _exhaustive;
+      return false;
+    }
+  }
+}
+
 /**
  * Pick the highest-preference strategy from `requirements.tokenAuthStrategies`,
  * sign the corresponding payload via core-sdk, and return the wire-format
  * `BosonTokenAuth` slot.
+ *
+ * The picker is capability-aware: a strategy is only chosen when the runtime
+ * config has the prerequisites for it (e.g. `tokenDomainResolver` for
+ * ERC-3009, both `tokenDomainResolver` and `publicClient` for Permit). This
+ * lets a deployment without `tokenDomainResolver` still satisfy servers that
+ * advertise `["erc3009", "permit2"]` by falling back to Permit2.
  */
 export async function buildAndSignTokenAuth(args: BuildTokenAuthArgs): Promise<BuiltTokenAuth> {
   const advertised = args.requirements.tokenAuthStrategies;
-  const chosen = STRATEGY_PREFERENCE.find((s) => advertised.includes(s));
+  const chosen = STRATEGY_PREFERENCE.find(
+    (s) => advertised.includes(s) && strategyIsAvailable(s, args),
+  );
   if (!chosen) {
     throw new UnsupportedTokenAuthError(
-      `server advertises tokenAuthStrategies=[${advertised.join(", ")}]; client supports [${STRATEGY_PREFERENCE.join(", ")}]`,
+      `server advertises tokenAuthStrategies=[${advertised.join(", ")}]; ` +
+        `client supports [${STRATEGY_PREFERENCE.join(", ")}] but none are usable ` +
+        `with the current X402bClientConfig ` +
+        `(ERC-3009 and Permit require tokenDomainResolver; Permit also requires ` +
+        `a PublicClient for the requirements' chain via publicClients)`,
     );
   }
 

--- a/typescript/packages/client/test/handle402.test.ts
+++ b/typescript/packages/client/test/handle402.test.ts
@@ -262,6 +262,57 @@ describe("handle402 — round-trip", () => {
     await expect(client.handle402(requirements)).rejects.toThrow(UnsupportedTokenAuthError);
   });
 
+  it("error message mentions tokenDomainResolver when only 'erc3009' advertised and no resolver", async () => {
+    const requirements = baseRequirements();
+    const client = createX402bClient({ signer: BUYER_SIGNER });
+    await expect(client.handle402(requirements)).rejects.toThrow(/tokenDomainResolver/);
+  });
+
+  it("falls back to Permit2 when server advertises ['erc3009','permit2'] and no tokenDomainResolver", async () => {
+    const requirements = baseRequirements();
+    requirements.tokenAuthStrategies = ["erc3009", "permit2"];
+    const client = createX402bClient({ signer: BUYER_SIGNER });
+    const header = await client.handle402(requirements);
+    const decoded = parseEscrowPaymentPayload(
+      JSON.parse(Buffer.from(header, "base64").toString("utf8")),
+    );
+
+    expect(decoded.payload.tokenAuthStrategy).toBe("permit2");
+    expect(decoded.payload.tokenAuth?.kind).toBe("permit2");
+    const tokenAuth = decoded.payload.tokenAuth?.data as Permit2AuthData;
+    expect(tokenAuth.permitted.token.toLowerCase()).toBe(requirements.asset.toLowerCase());
+    expect(tokenAuth.permitted.amount).toBe(requirements.amount);
+    expect(tokenAuth.spender.toLowerCase()).toBe(requirements.escrowAddress.toLowerCase());
+  });
+
+  it("falls back to Permit2 when server advertises ['permit','permit2'] and no PublicClient", async () => {
+    const requirements = baseRequirements();
+    requirements.tokenAuthStrategies = ["permit", "permit2"];
+    // tokenDomainResolver is provided, but no `publicClients` map — so Permit
+    // isn't usable and the picker should fall back to Permit2.
+    const client = makeClient();
+    const header = await client.handle402(requirements);
+    const decoded = parseEscrowPaymentPayload(
+      JSON.parse(Buffer.from(header, "base64").toString("utf8")),
+    );
+
+    expect(decoded.payload.tokenAuthStrategy).toBe("permit2");
+    expect(decoded.payload.tokenAuth?.kind).toBe("permit2");
+  });
+
+  it("still picks ERC-3009 first when advertised and tokenDomainResolver is configured", async () => {
+    const requirements = baseRequirements();
+    requirements.tokenAuthStrategies = ["erc3009", "permit2"];
+    const client = makeClient();
+    const header = await client.handle402(requirements);
+    const decoded = parseEscrowPaymentPayload(
+      JSON.parse(Buffer.from(header, "base64").toString("utf8")),
+    );
+
+    expect(decoded.payload.tokenAuthStrategy).toBe("erc3009");
+    expect(decoded.payload.tokenAuth?.kind).toBe("erc3009");
+  });
+
   it("signs Permit2 when the server advertises only 'permit2', without tokenDomainResolver", async () => {
     const requirements = baseRequirements();
     requirements.tokenAuthStrategies = ["permit2"];


### PR DESCRIPTION
## Summary

When the server advertised `["erc3009", "permit2"]` and the client lacked the `tokenDomainResolver` that ERC-3009 needs, the picker still selected `erc3009` first and threw — even though Permit2 was advertised and would have worked.

Fix: filter `STRATEGY_PREFERENCE` by the runtime capabilities the client config provides before picking the first match. Throw only when the intersection (advertised) ∩ (preferred) ∩ (capable) is empty. The error message lists what's advertised and which client-side prerequisite is missing.

## Test plan

- [x] Falls back to Permit2 when ERC-3009 advertised but no `tokenDomainResolver`
- [x] Falls back to Permit2 when Permit advertised but no `publicClient`
- [x] Throws `UnsupportedTokenAuthError` when only ERC-3009 advertised and no resolver
- [x] Existing ERC-3009-with-resolver happy path unchanged
- [x] `pnpm build && pnpm test && pnpm lint && pnpm format:check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token authentication now automatically falls back to alternative advertised strategies when the preferred method's runtime requirements are unavailable, improving resilience and preventing unnecessary failures.

* **Improvements**
  * Error messages now include specific details about missing prerequisites, making it easier to diagnose and troubleshoot authentication issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/63)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->