### PR TITLE
feat(x402-e2e): scaffold containerised e2e stack

### DIFF
--- a/docs/boson-impl-01-escrow-scheme.md
+++ b/docs/boson-impl-01-escrow-scheme.md
@@ -224,7 +224,7 @@ for the redeem-time wire shape and the channel adapter contract.
 
 ### 4.1 Seller — `FullOffer` (protocol EIP-712 domain)
 
-```
+```text
 domain:  { name: "Boson Protocol", version: "V2", salt: bytes32(chainId), verifyingContract: <Diamond> }
 type:    FullOffer(
            Offer offer,
@@ -244,7 +244,7 @@ Nested structs `Offer`, `OfferDates`, `OfferDurations`, `DRParameters`, `Conditi
 
 The buyer signs **one** EIP-712 meta-tx authorising execution of `<action>` on the protocol Diamond. This is the only Boson-side signature required regardless of which token-auth strategy the buyer picks.
 
-```
+```text
 domain:  { name: "Boson Protocol", version: "V2", chainId, verifyingContract: <Diamond> }
 type:    MetaTransaction(
            uint256 nonce,

--- a/docs/boson-impl-07-facilitator.md
+++ b/docs/boson-impl-07-facilitator.md
@@ -14,7 +14,7 @@ Stateless w.r.t. funds; never custodies tokens. Stateful only for in-flight tx t
 
 ## Endpoints
 
-```
+```text
 POST /verify
   body: { scheme: "escrow", network, payload, requirements }
   -> { ok: true } | { ok: false, code, reason }

--- a/examples/resource-server/package.json
+++ b/examples/resource-server/package.json
@@ -5,6 +5,14 @@
   "license": "Apache-2.0",
   "description": "Reference Express host for @bosonprotocol/x402-server-express. Boots a working x402B resource server from environment variables; doubles as the runtime image for the x402B e2e suite.",
   "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "build": "tsc --noEmit",
     "start": "tsx src/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,6 +472,31 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.40)
 
+  typescript/packages/x402-e2e:
+    dependencies:
+      '@bosonprotocol/x402-example-resource-server':
+        specifier: workspace:^
+        version: link:../../../examples/resource-server
+      '@bosonprotocol/x402-server':
+        specifier: workspace:^
+        version: link:../server
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.10
+        version: 20.19.40
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      viem:
+        specifier: ^2.39.3
+        version: 2.48.11(typescript@5.9.3)(zod@3.25.76)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.40)
+
 packages:
 
   '@adraffy/ens-normalize@1.10.1':
@@ -1185,9 +1210,19 @@ packages:
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm-eabi@4.60.3':
     resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
     cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.60.3':
@@ -1195,9 +1230,19 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-arm64@4.60.3':
     resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
     cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.60.3':
@@ -1205,9 +1250,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@rollup/rollup-freebsd-arm64@4.60.3':
     resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.60.3':
@@ -1215,8 +1270,18 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
 
@@ -1225,8 +1290,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
 
@@ -1235,8 +1310,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
 
@@ -1245,8 +1330,18 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
 
@@ -1255,8 +1350,18 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
 
@@ -1265,13 +1370,28 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
 
@@ -1280,19 +1400,39 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
   '@rollup/rollup-openbsd-x64@4.60.3':
     resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
     cpu: [x64]
     os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@rollup/rollup-openharmony-arm64@4.60.3':
     resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
     cpu: [arm64]
     os: [openharmony]
 
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rollup/rollup-win32-arm64-msvc@4.60.3':
     resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
     cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.60.3':
@@ -1300,8 +1440,18 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-gnu@4.60.3':
     resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
 
@@ -2529,6 +2679,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rollup@4.60.3:
     resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -3616,76 +3771,151 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
   '@rollup/rollup-android-arm-eabi@4.60.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
     optional: true
 
   '@rollup/rollup-android-arm64@4.60.3':
     optional: true
 
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
   '@rollup/rollup-darwin-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.60.3':
     optional: true
 
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
   '@rollup/rollup-freebsd-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.60.3':
     optional: true
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
   '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     optional: true
 
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     optional: true
 
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     optional: true
 
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     optional: true
 
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     optional: true
 
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.60.3':
     optional: true
 
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
   '@rollup/rollup-openharmony-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.60.3':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.60.3':
     optional: true
 
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
   '@rollup/rollup-win32-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.60.3':
@@ -4384,7 +4614,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
 
@@ -4993,6 +5223,37 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
   rollup@4.60.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -5357,7 +5618,7 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.14
-      rollup: 4.60.3
+      rollup: 4.60.2
     optionalDependencies:
       '@types/node': 20.19.40
       fsevents: 2.3.3
@@ -5366,7 +5627,7 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.14
-      rollup: 4.60.3
+      rollup: 4.60.2
     optionalDependencies:
       '@types/node': 22.7.5
       fsevents: 2.3.3

--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -1,0 +1,109 @@
+# @bosonprotocol/x402-e2e
+
+End-to-end test suite for x402B. Private workspace package — never
+published. Wraps the canonical Boson local stack
+(`boson-protocol-node`, `boson-subgraph`, `ipfs`, `postgres`,
+`meta-tx-gateway`, `boson-mcp-server`) plus the three x402B example
+services (`facilitator-http`, `resource-server`, `webhook-sink`) into
+a single programmatic lifecycle.
+
+> PR 4 of 6 ships the **stack scaffolding** — compose file, lifecycle
+> scripts, deploy-done readiness probe, and a gated smoke test.
+> The buyer/seller/resolver harness lands in PR 5; scenario tests in PR 6.
+
+## Layout
+
+```
+src/
+  bin/
+    resource-server.ts            ← entrypoint for x402b-resource-server (wraps the example)
+    resource-server.Dockerfile    ← Dockerfile invoked by compose.yaml
+  config/
+    accounts.ts                   ← verbatim test PKs from boson-protocol-contracts/accounts.js
+    local-31337-0.ts              ← address + URL constants from core-sdk's defaultConfig
+  stack/
+    compose.yaml                  ← canonical Boson stack + 3 x402B services
+    ipfs-config.sh                ← volume-mounted into the ipfs container
+    start.ts / stop.ts            ← programmatic docker compose up / down
+    readiness.ts                  ← polls boson-protocol-node + boson-subgraph deploy.done markers
+    paths.ts / exec.ts            ← internals
+scripts/
+  stack-up.ts / stack-down.ts     ← CLI wrappers (see `pnpm stack:up` / `:down`)
+test/
+  stack.test.ts                   ← gated smoke (E2E_DOCKER=1)
+```
+
+## Bring the stack up
+
+The compose file is anchored at `src/stack/compose.yaml`; the CLI
+wrappers resolve it absolute so `pnpm stack:up` works from any CWD.
+
+```sh
+pnpm --filter @bosonprotocol/x402-e2e stack:up [--pull] [--build] [--no-wait]
+```
+
+The `up` flow runs in two phases:
+
+1. **`docker compose up -d --wait`** — Docker reports every container
+   has started. For services without a Docker `HEALTHCHECK` (most of
+   the upstream Boson images), this only means the entry process
+   forked, not that the contracts / subgraph have finished deploying.
+2. **`waitForStackReady`** — polls the two deploy-done markers the
+   upstream containers drop after their automatic deploy step:
+   - `boson-protocol-node:/app/deploy.done` (~30–90s on a warm cache)
+   - `boson-subgraph:/home/deploy.done` (~30–60s after the chain is up)
+
+   Matches `bosonprotocol/core-components:e2e/prepare-e2e-services.sh`.
+   Pass `--no-wait` if you only need IPFS + RPC.
+
+```sh
+pnpm --filter @bosonprotocol/x402-e2e stack:down [--keep-volumes] [--rmi]
+```
+
+Default `down` removes the volumes (resets chain + subgraph + IPFS
+state). Pass `--keep-volumes` to preserve them across runs.
+
+## Smoke test
+
+```sh
+E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test
+```
+
+Boots the stack, waits for both `deploy.done` markers, pings every
+service's HTTP-level health probe (or root URL), and tears down. Allow
+2–5 minutes on a cold image pull.
+
+Without `E2E_DOCKER=1`, the suite skips itself so the repo-wide
+`pnpm test` stays fast.
+
+## Conventions
+
+- **Test accounts** — `src/config/accounts.ts` carries the verbatim
+  `ACCOUNT_1`…`ACCOUNT_9` keys from
+  [`bosonprotocol/core-components:contracts/accounts.js`](https://github.com/bosonprotocol/core-components/blob/main/contracts/accounts.js).
+  Test keys only. Role assignments (gateway, facilitator relayer,
+  seller, buyer, resolver) live in the `ROLE_ACCOUNTS` map; distinct
+  account per role so concurrent meta-tx submissions never share a
+  nonce.
+- **Addresses + URLs** — `src/config/local-31337-0.ts` is a typed copy
+  of the `local-31337-0` entry from `@bosonprotocol/core-sdk`'s
+  `defaultConfig`. Source-of-truth comment cites the upstream file so
+  bumps are obvious.
+- **Compose env vars** — left verbatim from the canonical
+  `bosonprotocol/agentic-commerce` compose file. Updates land here
+  only after they land upstream, so a developer running the canonical
+  stack from another Boson project sees the same env.
+
+## Caveats — PR4 scope
+
+- **`x402b-resource-server` uses a placeholder `ExchangeReader`**
+  ([`src/bin/resource-server.ts`](./src/bin/resource-server.ts)). The
+  `GET /resource` 402 challenge path works; `POST /x402B/{commit,redeem,
+  dispute/*}` will fail with `STATE_VERIFY_EXCHANGE_NOT_FOUND` until
+  PR5 wires a subgraph-backed reader.
+- **No seed step yet.** The boson-protocol-node container already ships
+  with a deployed dispute resolver (`id: 1`) and three test ERC-20s,
+  so for the smoke path no seed is needed. PR5 adds the
+  `createSeller` flow (via core-sdk → meta-tx-gateway) the buyer flows
+  depend on.
+- **No buyer / seller actors yet.** Lands in PR5.

--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -13,7 +13,7 @@ a single programmatic lifecycle.
 
 ## Layout
 
-```
+```text
 src/
   bin/
     resource-server.ts            ← entrypoint for x402b-resource-server (wraps the example)

--- a/typescript/packages/x402-e2e/package.json
+++ b/typescript/packages/x402-e2e/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@bosonprotocol/x402-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "description": "Containerised end-to-end test suite for x402B. Wraps the canonical Boson stack (boson-protocol-node, boson-subgraph, ipfs, postgres, meta-tx-gateway, boson-mcp-server) and the x402B example services (resource-server, facilitator-http, webhook-sink) behind a programmatic lifecycle + scenario harness.",
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src test scripts --max-warnings 0",
+    "stack:up": "tsx scripts/stack-up.ts",
+    "stack:down": "tsx scripts/stack-down.ts",
+    "clean": "rm -rf .turbo"
+  },
+  "dependencies": {
+    "@bosonprotocol/x402-example-resource-server": "workspace:^",
+    "@bosonprotocol/x402-server": "workspace:^",
+    "tsx": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.10",
+    "typescript": "^5.7.2",
+    "viem": "^2.39.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/typescript/packages/x402-e2e/scripts/stack-down.ts
+++ b/typescript/packages/x402-e2e/scripts/stack-down.ts
@@ -1,0 +1,33 @@
+// `pnpm --filter @bosonprotocol/x402-e2e stack:down` — tear the stack
+// down. Default behaviour matches the upstream `prepare-e2e-services.sh`
+// cleanup (`docker compose down -v`).
+
+import { stopStack } from "../src/stack/index.js";
+
+const args = new Set(process.argv.slice(2));
+const usage = args.has("--help") || args.has("-h");
+if (usage) {
+  console.log(
+    [
+      "Usage: pnpm --filter @bosonprotocol/x402-e2e stack:down [--keep-volumes] [--rmi]",
+      "",
+      "Flags:",
+      "  --keep-volumes   Skip `-v`; preserves the chain + subgraph + IPFS state.",
+      "  --rmi            Also remove locally-built images (`--rmi local`).",
+    ].join("\n"),
+  );
+  process.exit(0);
+}
+
+async function main(): Promise<void> {
+  await stopStack({
+    volumes: !args.has("--keep-volumes"),
+    removeImages: args.has("--rmi"),
+  });
+  console.log("[stack] torn down");
+}
+
+main().catch((e: unknown) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/typescript/packages/x402-e2e/scripts/stack-up.ts
+++ b/typescript/packages/x402-e2e/scripts/stack-up.ts
@@ -1,0 +1,34 @@
+// `pnpm --filter @bosonprotocol/x402-e2e stack:up` — bring up the stack
+// from a shell. CLI flags map directly to `startStack`'s options.
+
+import { startStack } from "../src/stack/index.js";
+
+const args = new Set(process.argv.slice(2));
+const usage = args.has("--help") || args.has("-h");
+if (usage) {
+  console.log(
+    [
+      "Usage: pnpm --filter @bosonprotocol/x402-e2e stack:up [--pull] [--build] [--no-wait]",
+      "",
+      "Flags:",
+      "  --pull       Run `docker compose pull` first to refresh upstream images.",
+      "  --build      Rebuild local images from the example Dockerfiles before `up`.",
+      "  --no-wait    Skip the contracts + subgraph `deploy.done` readiness probe.",
+    ].join("\n"),
+  );
+  process.exit(0);
+}
+
+async function main(): Promise<void> {
+  await startStack({
+    pull: args.has("--pull"),
+    build: args.has("--build"),
+    waitForReady: !args.has("--no-wait"),
+  });
+  console.log("[stack] ready");
+}
+
+main().catch((e: unknown) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/typescript/packages/x402-e2e/src/bin/resource-server.Dockerfile
+++ b/typescript/packages/x402-e2e/src/bin/resource-server.Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1.7
+#
+# Build from the monorepo root so the root pnpm-lock.yaml is in context:
+#   docker build -t x402b-e2e-resource-server -f typescript/packages/x402-e2e/src/bin/resource-server.Dockerfile .
+#
+# Wraps `@bosonprotocol/x402-example-resource-server` with the entrypoint
+# in `src/bin/resource-server.ts`, which constructs an `ExchangeReader`
+# (the example's own binary refuses to start without one).
+
+FROM node:22-alpine AS base
+RUN corepack enable
+WORKDIR /repo
+
+FROM base AS deps
+COPY . .
+RUN pnpm install --frozen-lockfile \
+    --filter @bosonprotocol/x402-e2e...
+
+# Build the workspace deps the bin entrypoint imports (tsup emits dist/
+# + the exports map points at it). The trailing `...` includes the
+# transitive workspace chain (x402-core, x402-evm, x402-actions,
+# x402-fulfillment, x402-server, x402-server-express, x402-example-resource-server).
+RUN pnpm --filter @bosonprotocol/x402-example-resource-server... build
+
+RUN pnpm --filter @bosonprotocol/x402-e2e deploy --legacy /deploy
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+COPY --from=deps /deploy ./
+
+ENV PORT=4001
+EXPOSE 4001
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- "http://127.0.0.1:${PORT}/health" >/dev/null || exit 1
+
+USER node
+CMD ["node_modules/.bin/tsx", "src/bin/resource-server.ts"]

--- a/typescript/packages/x402-e2e/src/bin/resource-server.ts
+++ b/typescript/packages/x402-e2e/src/bin/resource-server.ts
@@ -1,0 +1,34 @@
+// Boot entrypoint for the `x402b-resource-server` compose service.
+//
+// `@bosonprotocol/x402-example-resource-server`'s own `index.ts` throws
+// at startup because it intentionally ships no `ExchangeReader`. This
+// entrypoint provides one — for PR4 it's a logging placeholder that
+// returns `null`; the 402 challenge path doesn't touch the reader, so
+// the resource-server container boots and `/health` + `GET /resource`
+// work end-to-end. Write handlers (commit, redeem, dispute/*) will
+// fail with `STATE_VERIFY_EXCHANGE_NOT_FOUND` until PR5 swaps the
+// reader for a subgraph-backed implementation against the
+// `boson-subgraph` container.
+
+import { createResourceServerApp, readEnv } from "@bosonprotocol/x402-example-resource-server";
+import type { ExchangeReader, ExchangeSnapshot } from "@bosonprotocol/x402-server";
+
+const placeholderExchangeReader: ExchangeReader = {
+  read: async (exchangeId: string): Promise<ExchangeSnapshot | null> => {
+    console.warn(
+      `[x402-e2e/resource-server] placeholder ExchangeReader.read(${exchangeId}) returning null — PR5 wires the subgraph-backed reader`,
+    );
+    return null;
+  },
+};
+
+const env = readEnv();
+const { app, seller } = createResourceServerApp(env, {
+  exchangeReader: placeholderExchangeReader,
+});
+
+app.listen(env.port, () => {
+  console.log(
+    `[x402-e2e/resource-server] listening on :${env.port} (chain ${env.chainId}, seller ${seller.address}, asset ${env.assetAddress})`,
+  );
+});

--- a/typescript/packages/x402-e2e/src/bin/resource-server.ts
+++ b/typescript/packages/x402-e2e/src/bin/resource-server.ts
@@ -27,8 +27,15 @@ const { app, seller } = createResourceServerApp(env, {
   exchangeReader: placeholderExchangeReader,
 });
 
-app.listen(env.port, () => {
+const server = app.listen(env.port, () => {
   console.log(
     `[x402-e2e/resource-server] listening on :${env.port} (chain ${env.chainId}, seller ${seller.address}, asset ${env.assetAddress})`,
   );
+});
+
+server.on("error", (err: Error) => {
+  console.error(
+    `[x402-e2e/resource-server] failed to bind on :${env.port} (chain ${env.chainId}, seller ${seller.address}, asset ${env.assetAddress}): ${err.message}`,
+  );
+  process.exit(1);
 });

--- a/typescript/packages/x402-e2e/src/config/accounts.ts
+++ b/typescript/packages/x402-e2e/src/config/accounts.ts
@@ -1,0 +1,79 @@
+// Deterministic test accounts the `boson-protocol-node` container ships
+// with. Verbatim copy of `bosonprotocol/core-components:contracts/accounts.js`
+// at `main`. Every address listed here is pre-funded with native test ETH
+// on the in-container chain. **Test keys only — never use on a real network.**
+//
+// Naming follows the source file (1-indexed; `ACCOUNT_1` is what Hardhat
+// would label `ACCOUNT_0`). Names preserved so cross-referencing the
+// upstream contracts repo / canonical compose env vars (`ACCOUNT_9`) stays
+// straightforward.
+
+import type { Address, Hex } from "viem";
+
+export interface TestAccount {
+  address: Address;
+  privateKey: Hex;
+}
+
+export const ACCOUNT_1: TestAccount = {
+  address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+  privateKey: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+};
+
+export const ACCOUNT_2: TestAccount = {
+  address: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+  privateKey: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+};
+
+export const ACCOUNT_3: TestAccount = {
+  address: "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
+  privateKey: "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a",
+};
+
+export const ACCOUNT_4: TestAccount = {
+  address: "0x3A78DE5B3b3BdF61339f6D683ee82c5743c7b3EE",
+  privateKey: "0x3486daa503dcea7b6a3a9b956d5056f86bdae71323949588a90b2b65b75cd4e9",
+};
+
+export const ACCOUNT_5: TestAccount = {
+  address: "0x130F244980978a5A46C7339DDf43176047d794Ce",
+  privateKey: "0xa2e78cd4c87191e50d6a8f1610b1cf160b17216e9090dde7a92960a34c310482",
+};
+
+export const ACCOUNT_6: TestAccount = {
+  address: "0xd0182FBe7E02B95dF76b11f596beB529f18013f9",
+  privateKey: "0x2538569f1fa75a09fa2b5ec61995fdc6772b8b8bcbd26c6146e62f87dfc0b3ae",
+};
+
+export const ACCOUNT_7: TestAccount = {
+  address: "0x573d92bFb23Ec56FD991E2f54267e518EFC5A9c1",
+  privateKey: "0x213a02a5d190ccc5704ac9ec31a9f8ce7712e7ddba098ae1353c81d6e5046497",
+};
+
+export const ACCOUNT_8: TestAccount = {
+  address: "0x1487756254E93d00a6DCDfc40bAe757c1e99E8c0",
+  privateKey: "0x8e7f74d2eac64f4610b0ff0dea351b9f0fa61f31b0d3cc188b1dc8d5f71e7622",
+};
+
+/** Used by `meta-tx-gateway` in the canonical Boson e2e compose file. */
+export const ACCOUNT_9: TestAccount = {
+  address: "0x7aDCcBe646B707d0E8c0a339dF5277ee006f172B",
+  privateKey: "0x316b234f5fea007dcc40404188b588fb90cb9bb1e33fc163e212eab2f8565293",
+};
+
+/**
+ * Role assignments for the x402B e2e stack. Distinct accounts per role so
+ * concurrent meta-tx submissions never share a relayer nonce.
+ */
+export const ROLE_ACCOUNTS = {
+  /** Already wired into the meta-tx-gateway service in `compose.yaml`. */
+  metaTxGatewayRelayer: ACCOUNT_9,
+  /** `x402b-facilitator-http` service relayer wallet. */
+  facilitatorRelayer: ACCOUNT_8,
+  /** `x402b-resource-server` seller signer (FullOffer signatures). */
+  seller: ACCOUNT_2,
+  /** Buyer persona used by the harness (PR5+). */
+  buyer: ACCOUNT_3,
+  /** Dispute-resolver-operator persona used by the harness (PR5+). */
+  resolver: ACCOUNT_4,
+} as const;

--- a/typescript/packages/x402-e2e/src/config/local-31337-0.ts
+++ b/typescript/packages/x402-e2e/src/config/local-31337-0.ts
@@ -1,0 +1,50 @@
+// Address + URL constants for the `local-31337-0` Boson environment.
+// Lifted from `@bosonprotocol/core-sdk`'s `defaultConfig` so this package
+// doesn't drag the SDK in solely to read static values. Source:
+// https://github.com/bosonprotocol/core-components/blob/main/packages/common/src/configs.ts
+// (the `envConfigs.local[0]` entry).
+
+import type { Address } from "viem";
+
+export const LOCAL_31337_0 = {
+  envName: "local",
+  configId: "local-31337-0",
+  chainId: 31337,
+  /** CAIP-2 EVM network id derived from `chainId`. */
+  network: "eip155:31337" as const,
+  defaultDisputeResolverId: "1",
+
+  urls: {
+    /** Hardhat / boson-protocol-node JSON-RPC endpoint (host-side). */
+    jsonRpc: "http://localhost:8545",
+    /** From-container JSON-RPC endpoint (services running inside compose). */
+    jsonRpcInContainer: "http://host.docker.internal:8545",
+    /** Boson subgraph GraphQL endpoint (host-side). */
+    subgraph: "http://localhost:8000/subgraphs/name/boson/corecomponents",
+    /** From-container subgraph endpoint. */
+    subgraphInContainer: "http://host.docker.internal:8000/subgraphs/name/boson/corecomponents",
+    /** Meta-tx-gateway endpoint (host-side). */
+    metaTxGateway: "http://localhost:8888",
+    /** From-container meta-tx-gateway endpoint. */
+    metaTxGatewayInContainer: "http://host.docker.internal:8888",
+    /** Boson MCP server endpoint (host-side). */
+    bosonMcp: "http://localhost:3000",
+    /** From-container Boson MCP server endpoint. */
+    bosonMcpInContainer: "http://host.docker.internal:3000",
+  },
+
+  contracts: {
+    /** Boson Diamond — the protocol entry point and `escrowAddress` for x402B. */
+    protocolDiamond: "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853" as Address,
+    /** Generic test ERC-20 (`Foreign20`). */
+    testErc20: "0x70e0bA845a1A0F2DA3359C97E0285013525FFC49" as Address,
+    /** Test token implementing EIP-3009 `receiveWithAuthorization` (`MockERC3009Token`). */
+    testErc3009: "0x809d550fca64d94Bd9F66E60752A544199cfAC3D" as Address,
+    /** Test token implementing EIP-2612 `permit` (`MockERC2612Token`). */
+    testErc2612: "0x4c5859f0F772848b2D91F1D83E2Fe57935348029" as Address,
+    /** Permit2 deployment (deterministic address on every chain). */
+    permit2: "0x000000000022D473030F116dDEE9F6B43aC78BA3" as Address,
+    /** Forwarder the meta-tx-gateway wraps relayed txs through. */
+    forwarder: "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0" as Address,
+  },
+} as const;

--- a/typescript/packages/x402-e2e/src/index.ts
+++ b/typescript/packages/x402-e2e/src/index.ts
@@ -1,0 +1,7 @@
+// Public re-exports of the e2e package. PR4 ships the stack lifecycle
+// and config constants; PR5 will append the actor/asserter harness; PR6
+// will add the scenario test files.
+
+export * from "./config/accounts.js";
+export { LOCAL_31337_0 } from "./config/local-31337-0.js";
+export * from "./stack/index.js";

--- a/typescript/packages/x402-e2e/src/stack/compose.yaml
+++ b/typescript/packages/x402-e2e/src/stack/compose.yaml
@@ -1,0 +1,162 @@
+# Containerised stack for the x402B e2e suite.
+#
+# Base: bosonprotocol/agentic-commerce@boson-e2e-local-env:docs/boson/example/docker-compose.yaml.
+# Deltas from the canonical file:
+#  - drops `opensea-api-mock` (not exercised by x402B).
+#  - adds three x402B services (`x402b-facilitator-http`,
+#    `x402b-resource-server`, `x402b-webhook-sink`) built from the
+#    monorepo, all using `host.docker.internal:host-gateway` so they
+#    reach the canonical services through the same network alias the
+#    canonical services already use.
+#
+# Every env var on the canonical services is verbatim — keep that way
+# so credentials, FORWARDER_ADDRESS, API_KEYS, etc. stay consistent
+# across all Boson e2e environments. Updates to those should land here
+# only after they land in the canonical compose.
+
+services:
+  boson-protocol-node:
+    image: ghcr.io/bosonprotocol/core-components/boson-protocol-node:main
+    ports:
+      - "8545:8545"
+
+  boson-mcp-server:
+    image: ghcr.io/bosonprotocol/agentic-commerce/mcp-server:pr-89 # TODO: switch to :main once upstream PR merges
+    command: npm run start:boson:http
+    ports:
+      - "3000:3000"
+    environment:
+      - IPFS_METADATA_URL=http://host.docker.internal:5001
+      - THE_GRAPH_IPFS_URL=http://host.docker.internal:5001
+      - LOCALHOST_SUBSTITUTE=host.docker.internal
+      - PROTOCOL=BOSON
+    extra_hosts:
+      - host.docker.internal:host-gateway
+
+  boson-subgraph:
+    image: ghcr.io/bosonprotocol/core-components/boson-subgraph:main
+    ports:
+      - "8000:8000"
+      - "8001:8001"
+      - "8020:8020"
+      - "8030:8030"
+      - "8040:8040"
+    depends_on:
+      - ipfs
+      - postgres
+      - boson-protocol-node
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    environment:
+      postgres_host: postgres
+      postgres_user: graph-node
+      postgres_pass: let-me-in
+      postgres_db: graph-node
+      ipfs: "ipfs:5001"
+      ethereum: "localhost:http://host.docker.internal:8545"
+      GRAPH_LOG: debug
+      GRAPH_ALLOW_NON_DETERMINISTIC_IPFS: "true"
+
+  postgres:
+    image: postgres:14
+    ports:
+      - "5432:5432"
+    command: ["postgres", "-cshared_preload_libraries=pg_stat_statements", "-cmax_connections=200"]
+    environment:
+      POSTGRES_USER: graph-node
+      POSTGRES_PASSWORD: let-me-in
+      POSTGRES_DB: graph-node
+      PGDATA: "/var/lib/postgresql/data"
+      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
+
+  ipfs:
+    image: ipfs/go-ipfs:master-2022-05-25-e8f1ce0
+    ports:
+      - "5001:5001"
+      - "8080:8080"
+    volumes:
+      - ./ipfs-config.sh:/container-init.d/ipfs-config.sh
+
+  meta-tx-gateway:
+    image: ghcr.io/bosonprotocol/meta-tx-gateway:main
+    user: "node:node"
+    ports:
+      - "8888:8888"
+    environment:
+      - ENV_NAME=local
+      - CONFIG_ID=local-31337-0
+      # ACCOUNT_9 from boson-protocol-contracts/contracts/accounts.js.
+      - PRIVATE_KEY=0x316b234f5fea007dcc40404188b588fb90cb9bb1e33fc163e212eab2f8565293
+      - RPC_NODE=http://host.docker.internal:8545
+      - FORWARDER_ADDRESS=0x4c5859f0F772848b2D91F1D83E2Fe57935348029
+      - API_KEYS=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+      - 'API_IDS={"BOSON": ["xxxxxxxx-xxxx-xxxx-xxxx-111111111111"], "FERMION": ["xxxxxxxx-xxxx-xxxx-xxxx-222222222222"], "ERC20": ["xxxxxxxx-xxxx-xxxx-xxxx-333333333333"], "FORWARDER": ["xxxxxxxx-xxxx-xxxx-xxxx-444444444444"]}'
+      - BOSON_VOUCHER_INTERFACE_ID=0x6a474d2c
+    depends_on:
+      - boson-protocol-node
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    command: ["sh", "-c", "sleep 3 && npm run start"]
+
+  # ── x402B services ──────────────────────────────────────────────────
+
+  x402b-facilitator-http:
+    build:
+      # Repo root so the workspace lockfile + facilitator package source
+      # are visible to the multi-stage build.
+      context: ../../../../..
+      dockerfile: examples/facilitator-http/Dockerfile
+    ports:
+      - "8889:8889"
+    environment:
+      # ACCOUNT_8 — distinct from the gateway's ACCOUNT_9 so concurrent
+      # relayer submissions don't share a nonce.
+      - RELAYER_PK=0x8e7f74d2eac64f4610b0ff0dea351b9f0fa61f31b0d3cc188b1dc8d5f71e7622
+      - FACILITATOR_URL=http://host.docker.internal:8889
+      - RPC_NODE=http://host.docker.internal:8545
+      - CHAIN_ID=31337
+      - ESCROW_ADDRESS=0xa513E6E4b8f2a923D98304ec87F64353C4D5C853
+      - PORT=8889
+    depends_on:
+      - boson-protocol-node
+    extra_hosts:
+      - host.docker.internal:host-gateway
+
+  x402b-resource-server:
+    build:
+      context: ../../../../..
+      dockerfile: typescript/packages/x402-e2e/src/bin/resource-server.Dockerfile
+    ports:
+      - "4001:4001"
+    environment:
+      # ACCOUNT_2 — distinct from facilitator (ACCOUNT_8) and gateway
+      # (ACCOUNT_9). The Boson seller entity behind SELLER_ID is created
+      # at suite seed time (PR5); SELLER_ID=1 is a placeholder until
+      # then — the /resource 402 path doesn't dereference it on chain.
+      - SELLER_PK=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+      - SELLER_ID=1
+      - DISPUTE_RESOLVER_ID=1
+      - RESOURCE_SERVER_URL=http://host.docker.internal:4001
+      - RPC_NODE=http://host.docker.internal:8545
+      - CHAIN_ID=31337
+      - ESCROW_ADDRESS=0xa513E6E4b8f2a923D98304ec87F64353C4D5C853
+      - FACILITATOR_URL=http://host.docker.internal:8889
+      - ASSET_ADDRESS=0x70e0bA845a1A0F2DA3359C97E0285013525FFC49
+      - AMOUNT=1000000
+      - SUBGRAPH_URL=http://host.docker.internal:8000/subgraphs/name/boson/corecomponents
+      - PORT=4001
+    depends_on:
+      - boson-protocol-node
+      - boson-subgraph
+      - x402b-facilitator-http
+    extra_hosts:
+      - host.docker.internal:host-gateway
+
+  x402b-webhook-sink:
+    build:
+      context: ../../../../..
+      dockerfile: examples/webhook-sink/Dockerfile
+    ports:
+      - "4002:4000"
+    environment:
+      - PORT=4000

--- a/typescript/packages/x402-e2e/src/stack/compose.yaml
+++ b/typescript/packages/x402-e2e/src/stack/compose.yaml
@@ -22,7 +22,7 @@ services:
       - "8545:8545"
 
   boson-mcp-server:
-    image: ghcr.io/bosonprotocol/agentic-commerce/mcp-server:pr-89 # TODO: switch to :main once upstream PR merges
+    image: ghcr.io/bosonprotocol/agentic-commerce/mcp-server:main
     command: npm run start:boson:http
     ports:
       - "3000:3000"

--- a/typescript/packages/x402-e2e/src/stack/compose.yaml
+++ b/typescript/packages/x402-e2e/src/stack/compose.yaml
@@ -5,9 +5,10 @@
 #  - drops `opensea-api-mock` (not exercised by x402B).
 #  - adds three x402B services (`x402b-facilitator-http`,
 #    `x402b-resource-server`, `x402b-webhook-sink`) built from the
-#    monorepo, all using `host.docker.internal:host-gateway` so they
-#    reach the canonical services through the same network alias the
-#    canonical services already use.
+#    monorepo; the x402B services that need host access use
+#    `host.docker.internal:host-gateway` so they reach the canonical
+#    services through the same network alias the canonical services
+#    already use.
 #
 # Every env var on the canonical services is verbatim — keep that way
 # so credentials, FORWARDER_ADDRESS, API_KEYS, etc. stay consistent

--- a/typescript/packages/x402-e2e/src/stack/exec.ts
+++ b/typescript/packages/x402-e2e/src/stack/exec.ts
@@ -1,0 +1,62 @@
+// Thin promise-based wrapper around `child_process.spawn` for the
+// `docker compose` invocations the stack helpers need. Streams stdout
+// + stderr to the parent process so a long-running `docker compose up`
+// or readiness loop surfaces progress in real time.
+
+import { spawn } from "node:child_process";
+
+export interface RunOptions {
+  /** Working directory for the spawned process. */
+  cwd?: string;
+  /** When `true`, capture stdout instead of streaming it. */
+  captureStdout?: boolean;
+  /** Surface non-zero exit codes as rejected promises (default: true). */
+  rejectOnNonZero?: boolean;
+  /** Suppress stderr output (default: false; useful for polling probes). */
+  silent?: boolean;
+}
+
+export interface RunResult {
+  exitCode: number;
+  stdout: string;
+}
+
+export function run(
+  command: string,
+  args: readonly string[],
+  opts: RunOptions = {},
+): Promise<RunResult> {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(command, [...args], {
+      cwd: opts.cwd,
+      stdio: [
+        "ignore",
+        opts.captureStdout ? "pipe" : "inherit",
+        opts.silent ? "ignore" : "inherit",
+      ],
+    });
+
+    let stdout = "";
+    if (opts.captureStdout && child.stdout !== null) {
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+    }
+
+    child.on("error", reject);
+    child.on("close", (exitCode) => {
+      const code = exitCode ?? -1;
+      const result: RunResult = { exitCode: code, stdout };
+      if (code !== 0 && opts.rejectOnNonZero !== false) {
+        reject(
+          new Error(
+            `command failed (exit ${code}): ${command} ${args.join(" ")}${stdout ? `\n${stdout}` : ""}`,
+          ),
+        );
+        return;
+      }
+      resolveRun(result);
+    });
+  });
+}

--- a/typescript/packages/x402-e2e/src/stack/exec.ts
+++ b/typescript/packages/x402-e2e/src/stack/exec.ts
@@ -27,7 +27,7 @@ export function run(
   opts: RunOptions = {},
 ): Promise<RunResult> {
   return new Promise((resolveRun, reject) => {
-    const child = spawn(command, [...args], {
+    const child = spawn(command, args, {
       cwd: opts.cwd,
       stdio: [
         "ignore",

--- a/typescript/packages/x402-e2e/src/stack/index.ts
+++ b/typescript/packages/x402-e2e/src/stack/index.ts
@@ -1,0 +1,7 @@
+// Public surface of the stack helpers — what `pnpm stack:up`,
+// `pnpm stack:down`, and (in PR5+) the harness consume.
+
+export { startStack, type StartStackOptions } from "./start.js";
+export { stopStack, type StopStackOptions } from "./stop.js";
+export { waitForStackReady, type WaitForReadyOptions } from "./readiness.js";
+export { COMPOSE_FILE } from "./paths.js";

--- a/typescript/packages/x402-e2e/src/stack/ipfs-config.sh
+++ b/typescript/packages/x402-e2e/src/stack/ipfs-config.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+echo "Setting IPFS config..."
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
+ipfs config profile apply lowpower

--- a/typescript/packages/x402-e2e/src/stack/paths.ts
+++ b/typescript/packages/x402-e2e/src/stack/paths.ts
@@ -1,0 +1,12 @@
+// Shared path constants for the stack helpers. Anchors `compose.yaml`
+// at `src/stack/compose.yaml` regardless of where the caller's CWD is
+// (vitest runs from the package root, but `pnpm stack:up` could be
+// invoked from anywhere).
+
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to `src/stack/compose.yaml`. */
+export const COMPOSE_FILE = resolve(here, "compose.yaml");

--- a/typescript/packages/x402-e2e/src/stack/readiness.ts
+++ b/typescript/packages/x402-e2e/src/stack/readiness.ts
@@ -1,0 +1,79 @@
+// Poll for the two "deploy.done" markers the upstream Boson stack
+// drops once its automatic deploy step finishes:
+//
+//  - `/app/deploy.done`   inside `boson-protocol-node`  → contracts are deployed
+//  - `/home/deploy.done`  inside `boson-subgraph`        → subgraph is deployed
+//
+// Mirrors the readiness check from
+// https://github.com/bosonprotocol/core-components/blob/main/e2e/prepare-e2e-services.sh
+// — same probe, same compose-aware execution path. Both deploys are
+// idempotent and run automatically on container start; this helper
+// just waits for them to finish.
+
+import { run } from "./exec.js";
+import { COMPOSE_FILE } from "./paths.js";
+
+export interface WaitForReadyOptions {
+  /** Maximum wall-clock to wait per probe before throwing. Default: 10 minutes. */
+  timeoutMs?: number;
+  /** Polling interval. Default: 15 seconds (matches the upstream script). */
+  intervalMs?: number;
+  /** Logger for human-readable progress lines. Default: `console.log`. */
+  log?: (line: string) => void;
+}
+
+const DEFAULTS = {
+  timeoutMs: 10 * 60_000,
+  intervalMs: 15_000,
+} as const;
+
+async function probe(service: string, path: string): Promise<boolean> {
+  const result = await run(
+    "docker",
+    ["compose", "-f", COMPOSE_FILE, "exec", "-T", service, "ls", path],
+    { silent: true, captureStdout: true, rejectOnNonZero: false },
+  );
+  return result.exitCode === 0;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function pollUntilReady(
+  service: string,
+  path: string,
+  label: string,
+  opts: Required<Omit<WaitForReadyOptions, "log">> & { log: (line: string) => void },
+): Promise<void> {
+  const deadline = Date.now() + opts.timeoutMs;
+  opts.log(`[stack] waiting for ${label}…`);
+  // first check is immediate; subsequent attempts wait `intervalMs`.
+  while (Date.now() < deadline) {
+    if (await probe(service, path)) {
+      opts.log(`[stack] ${label} ✅`);
+      return;
+    }
+    await sleep(opts.intervalMs);
+  }
+  throw new Error(
+    `[stack] timed out after ${opts.timeoutMs / 1000}s waiting for ${label} (service=${service} path=${path})`,
+  );
+}
+
+/** Resolve once both contracts and subgraph are deployed. Sequential by design — subgraph indexes the chain so contracts must finish first. */
+export async function waitForStackReady(options: WaitForReadyOptions = {}): Promise<void> {
+  const merged = {
+    timeoutMs: options.timeoutMs ?? DEFAULTS.timeoutMs,
+    intervalMs: options.intervalMs ?? DEFAULTS.intervalMs,
+    log: options.log ?? ((line: string) => console.log(line)),
+  };
+
+  await pollUntilReady(
+    "boson-protocol-node",
+    "/app/deploy.done",
+    "boson-protocol-node contracts to be deployed",
+    merged,
+  );
+  await pollUntilReady("boson-subgraph", "/home/deploy.done", "boson-subgraph deploy", merged);
+}

--- a/typescript/packages/x402-e2e/src/stack/readiness.ts
+++ b/typescript/packages/x402-e2e/src/stack/readiness.ts
@@ -49,10 +49,13 @@ async function pollUntilReady(
   const deadline = Date.now() + opts.timeoutMs;
   opts.log(`[stack] waiting for ${label}…`);
   // first check is immediate; subsequent attempts wait `intervalMs`.
-  while (Date.now() < deadline) {
+  while (true) {
     if (await probe(service, path)) {
       opts.log(`[stack] ${label} ✅`);
       return;
+    }
+    if (Date.now() >= deadline) {
+      break;
     }
     await sleep(opts.intervalMs);
   }

--- a/typescript/packages/x402-e2e/src/stack/start.ts
+++ b/typescript/packages/x402-e2e/src/stack/start.ts
@@ -1,0 +1,32 @@
+import { run } from "./exec.js";
+import { COMPOSE_FILE } from "./paths.js";
+import { waitForStackReady, type WaitForReadyOptions } from "./readiness.js";
+
+export interface StartStackOptions extends WaitForReadyOptions {
+  /** When `true`, runs `docker compose pull` before `up`. Default: false. */
+  pull?: boolean;
+  /** When `true`, rebuilds images from local context before `up`. Default: false. */
+  build?: boolean;
+  /** When `true`, blocks until `waitForStackReady` resolves. Default: true. */
+  waitForReady?: boolean;
+}
+
+/**
+ * Bring up the canonical Boson stack + the three x402B services in
+ * detached mode. Returns once Docker reports every container started
+ * (`--wait`); set `waitForReady: false` to skip the contracts/subgraph
+ * readiness probe (e.g. when you only need the IPFS + RPC pair up).
+ */
+export async function startStack(options: StartStackOptions = {}): Promise<void> {
+  if (options.pull === true) {
+    await run("docker", ["compose", "-f", COMPOSE_FILE, "pull"]);
+  }
+
+  const upArgs = ["compose", "-f", COMPOSE_FILE, "up", "-d", "--wait"];
+  if (options.build === true) upArgs.push("--build");
+  await run("docker", upArgs);
+
+  if (options.waitForReady !== false) {
+    await waitForStackReady(options);
+  }
+}

--- a/typescript/packages/x402-e2e/src/stack/stop.ts
+++ b/typescript/packages/x402-e2e/src/stack/stop.ts
@@ -1,0 +1,17 @@
+import { run } from "./exec.js";
+import { COMPOSE_FILE } from "./paths.js";
+
+export interface StopStackOptions {
+  /** When `true`, deletes the named volumes (resets the chain + subgraph + IPFS). Default: true. */
+  volumes?: boolean;
+  /** When `true`, also removes images built by `compose up --build`. Default: false. */
+  removeImages?: boolean;
+}
+
+/** Tear down the stack. Mirrors `docker compose down [-v] [--rmi local]`. */
+export async function stopStack(options: StopStackOptions = {}): Promise<void> {
+  const args = ["compose", "-f", COMPOSE_FILE, "down"];
+  if (options.volumes !== false) args.push("-v");
+  if (options.removeImages === true) args.push("--rmi", "local");
+  await run("docker", args);
+}

--- a/typescript/packages/x402-e2e/test/stack.test.ts
+++ b/typescript/packages/x402-e2e/test/stack.test.ts
@@ -47,8 +47,16 @@ async function ping(url: string, expect2xx: boolean): Promise<PingResult> {
   }
 }
 
-const PING_MAX_ATTEMPTS = Number(process.env.E2E_PING_MAX_ATTEMPTS ?? 10);
-const PING_RETRY_DELAY_MS = Number(process.env.E2E_PING_RETRY_DELAY_MS ?? 1000);
+function envInt(name: string, fallback: number, min: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n)) return fallback;
+  return n < min ? min : n;
+}
+
+const PING_MAX_ATTEMPTS = envInt("E2E_PING_MAX_ATTEMPTS", 10, 1);
+const PING_RETRY_DELAY_MS = envInt("E2E_PING_RETRY_DELAY_MS", 1000, 100);
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));

--- a/typescript/packages/x402-e2e/test/stack.test.ts
+++ b/typescript/packages/x402-e2e/test/stack.test.ts
@@ -22,6 +22,10 @@ const HEALTH_TARGETS: readonly { name: string; url: string }[] = [
   { name: "boson-subgraph", url: "http://localhost:8030" },
   { name: "boson-mcp-server", url: LOCAL_31337_0.urls.bosonMcp },
   { name: "meta-tx-gateway", url: LOCAL_31337_0.urls.metaTxGateway },
+  // IPFS Kubo API — POST-only, so GET answers 4xx when the container is
+  // up. Probing it directly catches a stopped/unreachable IPFS instead
+  // of relying on the subgraph's startup dependency to surface it.
+  { name: "ipfs", url: "http://localhost:5001/api/v0/version" },
   { name: "x402b-facilitator-http", url: "http://localhost:8889/health" },
   { name: "x402b-resource-server", url: "http://localhost:4001/health" },
   { name: "x402b-webhook-sink", url: "http://localhost:4002/health" },

--- a/typescript/packages/x402-e2e/test/stack.test.ts
+++ b/typescript/packages/x402-e2e/test/stack.test.ts
@@ -31,16 +31,33 @@ const HEALTH_TARGETS: readonly { name: string; url: string }[] = [
   { name: "x402b-webhook-sink", url: "http://localhost:4002/health" },
 ];
 
-async function ping(url: string): Promise<{ ok: boolean; status: number }> {
+interface PingResult {
+  ok: boolean;
+  status: number;
+  error?: string;
+}
+
+async function ping(url: string): Promise<PingResult> {
   // POST-only services (the RPC node + the gateway) answer GET with a
   // 4xx — that's good enough for "the container is up and listening".
   // Treat only non-5xx as healthy reachability.
   try {
     const res = await fetch(url, { method: "GET" });
     return { ok: res.status < 500, status: res.status };
-  } catch {
-    return { ok: false, status: 0 };
+  } catch (err) {
+    return { ok: false, status: 0, error: err instanceof Error ? err.message : String(err) };
   }
+}
+
+const PING_MAX_ATTEMPTS = Number(process.env.E2E_PING_MAX_ATTEMPTS ?? 10);
+const PING_RETRY_DELAY_MS = Number(process.env.E2E_PING_RETRY_DELAY_MS ?? 1000);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function describePing(r: PingResult): string {
+  return r.error ? `error=${r.error}` : `status=${r.status}`;
 }
 
 describe.skipIf(!ENABLED)("x402-e2e stack smoke", () => {
@@ -54,8 +71,16 @@ describe.skipIf(!ENABLED)("x402-e2e stack smoke", () => {
 
   for (const target of HEALTH_TARGETS) {
     it(`${target.name} is reachable`, async () => {
-      const result = await ping(target.url);
-      expect(result.ok, `expected ${target.url} to be reachable; got ECONNREFUSED`).toBe(true);
+      let last: PingResult = { ok: false, status: 0, error: "no attempt made" };
+      for (let attempt = 1; attempt <= PING_MAX_ATTEMPTS; attempt++) {
+        last = await ping(target.url);
+        if (last.ok) break;
+        if (attempt < PING_MAX_ATTEMPTS) await sleep(PING_RETRY_DELAY_MS);
+      }
+      expect(
+        last.ok,
+        `expected ${target.url} to be reachable after ${PING_MAX_ATTEMPTS} attempts; last ${describePing(last)}`,
+      ).toBe(true);
     });
   }
 });

--- a/typescript/packages/x402-e2e/test/stack.test.ts
+++ b/typescript/packages/x402-e2e/test/stack.test.ts
@@ -34,10 +34,10 @@ const HEALTH_TARGETS: readonly { name: string; url: string }[] = [
 async function ping(url: string): Promise<{ ok: boolean; status: number }> {
   // POST-only services (the RPC node + the gateway) answer GET with a
   // 4xx — that's good enough for "the container is up and listening".
-  // Anything other than ECONNREFUSED counts as healthy.
+  // Treat only non-5xx as healthy reachability.
   try {
     const res = await fetch(url, { method: "GET" });
-    return { ok: true, status: res.status };
+    return { ok: res.status < 500, status: res.status };
   } catch {
     return { ok: false, status: 0 };
   }

--- a/typescript/packages/x402-e2e/test/stack.test.ts
+++ b/typescript/packages/x402-e2e/test/stack.test.ts
@@ -17,18 +17,18 @@ import { startStack, stopStack } from "../src/stack/index.js";
 
 const ENABLED = process.env.E2E_DOCKER === "1";
 
-const HEALTH_TARGETS: readonly { name: string; url: string }[] = [
-  { name: "boson-protocol-node", url: `${LOCAL_31337_0.urls.jsonRpc}` },
-  { name: "boson-subgraph", url: "http://localhost:8030" },
-  { name: "boson-mcp-server", url: LOCAL_31337_0.urls.bosonMcp },
-  { name: "meta-tx-gateway", url: LOCAL_31337_0.urls.metaTxGateway },
-  // IPFS Kubo API — POST-only, so GET answers 4xx when the container is
-  // up. Probing it directly catches a stopped/unreachable IPFS instead
-  // of relying on the subgraph's startup dependency to surface it.
-  { name: "ipfs", url: "http://localhost:5001/api/v0/version" },
-  { name: "x402b-facilitator-http", url: "http://localhost:8889/health" },
-  { name: "x402b-resource-server", url: "http://localhost:4001/health" },
-  { name: "x402b-webhook-sink", url: "http://localhost:4002/health" },
+// `expect2xx: true` — true /health routes must answer 2xx.
+// `expect2xx: false` — POST-only / JSON-RPC / IPFS endpoints answer GET
+// with a 4xx when the container is up; non-5xx is good enough.
+const HEALTH_TARGETS: readonly { name: string; url: string; expect2xx: boolean }[] = [
+  { name: "boson-protocol-node", url: `${LOCAL_31337_0.urls.jsonRpc}`, expect2xx: false },
+  { name: "boson-subgraph", url: "http://localhost:8030", expect2xx: false },
+  { name: "boson-mcp-server", url: LOCAL_31337_0.urls.bosonMcp, expect2xx: false },
+  { name: "meta-tx-gateway", url: LOCAL_31337_0.urls.metaTxGateway, expect2xx: false },
+  { name: "ipfs", url: "http://localhost:5001/api/v0/version", expect2xx: false },
+  { name: "x402b-facilitator-http", url: "http://localhost:8889/health", expect2xx: true },
+  { name: "x402b-resource-server", url: "http://localhost:4001/health", expect2xx: true },
+  { name: "x402b-webhook-sink", url: "http://localhost:4002/health", expect2xx: true },
 ];
 
 interface PingResult {
@@ -37,13 +37,11 @@ interface PingResult {
   error?: string;
 }
 
-async function ping(url: string): Promise<PingResult> {
-  // POST-only services (the RPC node + the gateway) answer GET with a
-  // 4xx — that's good enough for "the container is up and listening".
-  // Treat only non-5xx as healthy reachability.
+async function ping(url: string, expect2xx: boolean): Promise<PingResult> {
   try {
     const res = await fetch(url, { method: "GET" });
-    return { ok: res.status < 500, status: res.status };
+    const ok = expect2xx ? res.status >= 200 && res.status < 300 : res.status < 500;
+    return { ok, status: res.status };
   } catch (err) {
     return { ok: false, status: 0, error: err instanceof Error ? err.message : String(err) };
   }
@@ -73,7 +71,7 @@ describe.skipIf(!ENABLED)("x402-e2e stack smoke", () => {
     it(`${target.name} is reachable`, async () => {
       let last: PingResult = { ok: false, status: 0, error: "no attempt made" };
       for (let attempt = 1; attempt <= PING_MAX_ATTEMPTS; attempt++) {
-        last = await ping(target.url);
+        last = await ping(target.url, target.expect2xx);
         if (last.ok) break;
         if (attempt < PING_MAX_ATTEMPTS) await sleep(PING_RETRY_DELAY_MS);
       }

--- a/typescript/packages/x402-e2e/test/stack.test.ts
+++ b/typescript/packages/x402-e2e/test/stack.test.ts
@@ -1,0 +1,63 @@
+// Stack-boot smoke test. Gated behind `E2E_DOCKER=1` so the default
+// `pnpm test` (which Turbo runs across the whole repo) doesn't spin up
+// containers — keeps repo-wide CI fast. Run locally with:
+//
+//   E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test
+//
+// The test boots the full canonical Boson stack + the three x402B
+// services, waits for the deploy.done markers
+// (`boson-protocol-node:/app/deploy.done`,
+//  `boson-subgraph:/home/deploy.done`), hits every service's
+// HTTP-level health probe, then tears the stack down.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { LOCAL_31337_0 } from "../src/config/local-31337-0.js";
+import { startStack, stopStack } from "../src/stack/index.js";
+
+const ENABLED = process.env.E2E_DOCKER === "1";
+
+const HEALTH_TARGETS: readonly { name: string; url: string }[] = [
+  { name: "boson-protocol-node", url: `${LOCAL_31337_0.urls.jsonRpc}` },
+  { name: "boson-subgraph", url: "http://localhost:8030" },
+  { name: "boson-mcp-server", url: LOCAL_31337_0.urls.bosonMcp },
+  { name: "meta-tx-gateway", url: LOCAL_31337_0.urls.metaTxGateway },
+  { name: "x402b-facilitator-http", url: "http://localhost:8889/health" },
+  { name: "x402b-resource-server", url: "http://localhost:4001/health" },
+  { name: "x402b-webhook-sink", url: "http://localhost:4002/health" },
+];
+
+async function ping(url: string): Promise<{ ok: boolean; status: number }> {
+  // POST-only services (the RPC node + the gateway) answer GET with a
+  // 4xx — that's good enough for "the container is up and listening".
+  // Anything other than ECONNREFUSED counts as healthy.
+  try {
+    const res = await fetch(url, { method: "GET" });
+    return { ok: true, status: res.status };
+  } catch {
+    return { ok: false, status: 0 };
+  }
+}
+
+describe.skipIf(!ENABLED)("x402-e2e stack smoke", () => {
+  beforeAll(async () => {
+    await startStack({ waitForReady: true });
+  });
+
+  afterAll(async () => {
+    await stopStack();
+  });
+
+  for (const target of HEALTH_TARGETS) {
+    it(`${target.name} is reachable`, async () => {
+      const result = await ping(target.url);
+      expect(result.ok, `expected ${target.url} to be reachable; got ECONNREFUSED`).toBe(true);
+    });
+  }
+});
+
+describe.skipIf(ENABLED)("x402-e2e stack smoke (skipped — set E2E_DOCKER=1 to run)", () => {
+  it("placeholder", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/typescript/packages/x402-e2e/tsconfig.json
+++ b/typescript/packages/x402-e2e/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["src", "test", "scripts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/typescript/packages/x402-e2e/vitest.config.ts
+++ b/typescript/packages/x402-e2e/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+    // Docker boot + contract + subgraph readiness can take 2–5 min on a cold pull.
+    testTimeout: 5 * 60_000,
+    hookTimeout: 5 * 60_000,
+  },
+});

--- a/typescript/packages/x402-e2e/vitest.config.ts
+++ b/typescript/packages/x402-e2e/vitest.config.ts
@@ -4,8 +4,9 @@ export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
     environment: "node",
-    // Docker boot + contract + subgraph readiness can take 2–5 min on a cold pull.
+    // Individual tests should finish quickly, but stack startup can take much longer
+    // on cold/slow Docker runs due to image pull/build and multiple readiness probes.
     testTimeout: 5 * 60_000,
-    hookTimeout: 5 * 60_000,
+    hookTimeout: 12 * 60_000,
   },
 });


### PR DESCRIPTION
## Summary

- Adds `typescript/packages/x402-e2e` — a private workspace package that wraps the canonical Boson local stack (`boson-protocol-node`, `boson-subgraph`, `ipfs`, `postgres`, `meta-tx-gateway`, `boson-mcp-server`) plus the three x402B example services behind a programmatic lifecycle.
- `src/stack/compose.yaml` keeps env vars on the canonical services **verbatim** from [`bosonprotocol/agentic-commerce@boson-e2e-local-env`](https://github.com/bosonprotocol/agentic-commerce/blob/boson-e2e-local-env/docs/boson/example/docker-compose.yaml). `opensea-api-mock` dropped (not exercised by x402B). Three x402B services added (`x402b-facilitator-http`, `x402b-resource-server`, `x402b-webhook-sink`) all using `host.docker.internal:host-gateway`.
- `src/config/accounts.ts` carries `ACCOUNT_1`–`ACCOUNT_9` verbatim from `bosonprotocol/core-components:contracts/accounts.js`. `ROLE_ACCOUNTS` map pins distinct keys per role (gateway=9, facilitator relayer=8, seller=2, buyer=3, resolver=4) so concurrent meta-tx submissions never share a nonce.
- `src/config/local-31337-0.ts` is a typed copy of core-sdk's `defaultConfig` entry (protocolDiamond, test ERC-20s, RPC + subgraph + gateway + MCP URLs).
- `src/stack/readiness.ts` mirrors [`core-components/e2e/prepare-e2e-services.sh`](https://github.com/bosonprotocol/core-components/blob/main/e2e/prepare-e2e-services.sh) — polls `boson-protocol-node:/app/deploy.done` and `boson-subgraph:/home/deploy.done`.
- `test/stack.test.ts` is gated behind `E2E_DOCKER=1` so `pnpm test` stays <1s. With the flag set it boots the stack, waits for readiness, pings every service, tears down.

This is **PR 4 of 6** in the staged e2e rollout. **Based on `add-example-resource-server` (PR #70)** since that PR isn't merged yet — auto-rebases to `main` when #70 merges.

### Cross-PR change flagged

This PR adds `"main"` / `"types"` / `"exports"` to `examples/resource-server/package.json` (a PR3 file) so workspace consumers — namely the `src/bin/resource-server.ts` entrypoint here — can import `createResourceServerApp` / `readEnv` from `@bosonprotocol/x402-example-resource-server`. Happy to cherry-pick onto the PR3 branch if reviewers prefer that home for it.

### PR4 caveats

- **`x402b-resource-server` uses a placeholder ExchangeReader** (returns `null`, logs a warning). The 402 challenge path works end-to-end; write handlers (`commit`, `redeem`, `dispute/*`) fail with `STATE_VERIFY_EXCHANGE_NOT_FOUND`. **PR5 wires the subgraph-backed reader.**
- **No seed step yet.** boson-protocol-node ships with a deployed dispute resolver (id=1) and test ERC-20s — enough for the PR4 smoke. **PR5 adds `createSeller` via core-sdk → meta-tx-gateway.**
- **No buyer / seller / resolver actors yet.** Lands in **PR5**.

## Test plan

- [x] `pnpm install` resolves cleanly with `examples/resource-server`'s new exports
- [x] `pnpm --filter @bosonprotocol/x402-e2e build` (tsc --noEmit) passes
- [x] `pnpm --filter @bosonprotocol/x402-e2e test` — default run skips all gated cases in <1s
- [x] `pnpm --filter @bosonprotocol/x402-e2e lint` passes
- [x] `pnpm format:check` clean
- [x] `E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test` — full stack boots, deploy-done markers reached, every service reachable, tears down

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a packaged, containerized x402B end-to-end test suite with runnable resource-server image, Docker Compose stack, CLI scripts to bring the stack up/down, readiness helpers, and a packaged workspace entrypoint.
  * Added deterministic test accounts and local environment configs for e2e runs; public re-exports expose the package entrypoint.

* **Tests**
  * Added Docker-backed smoke tests that boot the stack and verify service health endpoints with retries.

* **Documentation**
  * Added comprehensive e2e README and small formatting fixes.

* **Chores**
  * Updated example resource-server package entrypoint and export configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->