### PR TITLE
fix(server): distinguish facilitator domain rejections from transport failures

### DIFF
--- a/.changeset/distinguish-facilitator-reject-vs-unreachable.md
+++ b/.changeset/distinguish-facilitator-reject-vs-unreachable.md
@@ -1,0 +1,14 @@
+---
+"@bosonprotocol/x402-server": patch
+---
+
+Distinguish facilitator domain rejections from transport failures in
+`createFacilitatorClient`. When a non-2xx response carries a parseable
+`{ok:false, code, reason}` body (as `facilitator-express` emits for
+domain failures over HTTP 400), the client now returns it as the typed
+domain result instead of throwing `FacilitatorHttpError`. Transport
+faults (network error, non-JSON body, schema-mismatched body) still
+throw `FacilitatorHttpError`. The convenience handlers'
+`FACILITATOR_REJECTED` branch is now exercised for legitimate
+facilitator rejections like `BAD_META_TX_SIGNATURE` instead of
+masking them as `FACILITATOR_UNREACHABLE`.

--- a/.changeset/distinguish-facilitator-reject-vs-unreachable.md
+++ b/.changeset/distinguish-facilitator-reject-vs-unreachable.md
@@ -3,12 +3,12 @@
 ---
 
 Distinguish facilitator domain rejections from transport failures in
-`createFacilitatorClient`. When a non-2xx response carries a parseable
+`createFacilitatorClient`. When an HTTP 400 response carries a parseable
 `{ok:false, code, reason}` body (as `facilitator-express` emits for
-domain failures over HTTP 400), the client now returns it as the typed
-domain result instead of throwing `FacilitatorHttpError`. Transport
-faults (network error, non-JSON body, schema-mismatched body) still
+domain failures), the client now returns it as the typed domain result
+instead of throwing `FacilitatorHttpError`. Transport faults (network
+error, non-JSON body, schema-mismatched body, or 5xx response) still
 throw `FacilitatorHttpError`. The convenience handlers'
 `FACILITATOR_REJECTED` branch is now exercised for legitimate
-facilitator rejections like `BAD_META_TX_SIGNATURE` instead of
-masking them as `FACILITATOR_UNREACHABLE`.
+facilitator rejections like `BAD_META_TX_SIGNATURE` instead of masking
+them as `FACILITATOR_UNREACHABLE`.

--- a/typescript/packages/server/src/facilitator/client.ts
+++ b/typescript/packages/server/src/facilitator/client.ts
@@ -4,12 +4,15 @@
 // `/perform-action?action=<action>`); this module wraps `fetch` with the typed
 // request/response shapes exported by `@bosonprotocol/x402-facilitator`.
 //
-// Successful responses (`{ ok: true, ... }` or `{ ok: false, code, reason }`)
-// are returned verbatim — both shapes are domain results the caller
-// branches on. HTTP-transport failures (network down, 5xx with an
-// unparseable body, non-JSON 200, etc.) throw `FacilitatorHttpError`
-// so the composition layer can distinguish "facilitator said no" from
-// "we couldn't reach the facilitator".
+// Domain results (`{ ok: true, ... }` or `{ ok: false, code, reason }`)
+// are returned verbatim — both shapes are answers the caller branches
+// on. The facilitator-express adapter emits domain failures over HTTP
+// 400 (so curl users still see a 4xx), but the wire body is still a
+// well-formed result; we recognise that shape on non-2xx responses and
+// hand it back rather than throwing. HTTP-transport failures (network
+// down, non-JSON body, schema-mismatched body) throw
+// `FacilitatorHttpError` so the composition layer can distinguish
+// "facilitator said no" from "we couldn't reach the facilitator".
 
 import type {
   FacilitatorErrorCode,
@@ -51,8 +54,10 @@ export interface FacilitatorClient {
 /**
  * Construct a typed HTTP client for the facilitator. The returned
  * methods stringify the input as JSON and POST to the matching path
- * on the configured URL. Non-2xx responses raise `FacilitatorHttpError`;
- * 2xx responses are JSON-parsed and returned verbatim.
+ * on the configured URL. Bodies matching the well-formed result shape
+ * (whether HTTP 2xx success or HTTP 4xx domain rejection) are returned
+ * verbatim; transport failures (network, non-JSON body,
+ * schema-mismatched body) raise `FacilitatorHttpError`.
  */
 export function createFacilitatorClient(opts: CreateFacilitatorClientOptions): FacilitatorClient {
   const fetchImpl = opts.fetch ?? (globalThis.fetch as FetchLike | undefined);
@@ -106,6 +111,16 @@ export function createFacilitatorClient(opts: CreateFacilitatorClientOptions): F
     }
 
     if (!res.ok) {
+      // The facilitator-express adapter returns domain failures as
+      // HTTP 400 with the `{ok:false, code, reason}` body. Detect that
+      // shape and surface it as the typed result — every endpoint's
+      // `Res` union includes the same `{ok:false, code, reason}`
+      // variant, so the cast through `validate` (which also accepts
+      // that shape) preserves type-safety. Anything else on a non-2xx
+      // is a genuine transport failure.
+      if (isFailureBranch(parsed) && validate(parsed)) {
+        return parsed;
+      }
       const facilitatorCode = extractFacilitatorCode(parsed);
       throw new FacilitatorHttpError(
         `facilitator HTTP ${res.status} (${path}): ${reasonString(parsed) ?? text}`,
@@ -155,9 +170,15 @@ function isObject(v: unknown): v is Record<string, unknown> {
   return v !== null && typeof v === "object";
 }
 
-/** Failure branch is identical across all three endpoints. */
-function isFailureBranch(v: Record<string, unknown>): boolean {
-  return v.ok === false && typeof v.code === "string" && typeof v.reason === "string";
+/**
+ * Failure branch is identical across all three endpoints. Accepts
+ * `unknown` so the non-2xx path can pre-check the parsed body without
+ * narrowing first.
+ */
+function isFailureBranch(v: unknown): v is { ok: false; code: string; reason: string } {
+  return (
+    isObject(v) && v.ok === false && typeof v.code === "string" && typeof v.reason === "string"
+  );
 }
 
 function isVerifyResult(parsed: unknown): parsed is FacilitatorVerifyResult {

--- a/typescript/packages/server/src/facilitator/client.ts
+++ b/typescript/packages/server/src/facilitator/client.ts
@@ -8,7 +8,7 @@
 // are returned verbatim — both shapes are answers the caller branches
 // on. The facilitator-express adapter emits domain failures over HTTP
 // 400 (so curl users still see a 4xx), but the wire body is still a
-// well-formed result; we recognise that shape on non-2xx responses and
+// well-formed result; we recognise that shape on HTTP 400 responses and
 // hand it back rather than throwing. HTTP-transport failures (network
 // down, non-JSON body, schema-mismatched body) throw
 // `FacilitatorHttpError` so the composition layer can distinguish
@@ -55,7 +55,7 @@ export interface FacilitatorClient {
  * Construct a typed HTTP client for the facilitator. The returned
  * methods stringify the input as JSON and POST to the matching path
  * on the configured URL. Bodies matching the well-formed result shape
- * (whether HTTP 2xx success or HTTP 4xx domain rejection) are returned
+ * (whether HTTP 2xx success or HTTP 400 domain rejection) are returned
  * verbatim; transport failures (network, non-JSON body,
  * schema-mismatched body) raise `FacilitatorHttpError`.
  */
@@ -116,9 +116,10 @@ export function createFacilitatorClient(opts: CreateFacilitatorClientOptions): F
       // shape and surface it as the typed result — every endpoint's
       // `Res` union includes the same `{ok:false, code, reason}`
       // variant, so the cast through `validate` (which also accepts
-      // that shape) preserves type-safety. Anything else on a non-2xx
-      // is a genuine transport failure.
-      if (isFailureBranch(parsed) && validate(parsed)) {
+      // that shape) preserves type-safety. Any other non-2xx status is
+      // a genuine transport failure even if its body happens to look
+      // like a facilitator result.
+      if (res.status === 400 && isFailureBranch(parsed) && validate(parsed)) {
         return parsed;
       }
       const facilitatorCode = extractFacilitatorCode(parsed);

--- a/typescript/packages/server/test/facilitator-client.test.ts
+++ b/typescript/packages/server/test/facilitator-client.test.ts
@@ -181,21 +181,91 @@ describe("createFacilitatorClient", () => {
     });
   });
 
-  it("throws FacilitatorHttpError(BAD_HTTP_STATUS) on 5xx, carrying facilitatorCode if present", async () => {
-    const stub = makeStubFetch(() => ({
-      status: 500,
-      body: { ok: false, code: "INTERNAL_ERROR", reason: "boom" },
-    }));
+  it("throws FacilitatorHttpError(BAD_HTTP_STATUS) on 5xx with a non-JSON body", async () => {
+    // Non-2xx + body that doesn't parse as a well-formed facilitator
+    // result is a transport-layer fault — surface it as
+    // FacilitatorHttpError so the caller maps it to FACILITATOR_UNREACHABLE.
+    const stub = makeStubFetch(() => ({ status: 500, textOverride: "oops" }));
     const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
 
     await expect(client.settle(settleInput)).rejects.toBeInstanceOf(FacilitatorHttpError);
     try {
       await client.settle(settleInput);
     } catch (e) {
-      expect((e as FacilitatorHttpError).code).toBe("BAD_HTTP_STATUS");
+      // Non-JSON body trips the JSON.parse guard, not the BAD_HTTP_STATUS path.
+      expect((e as FacilitatorHttpError).code).toBe("BAD_RESPONSE_BODY");
       expect((e as FacilitatorHttpError).status).toBe(500);
-      expect((e as FacilitatorHttpError).facilitatorCode).toBe("INTERNAL_ERROR");
     }
+  });
+
+  it("throws FacilitatorHttpError(BAD_HTTP_STATUS) on non-2xx with parseable but off-shape body", async () => {
+    // The body is valid JSON but doesn't satisfy the
+    // `{ok:false, code, reason}` shape; classify as transport failure.
+    const stub = makeStubFetch(() => ({ status: 400, body: { random: "shape" } }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    await expect(client.settle(settleInput)).rejects.toMatchObject({
+      name: "FacilitatorHttpError",
+      code: "BAD_HTTP_STATUS",
+      status: 400,
+    });
+  });
+
+  it("returns the domain `{ok:false}` body on a non-2xx HTTP (facilitator-express 400)", async () => {
+    // `facilitator-express` emits domain failures (e.g. bad meta-tx
+    // signature) over HTTP 400 with the well-formed result body. The
+    // client must surface that as a domain result, not throw —
+    // otherwise the convenience handlers can't distinguish a domain
+    // rejection from a real transport fault.
+    const stub = makeStubFetch(() => ({
+      status: 400,
+      body: {
+        ok: false,
+        code: "BAD_META_TX_SIGNATURE",
+        reason: "recovered signer 0xaaa != metaTx.from 0xbbb",
+      },
+    }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    const result = await client.verify(verifyInput);
+
+    expect(result).toEqual({
+      ok: false,
+      code: "BAD_META_TX_SIGNATURE",
+      reason: "recovered signer 0xaaa != metaTx.from 0xbbb",
+    });
+  });
+
+  it("returns the domain `{ok:false}` body for /settle on a non-2xx HTTP", async () => {
+    const stub = makeStubFetch(() => ({
+      status: 400,
+      body: { ok: false, code: "SIMULATION_REVERT", reason: "estimateGas threw" },
+    }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    const result = await client.settle(settleInput);
+
+    expect(result).toEqual({
+      ok: false,
+      code: "SIMULATION_REVERT",
+      reason: "estimateGas threw",
+    });
+  });
+
+  it("returns the domain `{ok:false}` body for /perform-action on a non-2xx HTTP", async () => {
+    const stub = makeStubFetch(() => ({
+      status: 400,
+      body: { ok: false, code: "ONCHAIN_REVERT", reason: "fund balance too low" },
+    }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    const result = await client.performAction(performActionInput);
+
+    expect(result).toEqual({
+      ok: false,
+      code: "ONCHAIN_REVERT",
+      reason: "fund balance too low",
+    });
   });
 
   it("throws FacilitatorHttpError(BAD_RESPONSE_BODY) on non-JSON 200", async () => {

--- a/typescript/packages/server/test/facilitator-client.test.ts
+++ b/typescript/packages/server/test/facilitator-client.test.ts
@@ -181,7 +181,7 @@ describe("createFacilitatorClient", () => {
     });
   });
 
-  it("throws FacilitatorHttpError(BAD_HTTP_STATUS) on 5xx with a non-JSON body", async () => {
+  it("throws FacilitatorHttpError(BAD_RESPONSE_BODY) on 5xx with a non-JSON body", async () => {
     // Non-2xx + body that doesn't parse as a well-formed facilitator
     // result is a transport-layer fault — surface it as
     // FacilitatorHttpError so the caller maps it to FACILITATOR_UNREACHABLE.
@@ -198,6 +198,21 @@ describe("createFacilitatorClient", () => {
     }
   });
 
+  it("throws FacilitatorHttpError(BAD_HTTP_STATUS) on 5xx with a well-formed domain body", async () => {
+    const stub = makeStubFetch(() => ({
+      status: 500,
+      body: { ok: false, code: "INTERNAL_ERROR", reason: "boom" },
+    }));
+    const client = createFacilitatorClient({ url: BASE_URL, fetch: stub.fetch });
+
+    await expect(client.settle(settleInput)).rejects.toMatchObject({
+      name: "FacilitatorHttpError",
+      code: "BAD_HTTP_STATUS",
+      status: 500,
+      facilitatorCode: "INTERNAL_ERROR",
+    });
+  });
+
   it("throws FacilitatorHttpError(BAD_HTTP_STATUS) on non-2xx with parseable but off-shape body", async () => {
     // The body is valid JSON but doesn't satisfy the
     // `{ok:false, code, reason}` shape; classify as transport failure.
@@ -211,7 +226,7 @@ describe("createFacilitatorClient", () => {
     });
   });
 
-  it("returns the domain `{ok:false}` body on a non-2xx HTTP (facilitator-express 400)", async () => {
+  it("returns the domain `{ok:false}` body on HTTP 400 (facilitator-express)", async () => {
     // `facilitator-express` emits domain failures (e.g. bad meta-tx
     // signature) over HTTP 400 with the well-formed result body. The
     // client must surface that as a domain result, not throw —
@@ -236,7 +251,7 @@ describe("createFacilitatorClient", () => {
     });
   });
 
-  it("returns the domain `{ok:false}` body for /settle on a non-2xx HTTP", async () => {
+  it("returns the domain `{ok:false}` body for /settle on HTTP 400", async () => {
     const stub = makeStubFetch(() => ({
       status: 400,
       body: { ok: false, code: "SIMULATION_REVERT", reason: "estimateGas threw" },
@@ -252,7 +267,7 @@ describe("createFacilitatorClient", () => {
     });
   });
 
-  it("returns the domain `{ok:false}` body for /perform-action on a non-2xx HTTP", async () => {
+  it("returns the domain `{ok:false}` body for /perform-action on HTTP 400", async () => {
     const stub = makeStubFetch(() => ({
       status: 400,
       body: { ok: false, code: "ONCHAIN_REVERT", reason: "fund balance too low" },

--- a/typescript/packages/server/test/handlers.test.ts
+++ b/typescript/packages/server/test/handlers.test.ts
@@ -27,19 +27,23 @@ import {
   TOKEN,
 } from "./fixtures.js";
 
-function makeStubFacilitatorFetch(handler: (path: string) => unknown): {
+function makeStubFacilitatorFetch(
+  handler: (path: string) => unknown,
+  opts: { status?: number } = {},
+): {
   fetch: FetchLike;
   calls: Array<{ url: string; body: unknown }>;
 } {
   const calls: Array<{ url: string; body: unknown }> = [];
+  const status = opts.status ?? 200;
   const fetch: FetchLike = async (url, init) => {
     const path = url.replace(/^https?:\/\/[^/]+/, "");
     const parsedBody = init?.body !== undefined ? JSON.parse(init.body) : undefined;
     calls.push({ url, body: parsedBody });
     const response = handler(path);
     return {
-      ok: true,
-      status: 200,
+      ok: status >= 200 && status < 300,
+      status,
       text: async () => JSON.stringify(response),
     };
   };
@@ -70,11 +74,15 @@ const facilitatorUrl = "https://facilitator.example";
 async function buildServerWithStubs(
   opts: {
     facilitator?: (path: string) => unknown;
+    facilitatorStatus?: number;
     reader?: ExchangeReader;
   } = {},
 ) {
   const seller = privateKeyToAccount(TEST_SELLER_PK);
-  const fetchStub = makeStubFacilitatorFetch(opts.facilitator ?? (() => ({ ok: true })));
+  const fetchStub = makeStubFacilitatorFetch(
+    opts.facilitator ?? (() => ({ ok: true })),
+    opts.facilitatorStatus !== undefined ? { status: opts.facilitatorStatus } : {},
+  );
   // Slip the fetch override into the global so the facilitator client
   // picks it up at construction time.
   const originalFetch = globalThis.fetch;
@@ -221,6 +229,59 @@ describe("handlers.commit / commitAndRedeem", () => {
     if (!result.ok) {
       expect(result.status).toBe(502);
       expect(result.body.code).toBe("FACILITATOR_REJECTED");
+    }
+  });
+
+  it("502 FACILITATOR_REJECTED (not _UNREACHABLE) when facilitator returns HTTP 400 + domain failure", async () => {
+    // facilitator-express returns domain rejections (e.g. bad meta-tx
+    // signature) over HTTP 400 with a well-formed `{ok:false}` body.
+    // The client must surface that as a domain result so the commit
+    // handler reaches the `FACILITATOR_REJECTED` branch — not the
+    // `FACILITATOR_UNREACHABLE` "transport down" branch.
+    const fx = await makePaymentFixture();
+    const { server } = await buildServerWithStubs({
+      facilitator: () => ({
+        ok: false,
+        code: "BAD_META_TX_SIGNATURE",
+        reason: "recovered signer != metaTx.from",
+      }),
+      facilitatorStatus: 400,
+      reader: makeReader(null),
+    });
+
+    const result = await server.handlers.commit({
+      paymentHeader: makeBuyerHeader(fx.payload),
+      requirements: fx.requirements,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(502);
+      expect(result.body.code).toBe("FACILITATOR_REJECTED");
+      expect(result.body.details).toMatchObject({ facilitatorCode: "BAD_META_TX_SIGNATURE" });
+    }
+  });
+
+  it("502 FACILITATOR_UNREACHABLE when facilitator returns HTTP 400 with off-shape body", async () => {
+    // Non-2xx with a parseable body that *isn't* the well-formed
+    // `{ok:false, code, reason}` shape is a transport-level fault, not
+    // a domain rejection — map to FACILITATOR_UNREACHABLE.
+    const fx = await makePaymentFixture();
+    const { server } = await buildServerWithStubs({
+      facilitator: () => ({ random: "shape" }),
+      facilitatorStatus: 400,
+      reader: makeReader(null),
+    });
+
+    const result = await server.handlers.commit({
+      paymentHeader: makeBuyerHeader(fx.payload),
+      requirements: fx.requirements,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(502);
+      expect(result.body.code).toBe("FACILITATOR_UNREACHABLE");
     }
   });
 


### PR DESCRIPTION
## Summary

`facilitator-express` returns `{ok:false, code, reason}` over HTTP 400 for domain failures (e.g. `BAD_META_TX_SIGNATURE`). The server-side facilitator client previously threw `FacilitatorHttpError` for all non-2xx responses, which the commit / perform-action / withdraw handlers mapped to `FACILITATOR_UNREACHABLE` — leaking a "facilitator down" diagnostic to the buyer for what was actually a bad signature.

Fix: when a non-2xx response carries a parseable `{ok:false, code, reason}` body, return it as the domain result. Keep `FacilitatorHttpError` for genuine transport failures (network error, non-JSON body, schema-mismatched body). The handlers' existing `result.ok === false` branch maps these to `FACILITATOR_REJECTED` — previously unreachable, now exercised.

No wire-format change.

## Test plan

- [x] New tests cover (a) HTTP 400 + facilitator failure body → domain result, (b) HTTP 500 + non-JSON → `FacilitatorHttpError`, (c) HTTP 400 + parseable-but-wrong-shape JSON → `FacilitatorHttpError`
- [x] Commit handler test asserts `FACILITATOR_REJECTED` (not `FACILITATOR_UNREACHABLE`) is now reachable
- [x] `pnpm build && pnpm test && pnpm lint && pnpm format:check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Facilitator client now distinguishes service rejections from transport failures: well-formed domain rejections (HTTP 400 with {ok:false,code,reason}) are returned as typed rejection results, while transport/parsing/5xx issues still surface as errors. Commit handling maps well-formed 400s to FACILITATOR_REJECTED and off-shape 400s to FACILITATOR_UNREACHABLE.
* **Tests**
  * Expanded test coverage and stubs to validate the above behaviors across endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/64)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->