### PR TITLE
feat(x402-e2e): scenario suite scaffolding + A1 commit-time happy path

### DIFF
--- a/examples/resource-server/src/offer.ts
+++ b/examples/resource-server/src/offer.ts
@@ -105,7 +105,14 @@ export function buildUnsignedOffer({ env, sellerAddress, now }: BuildOfferArgs):
     validUntilDateInMS: String(t + oneHour),
     voucherRedeemableFromDateInMS: String(t),
     voucherRedeemableUntilDateInMS: String(t + oneHour),
-    disputePeriodDurationInMS: String(oneDay),
+    // 1 week clears the protocol's `minDisputePeriod` floor on every
+    // shipped Boson deployment seen so far. The local
+    // `boson-protocol-node` enforces it via `InvalidDisputePeriod`;
+    // a previous `oneDay` value tripped that revert. PR 7 (e2e
+    // robustness work) will read the actual floor from
+    // `ConfigHandlerFacet.getMinDisputePeriod()` and pick
+    // `max(envValue, minDisputePeriod)`.
+    disputePeriodDurationInMS: String(oneWeek),
     voucherValidDurationInMS: "0",
     resolutionPeriodDurationInMS: String(oneWeek),
     exchangeToken: env.assetAddress,
@@ -113,7 +120,14 @@ export function buildUnsignedOffer({ env, sellerAddress, now }: BuildOfferArgs):
     metadataUri: "ipfs://x402b-example",
     metadataHash: "x402b-example",
     collectionIndex: "0",
-    feeLimit: "0",
+    // Max protocol + agent fee the seller will accept on this offer.
+    // `"0"` reverts every commit with `TotalFeeExceedsLimit` because
+    // the protocol fee is non-zero on every shipped Boson deployment
+    // seen so far. Setting the cap to the full price means the
+    // seller absorbs whatever the protocol charges (worst case:
+    // their entire revenue) — fine for the demo. Production sellers
+    // should pin a tighter cap based on their margin model.
+    feeLimit: env.amount,
     offerCreator: sellerAddress,
     committer: ZERO_ADDRESS,
     condition: {

--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -7,11 +7,16 @@ published. Wraps the canonical Boson local stack
 services (`facilitator-http`, `resource-server`, `webhook-sink`) into
 a single programmatic lifecycle.
 
-> PR 4 shipped the **stack scaffolding** — compose file, lifecycle
-> scripts, deploy-done readiness probe, gated smoke. PR 5 (this PR)
-> adds the **actor + asserter harness** plus the subgraph-backed
-> `ExchangeReader` the resource-server container now uses. Scenario
-> tests land in PR 6.
+> PR 4 shipped the **stack scaffolding** (compose, lifecycle, readiness
+> probe, gated smoke). PR 5 added the **actor + asserter harness** and
+> the subgraph-backed `ExchangeReader`. PR 6 (this PR) lands the
+> **scenario suite scaffolding**: vitest `globalSetup` that boots the
+> stack + seeds the seller entity via core-sdk, an in-process
+> resource-server-per-test, and the first runnable scenario (A1 —
+> deferred commit with `none` token-auth). A2–A5 (atomic + token-auth
+> variants) and C1–C5/C8 (commit-time validations) are enumerated as
+> `it.todo` and land in PR 7. PR 8 covers operational failure modes
+> and nightly CI.
 
 ## Layout
 
@@ -38,6 +43,7 @@ src/
     onchain-asserter.ts           ← retry-aware snapshot assertions
     x-payment-response-asserter.ts ← decodes X-PAYMENT-RESPONSE header
     seed.ts                       ← suite-level idempotent seed (createSeller)
+    create-seller.ts              ← PR 6 — wallet-bound createSeller callback (core-sdk)
 scripts/
   stack-up.ts / stack-down.ts     ← CLI wrappers (see `pnpm stack:up` / `:down`)
 test/
@@ -46,6 +52,14 @@ test/
     actors.test.ts
     asserters.test.ts
     seed.test.ts
+  setup/                          ← PR 6
+    globalSetup.ts                ← boots stack + seeds seller; gated on E2E_DOCKER
+  scenarios/                      ← PR 6
+    _setup.ts                     ← per-test scaffolding (in-process resource server, actors, asserter)
+    _buyer-setup.ts               ← mint + approve helpers for the `none` strategy
+    _skeletons.test.ts            ← it.todo declarations for PR 7 / PR 8 scenarios
+    commit.test.ts                ← A1 runnable + A2–A5 todo
+    validation-commit.test.ts     ← C1–C5/C8 todo (lands in PR 7)
 ```
 
 ## Bring the stack up

--- a/typescript/packages/x402-e2e/src/harness/create-seller.ts
+++ b/typescript/packages/x402-e2e/src/harness/create-seller.ts
@@ -3,7 +3,7 @@
 // `seedSuite` is generic — it accepts any `(assistant) => Promise<void>`
 // callback so each suite can plug in whichever core-sdk shape its
 // version supports. This helper is the concrete wiring against
-// `@bosonprotocol/core-sdk@1.48`'s `AccountsMixin.createSeller` for
+// `@bosonprotocol/core-sdk`'s `AccountsMixin.createSeller` for
 // the local `boson-protocol-node` stack: it builds a `CoreSDK` bound
 // to the seller's viem `WalletClient`, submits the on-chain seller
 // registration, and awaits the receipt before returning so

--- a/typescript/packages/x402-e2e/src/harness/create-seller.ts
+++ b/typescript/packages/x402-e2e/src/harness/create-seller.ts
@@ -1,0 +1,82 @@
+// Wallet-bound `createSeller` callback for `seedSuite`.
+//
+// `seedSuite` is generic — it accepts any `(assistant) => Promise<void>`
+// callback so each suite can plug in whichever core-sdk shape its
+// version supports. This helper is the concrete wiring against
+// `@bosonprotocol/core-sdk@1.48`'s `AccountsMixin.createSeller` for
+// the local `boson-protocol-node` stack: it builds a `CoreSDK` bound
+// to the seller's viem `WalletClient`, submits the on-chain seller
+// registration, and awaits the receipt before returning so
+// `seedSuite`'s post-create subgraph poll only fires once the
+// indexer has a block to ingest.
+
+import { CoreSDK } from "@bosonprotocol/core-sdk";
+import { walletClientToWeb3LibAdapter } from "@bosonprotocol/x402-evm/adapters";
+import type { Address, PublicClient, WalletClient } from "viem";
+
+import { LOCAL_31337_0 } from "../config/local-31337-0.js";
+
+export interface BuildCreateSellerCallbackArgs {
+  /** Seller's viem `WalletClient` (must hold native ETH on the local chain). */
+  walletClient: WalletClient;
+  /** Read-side `PublicClient` the SDK uses for receipt polling. */
+  publicClient: PublicClient;
+  /** Boson Diamond. Defaults to `LOCAL_31337_0.contracts.protocolDiamond`. */
+  escrowAddress?: Address;
+  /** Chain id. Defaults to `LOCAL_31337_0.chainId`. */
+  chainId?: number;
+  /** Subgraph URL. Only used to satisfy CoreSDK's constructor — `createSeller` itself doesn't query it. */
+  subgraphUrl?: string;
+  /** Seller account-level metadata. Defaults to a static x402b-e2e contract URI. */
+  contractUri?: string;
+  /** Seller account-level metadata URI. Defaults to a static x402b-e2e seller URI. */
+  metadataUri?: string;
+}
+
+/**
+ * Build a callback compatible with `seedSuite({ createSeller })`. The
+ * returned function calls `coreSdk.createSeller({...})` with the
+ * supplied `assistant` as the seller's `assistant` / `admin` / `treasury`
+ * — single-wallet seller, simplest valid configuration. Returns once
+ * the transaction is mined.
+ */
+export function buildCreateSellerCallback(
+  args: BuildCreateSellerCallbackArgs,
+): (assistant: Address) => Promise<void> {
+  const escrowAddress = args.escrowAddress ?? LOCAL_31337_0.contracts.protocolDiamond;
+  const chainId = args.chainId ?? LOCAL_31337_0.chainId;
+  const subgraphUrl = args.subgraphUrl ?? LOCAL_31337_0.urls.subgraph;
+  const contractUri = args.contractUri ?? "ipfs://x402b-e2e/seller";
+  const metadataUri = args.metadataUri ?? "ipfs://x402b-e2e/metadata";
+
+  const web3Lib = walletClientToWeb3LibAdapter({
+    walletClient: args.walletClient,
+    publicClient: args.publicClient,
+    chainId,
+  });
+  const coreSdk = new CoreSDK({
+    web3Lib,
+    subgraphUrl,
+    protocolDiamond: escrowAddress,
+    chainId,
+  });
+
+  return async (assistant: Address): Promise<void> => {
+    const tx = await coreSdk.createSeller({
+      assistant,
+      admin: assistant,
+      treasury: assistant,
+      contractUri,
+      royaltyPercentage: "0",
+      authTokenId: "0",
+      authTokenType: 0,
+      metadataUri,
+    });
+    // `coreSdk`'s `TransactionResponse` carries a `wait()` that resolves
+    // once the receipt is in. Block here so `seedSuite`'s subgraph
+    // poll has something to find.
+    if (typeof (tx as { wait?: unknown }).wait === "function") {
+      await (tx as { wait: () => Promise<unknown> }).wait();
+    }
+  };
+}

--- a/typescript/packages/x402-e2e/src/harness/exchange-reader.ts
+++ b/typescript/packages/x402-e2e/src/harness/exchange-reader.ts
@@ -60,6 +60,48 @@ interface CoreSdkExchangeEntity {
   };
 }
 
+export interface WithPollUntilFoundOptions {
+  /** Max times the wrapper re-asks the underlying reader. Default: 30. */
+  attempts?: number;
+  /** Delay between attempts in ms. Default: 1000 (1 s). */
+  delayMs?: number;
+}
+
+/**
+ * Wrap an `ExchangeReader` so it polls internally until the snapshot
+ * is non-null, instead of forwarding `null` immediately.
+ *
+ * Why: `@bosonprotocol/x402-server`'s `verifyExchange` defaults to
+ * **3 attempts × 50 ms** before giving up with
+ * `STATE_VERIFY_EXCHANGE_NOT_FOUND` — fine for a fast/cached subgraph,
+ * too short for the local `boson-subgraph` container whose indexer
+ * typically needs 1–5 s to ingest a fresh block. Wrapping the reader
+ * effectively extends that budget without touching the server's
+ * defaults (production consumers want the fast path).
+ *
+ * No behaviour change for non-null reads: `verifyExchangeSnapshot`
+ * does field-level comparison, which the wrapper doesn't interpose
+ * on. Once the subgraph has indexed, the first poll returns the
+ * snapshot and the wrapper exits.
+ */
+export function withPollUntilFound(
+  reader: ExchangeReader,
+  options: WithPollUntilFoundOptions = {},
+): ExchangeReader {
+  const attempts = Math.max(1, Math.floor(options.attempts ?? 30));
+  const delayMs = Math.max(0, Math.floor(options.delayMs ?? 1000));
+  return {
+    read: async (exchangeId: string): Promise<ExchangeSnapshot | null> => {
+      for (let i = 0; i < attempts; i++) {
+        const snapshot = await reader.read(exchangeId);
+        if (snapshot !== null) return snapshot;
+        if (i < attempts - 1) await new Promise<void>((r) => setTimeout(r, delayMs));
+      }
+      return null;
+    },
+  };
+}
+
 /**
  * Build an `ExchangeReader` that resolves snapshots through the local
  * Boson subgraph. The CoreSDK is constructed with a throwing web3Lib

--- a/typescript/packages/x402-e2e/src/harness/index.ts
+++ b/typescript/packages/x402-e2e/src/harness/index.ts
@@ -28,3 +28,4 @@ export {
 } from "./x-payment-response-asserter.js";
 
 export { seedSuite, type SeedArgs, type SeededSeller, type SuiteState } from "./seed.js";
+export { buildCreateSellerCallback, type BuildCreateSellerCallbackArgs } from "./create-seller.js";

--- a/typescript/packages/x402-e2e/src/harness/index.ts
+++ b/typescript/packages/x402-e2e/src/harness/index.ts
@@ -4,7 +4,9 @@
 export { buildPublicClient, buildWalletClient, localBosonChain } from "./clients.js";
 export {
   createSubgraphExchangeReader,
+  withPollUntilFound,
   type SubgraphExchangeReaderArgs,
+  type WithPollUntilFoundOptions,
 } from "./exchange-reader.js";
 
 export { createBuyerActor, type BuyerActor, type BuyerActorArgs } from "./buyer-actor.js";

--- a/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
@@ -1,0 +1,116 @@
+// Buyer-side ERC-20 prep for the `none` token-auth strategy.
+//
+// With `tokenAuthStrategy: "none"`, the buyer must have already
+// approved the escrow for at least `amount` of the payment asset
+// before committing — settle just calls `transferFrom` and reverts on
+// insufficient allowance. The other three strategies bundle their own
+// authorisation in the X-PAYMENT payload and don't need this.
+//
+// The local Boson stack ships the `Foreign20` test ERC-20 with a
+// public `mint(to, amount)`, so we mint the buyer enough to cover the
+// scenario amount before approving. Both calls are no-ops when
+// re-run with already-sufficient balance / allowance.
+
+import type { Address, PublicClient, WalletClient } from "viem";
+
+const ERC20_TEST_ABI = [
+  {
+    type: "function",
+    name: "mint",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "owner", type: "address" }],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "allowance",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ type: "uint256" }],
+  },
+] as const;
+
+export interface BuyerSetupArgs {
+  /** Buyer's viem `WalletClient` (must hold native ETH for gas). */
+  walletClient: WalletClient;
+  /** Read-side `PublicClient`. */
+  publicClient: PublicClient;
+  /** Payment-asset address (typically `LOCAL_31337_0.contracts.testErc20`). */
+  assetAddress: Address;
+  /** Escrow address — the `spender` the buyer approves. */
+  escrowAddress: Address;
+  /** Amount the scenario will commit (decimal string of atomic units). */
+  amount: bigint;
+  /** Buyer's wallet address. */
+  buyerAddress: Address;
+}
+
+/**
+ * Ensure the buyer has at least `amount` balance + allowance against
+ * the escrow. Mints the deficit + sends an `approve` only when
+ * necessary so re-runs of the same scenario don't burn gas pointlessly.
+ */
+export async function ensureBuyerCanPay(args: BuyerSetupArgs): Promise<void> {
+  const balance = (await args.publicClient.readContract({
+    address: args.assetAddress,
+    abi: ERC20_TEST_ABI,
+    functionName: "balanceOf",
+    args: [args.buyerAddress],
+  })) as bigint;
+
+  if (balance < args.amount) {
+    const mintHash = await args.walletClient.writeContract({
+      address: args.assetAddress,
+      abi: ERC20_TEST_ABI,
+      functionName: "mint",
+      args: [args.buyerAddress, args.amount - balance],
+      account: args.walletClient.account!,
+      chain: args.walletClient.chain!,
+    });
+    await args.publicClient.waitForTransactionReceipt({ hash: mintHash });
+  }
+
+  const allowance = (await args.publicClient.readContract({
+    address: args.assetAddress,
+    abi: ERC20_TEST_ABI,
+    functionName: "allowance",
+    args: [args.buyerAddress, args.escrowAddress],
+  })) as bigint;
+
+  if (allowance < args.amount) {
+    const approveHash = await args.walletClient.writeContract({
+      address: args.assetAddress,
+      abi: ERC20_TEST_ABI,
+      functionName: "approve",
+      // Approve a generous cap so subsequent scenarios on the same
+      // chain state don't need to re-approve; refunds untouched.
+      args: [args.escrowAddress, args.amount * 1000n],
+      account: args.walletClient.account!,
+      chain: args.walletClient.chain!,
+    });
+    await args.publicClient.waitForTransactionReceipt({ hash: approveHash });
+  }
+}

--- a/typescript/packages/x402-e2e/test/scenarios/_flags.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_flags.ts
@@ -1,0 +1,6 @@
+// Shared gating flag for the scenario suite. Every scenario file
+// declares `describe.skipIf(!ENABLED)` so the suite no-ops in the
+// repo-wide `pnpm test` and only runs when the docker stack is up
+// (`E2E_DOCKER=1`).
+
+export const ENABLED = process.env.E2E_DOCKER === "1";

--- a/typescript/packages/x402-e2e/test/scenarios/_setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_setup.ts
@@ -31,6 +31,7 @@ import {
   createResolverActor,
   createSellerActor,
   createSubgraphExchangeReader,
+  withPollUntilFound,
   type BuyerActor,
   type OnchainAsserter,
   type ResolverActor,
@@ -121,7 +122,14 @@ export async function createScenarioContext(
   };
 
   const publicClient = buildPublicClient();
-  const exchangeReader = createSubgraphExchangeReader();
+  // The local boson-subgraph container's indexer typically needs 1–5 s
+  // to ingest a freshly-mined block; `@bosonprotocol/x402-server`'s
+  // default `verifyExchange` retry budget (3 × 50 ms) gives up well
+  // before that, surfacing as `STATE_VERIFY_EXCHANGE_NOT_FOUND` on
+  // every commit. `withPollUntilFound` extends the reader's wait
+  // budget without touching the server's defaults (production
+  // consumers want the fast path).
+  const exchangeReader = withPollUntilFound(createSubgraphExchangeReader());
   const asserter = createOnchainAsserter(exchangeReader);
 
   // Reserve a real port up front: `createResourceServerApp` builds the

--- a/typescript/packages/x402-e2e/test/scenarios/_setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_setup.ts
@@ -16,6 +16,7 @@
 
 import { createResourceServerApp, readEnv } from "@bosonprotocol/x402-example-resource-server";
 import { type AddressInfo } from "node:net";
+import { type Hex } from "viem";
 import { privateKeyToAccount, type LocalAccount } from "viem/accounts";
 
 /** `ResourceServerEnv` isn't re-exported from the example's barrel; derive it from `readEnv`'s return type. */
@@ -39,8 +40,12 @@ import {
 import { SUITE_STATE_ENV } from "../setup/globalSetup.js";
 
 export interface ScenarioContextArgs {
-  /** Override the seller `LocalAccount`. Defaults to `ROLE_ACCOUNTS.seller`. */
-  sellerAccount?: LocalAccount;
+  /**
+   * Override the seller private key. Defaults to `ROLE_ACCOUNTS.seller.privateKey`.
+   * Taken as a raw key (not a `LocalAccount`) so the same identity drives both
+   * the `SellerActor` and the in-process resource server's `sellerPk`.
+   */
+  sellerPk?: Hex;
   /** Override the buyer `LocalAccount`. Defaults to `ROLE_ACCOUNTS.buyer`. */
   buyerAccount?: LocalAccount;
   /** Override the resolver `LocalAccount`. Defaults to `ROLE_ACCOUNTS.resolver`. */
@@ -79,7 +84,8 @@ function requireSuiteEnv(key: string): string {
 export async function createScenarioContext(
   args: ScenarioContextArgs = {},
 ): Promise<ScenarioContext> {
-  const sellerAccount = args.sellerAccount ?? privateKeyToAccount(ROLE_ACCOUNTS.seller.privateKey);
+  const sellerPk = args.sellerPk ?? ROLE_ACCOUNTS.seller.privateKey;
+  const sellerAccount = privateKeyToAccount(sellerPk);
   const buyerAccount = args.buyerAccount ?? privateKeyToAccount(ROLE_ACCOUNTS.buyer.privateKey);
   const resolverAccount =
     args.resolverAccount ?? privateKeyToAccount(ROLE_ACCOUNTS.resolver.privateKey);
@@ -104,7 +110,7 @@ export async function createScenarioContext(
     network: LOCAL_31337_0.network,
     escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
     facilitatorUrl: "http://127.0.0.1:8889",
-    sellerPk: ROLE_ACCOUNTS.seller.privateKey,
+    sellerPk,
     sellerId: suite.sellerId,
     disputeResolverId: suite.disputeResolverId,
     assetAddress: args.assetAddress ?? LOCAL_31337_0.contracts.testErc20,

--- a/typescript/packages/x402-e2e/test/scenarios/_setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_setup.ts
@@ -39,6 +39,8 @@ import {
 
 import { SUITE_STATE_ENV } from "../setup/globalSetup.js";
 
+const LOCALHOST_HTTP = "http://127.0.0.1";
+
 export interface ScenarioContextArgs {
   /**
    * Override the seller private key. Defaults to `ROLE_ACCOUNTS.seller.privateKey`.
@@ -127,14 +129,14 @@ export async function createScenarioContext(
   // endpoint URL) at construction time, so a `:0` placeholder would
   // bake an unreachable port into `nextActions`.
   const port = await allocateFreePort();
-  const resourceServerUrl = `http://127.0.0.1:${port}`;
+  const resourceServerUrl = `${LOCALHOST_HTTP}:${port}`;
   const env: ResourceServerEnv = {
     publicUrl: resourceServerUrl,
     rpcNode: LOCAL_31337_0.urls.jsonRpc,
     chainId: LOCAL_31337_0.chainId,
     network: LOCAL_31337_0.network,
     escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
-    facilitatorUrl: "http://127.0.0.1:8889",
+    facilitatorUrl: `${LOCALHOST_HTTP}:8889`,
     sellerPk,
     sellerId: suite.sellerId,
     disputeResolverId: suite.disputeResolverId,

--- a/typescript/packages/x402-e2e/test/scenarios/_setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_setup.ts
@@ -1,0 +1,142 @@
+// Shared per-test scaffolding for the scenario suite. Each scenario
+// file's `beforeAll` constructs a `ScenarioContext` and tears it down
+// in `afterAll`. The context wires:
+//
+//   - Resource server (in-process via `createResourceServerApp`)
+//     listening on an OS-assigned port so parallel test files don't
+//     collide on a fixed port.
+//   - SellerActor / BuyerActor / ResolverActor against the wallets
+//     from `ROLE_ACCOUNTS`.
+//   - Subgraph-backed `ExchangeReader` + `OnchainAsserter`.
+//
+// The resource server is in-process (not the `x402b-resource-server`
+// compose service) so each scenario can reconfigure `SELLER_ID`,
+// `ASSET_ADDRESS`, etc. with the seeded state. The compose service
+// stays available for manual smoke testing.
+
+import { createResourceServerApp, readEnv } from "@bosonprotocol/x402-example-resource-server";
+import { type AddressInfo } from "node:net";
+import { privateKeyToAccount, type LocalAccount } from "viem/accounts";
+
+/** `ResourceServerEnv` isn't re-exported from the example's barrel; derive it from `readEnv`'s return type. */
+type ResourceServerEnv = ReturnType<typeof readEnv>;
+
+import { ROLE_ACCOUNTS } from "../../src/config/accounts.js";
+import { LOCAL_31337_0 } from "../../src/config/local-31337-0.js";
+import {
+  buildPublicClient,
+  createBuyerActor,
+  createOnchainAsserter,
+  createResolverActor,
+  createSellerActor,
+  createSubgraphExchangeReader,
+  type BuyerActor,
+  type OnchainAsserter,
+  type ResolverActor,
+  type SellerActor,
+} from "../../src/harness/index.js";
+
+import { SUITE_STATE_ENV } from "../setup/globalSetup.js";
+
+export interface ScenarioContextArgs {
+  /** Override the seller `LocalAccount`. Defaults to `ROLE_ACCOUNTS.seller`. */
+  sellerAccount?: LocalAccount;
+  /** Override the buyer `LocalAccount`. Defaults to `ROLE_ACCOUNTS.buyer`. */
+  buyerAccount?: LocalAccount;
+  /** Override the resolver `LocalAccount`. Defaults to `ROLE_ACCOUNTS.resolver`. */
+  resolverAccount?: LocalAccount;
+  /** Override `ASSET_ADDRESS`. Defaults to the test ERC-20 (`testErc20`). */
+  assetAddress?: `0x${string}`;
+  /** Override `AMOUNT`. Defaults to `"1000000"` (1 USDC at 6dp). */
+  amount?: string;
+  /** Override `MAX_TIMEOUT_SECONDS`. Defaults to `3600`. */
+  maxTimeoutSeconds?: number;
+}
+
+export interface ScenarioContext {
+  /** Public URL of the in-process resource server (`http://127.0.0.1:<port>`). */
+  resourceServerUrl: string;
+  seller: SellerActor;
+  buyer: BuyerActor;
+  resolver: ResolverActor;
+  asserter: OnchainAsserter;
+  /** Resolved suite state pulled from `globalSetup`'s env exports. */
+  suite: { sellerId: string; sellerAddress: `0x${string}`; disputeResolverId: string };
+  /** Stop the in-process resource server. Call in `afterAll`. */
+  teardown: () => Promise<void>;
+}
+
+function requireSuiteEnv(key: string): string {
+  const v = process.env[key];
+  if (v === undefined || v.length === 0) {
+    throw new Error(
+      `[x402-e2e/scenarios] missing ${key} — did globalSetup run? (set E2E_DOCKER=1)`,
+    );
+  }
+  return v;
+}
+
+export async function createScenarioContext(
+  args: ScenarioContextArgs = {},
+): Promise<ScenarioContext> {
+  const sellerAccount = args.sellerAccount ?? privateKeyToAccount(ROLE_ACCOUNTS.seller.privateKey);
+  const buyerAccount = args.buyerAccount ?? privateKeyToAccount(ROLE_ACCOUNTS.buyer.privateKey);
+  const resolverAccount =
+    args.resolverAccount ?? privateKeyToAccount(ROLE_ACCOUNTS.resolver.privateKey);
+
+  const suite = {
+    sellerId: requireSuiteEnv(SUITE_STATE_ENV.sellerId),
+    sellerAddress: requireSuiteEnv(SUITE_STATE_ENV.sellerAddress) as `0x${string}`,
+    disputeResolverId: requireSuiteEnv(SUITE_STATE_ENV.disputeResolverId),
+  };
+
+  const publicClient = buildPublicClient();
+  const exchangeReader = createSubgraphExchangeReader();
+  const asserter = createOnchainAsserter(exchangeReader);
+
+  // Bind to port 0 so the OS picks a free port; tests use the
+  // returned URL directly. The address() call below is synchronous
+  // once the server emits `listening`.
+  const env: ResourceServerEnv = {
+    publicUrl: "http://127.0.0.1:0",
+    rpcNode: LOCAL_31337_0.urls.jsonRpc,
+    chainId: LOCAL_31337_0.chainId,
+    network: LOCAL_31337_0.network,
+    escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+    facilitatorUrl: "http://127.0.0.1:8889",
+    sellerPk: ROLE_ACCOUNTS.seller.privateKey,
+    sellerId: suite.sellerId,
+    disputeResolverId: suite.disputeResolverId,
+    assetAddress: args.assetAddress ?? LOCAL_31337_0.contracts.testErc20,
+    amount: args.amount ?? "1000000",
+    maxTimeoutSeconds: args.maxTimeoutSeconds ?? 3600,
+    subgraphUrl: LOCAL_31337_0.urls.subgraph,
+    port: 0,
+  };
+
+  const { app } = createResourceServerApp(env, { exchangeReader });
+  const httpServer = app.listen(0);
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("listening", resolve);
+    httpServer.once("error", reject);
+  });
+  const address = httpServer.address() as AddressInfo;
+  const resourceServerUrl = `http://127.0.0.1:${address.port}`;
+
+  const seller = createSellerActor({ account: sellerAccount });
+  const buyer = createBuyerActor({ account: buyerAccount, publicClient });
+  const resolver = createResolverActor({ account: resolverAccount });
+
+  return {
+    resourceServerUrl,
+    seller,
+    buyer,
+    resolver,
+    asserter,
+    suite,
+    teardown: () =>
+      new Promise<void>((resolve, reject) => {
+        httpServer.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}

--- a/typescript/packages/x402-e2e/test/scenarios/_setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_setup.ts
@@ -15,7 +15,7 @@
 // stays available for manual smoke testing.
 
 import { createResourceServerApp, readEnv } from "@bosonprotocol/x402-example-resource-server";
-import { type AddressInfo } from "node:net";
+import { createServer, type AddressInfo } from "node:net";
 import { type Hex } from "viem";
 import { privateKeyToAccount, type LocalAccount } from "viem/accounts";
 
@@ -81,6 +81,28 @@ function requireSuiteEnv(key: string): string {
   return v;
 }
 
+/**
+ * Reserve a free TCP port on 127.0.0.1 by binding a throwaway server to port 0,
+ * reading the OS-assigned port, then releasing it. The resource server bakes
+ * `publicUrl` into ChannelRegistry endpoints at construction time, so we need
+ * the real port *before* calling `createResourceServerApp`. The brief gap
+ * between close and re-listen has a theoretical TOCTOU race, but it's
+ * acceptable for the in-process test scaffolding.
+ */
+async function allocateFreePort(): Promise<number> {
+  const probe = createServer();
+  await new Promise<void>((resolve, reject) => {
+    probe.once("listening", resolve);
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1");
+  });
+  const port = (probe.address() as AddressInfo).port;
+  await new Promise<void>((resolve, reject) => {
+    probe.close((err) => (err ? reject(err) : resolve()));
+  });
+  return port;
+}
+
 export async function createScenarioContext(
   args: ScenarioContextArgs = {},
 ): Promise<ScenarioContext> {
@@ -100,11 +122,14 @@ export async function createScenarioContext(
   const exchangeReader = createSubgraphExchangeReader();
   const asserter = createOnchainAsserter(exchangeReader);
 
-  // Bind to port 0 so the OS picks a free port; tests use the
-  // returned URL directly. The address() call below is synchronous
-  // once the server emits `listening`.
+  // Reserve a real port up front: `createResourceServerApp` builds the
+  // ChannelRegistry (and stamps `publicUrl` into every server-channel
+  // endpoint URL) at construction time, so a `:0` placeholder would
+  // bake an unreachable port into `nextActions`.
+  const port = await allocateFreePort();
+  const resourceServerUrl = `http://127.0.0.1:${port}`;
   const env: ResourceServerEnv = {
-    publicUrl: "http://127.0.0.1:0",
+    publicUrl: resourceServerUrl,
     rpcNode: LOCAL_31337_0.urls.jsonRpc,
     chainId: LOCAL_31337_0.chainId,
     network: LOCAL_31337_0.network,
@@ -117,17 +142,15 @@ export async function createScenarioContext(
     amount: args.amount ?? "1000000",
     maxTimeoutSeconds: args.maxTimeoutSeconds ?? 3600,
     subgraphUrl: LOCAL_31337_0.urls.subgraph,
-    port: 0,
+    port,
   };
 
   const { app } = createResourceServerApp(env, { exchangeReader });
-  const httpServer = app.listen(0);
+  const httpServer = app.listen(port);
   await new Promise<void>((resolve, reject) => {
     httpServer.once("listening", resolve);
     httpServer.once("error", reject);
   });
-  const address = httpServer.address() as AddressInfo;
-  const resourceServerUrl = `http://127.0.0.1:${address.port}`;
 
   const seller = createSellerActor({ account: sellerAccount });
   const buyer = createBuyerActor({ account: buyerAccount, publicClient });

--- a/typescript/packages/x402-e2e/test/scenarios/_skeletons.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_skeletons.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it } from "vitest";
 
-const ENABLED = process.env.E2E_DOCKER === "1";
+import { ENABLED } from "./_flags.js";
 
 describe.skipIf(!ENABLED)("@p0 post-commit lifecycle — PR 7", () => {
   it.todo("B1 — redeem after deferred commit → ExchangeState.REDEEMED");

--- a/typescript/packages/x402-e2e/test/scenarios/_skeletons.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_skeletons.test.ts
@@ -1,0 +1,67 @@
+// Anchored `it.todo` declarations for scenarios that land in PR 7 /
+// PR 8. The file exists so a grep for any scenario id (e.g. `B4`,
+// `F1`, `D3`) lands in this repo and the future PR has a defined
+// home to fill in. Each todo carries the same description text as the
+// plan in `docs/`... oh wait, the plan lives in a working file
+// outside the repo — describe each scenario inline below so the
+// suite is self-contained.
+
+import { describe, it } from "vitest";
+
+const ENABLED = process.env.E2E_DOCKER === "1";
+
+describe.skipIf(!ENABLED)("@p0 post-commit lifecycle — PR 7", () => {
+  it.todo("B1 — redeem after deferred commit → ExchangeState.REDEEMED");
+  it.todo("B2 — completeExchange after redeem → ExchangeState.COMPLETED, escrow released");
+  it.todo("B3 — raiseDispute after redeem → DisputeState.RESOLVING");
+  it.todo("B4 — mutual resolveDispute (buyer % split, dual-sig) → DisputeState.RESOLVED");
+});
+
+describe.skipIf(!ENABLED)("@p1 post-commit lifecycle — PR 7", () => {
+  it.todo("B5 — escalateDispute with deposit → DisputeState.ESCALATED");
+  it.todo("B6 — retractDispute by buyer → DisputeState.RETRACTED");
+  it.todo("B7 — cancelVoucher before redeem → ExchangeState.CANCELLED, escrow refunded - penalty");
+});
+
+describe.skipIf(!ENABLED)("@p2 post-commit lifecycle — PR 7", () => {
+  it.todo("B8 — revokeVoucher by seller → seller-initiated cancel");
+  it.todo("B9 — decideDispute by resolver → DisputeState.DECIDED, resolver-set split");
+});
+
+describe.skipIf(!ENABLED)("@p1 commit-time validations — PR 7", () => {
+  it.todo("C6 — insufficient escrow balance → SIMULATION_REVERT");
+  it.todo("C9 — sellerSig mismatch in FullOffer → server BAD_SELLER_SIG");
+  it.todo("C10 — post-commit action on wrong state (e.g. redeem while CANCELLED) → reject");
+});
+
+describe.skipIf(!ENABLED)("@p2 commit-time validations — PR 7", () => {
+  it.todo("C7 — invalid `tokenAuthStrategy` value (not in enum) → INVALID_PAYLOAD");
+});
+
+describe.skipIf(!ENABLED)("@p0/@p1 nextActions / channel routing — PR 7", () => {
+  it.todo("D1 — post-commit nextActions[] matches ACTION_POST_STATE for the new state");
+  it.todo("D2 — post-redeem nextActions[] shrinks to [completeExchange, raiseDispute]");
+  it.todo("D3 — server/facilitator/onchain channel fallback chain (kill facilitator)");
+  it.todo(
+    "D4 — `mcp` channel for buyer-side action — skipped until `@bosonprotocol/x402-agent` lands",
+  );
+});
+
+describe.skipIf(!ENABLED)("@p1/@p2 multi-party — PR 7", () => {
+  it.todo("E1 — two concurrent buyers commit to the same offer → distinct exchangeIds");
+  it.todo("E2 — buyer commits, then seller revokeVoucher → buyer refunded");
+  it.todo("E3 — mutual resolveDispute requires both buyer + seller sigs (dual-sig regression)");
+});
+
+describe.skipIf(!ENABLED)("@p1/@p2 operational / failure-mode — PR 8", () => {
+  it.todo("F1 — facilitator restart mid-flight → client retries idempotently");
+  it.todo("F2 — subgraph indexer lag → server falls back to RPC ExchangeReader");
+  it.todo("F3 — meta-tx-gateway down during createSeller seed → clear error surfaces");
+  it.todo("F4 — buyer key rotation mid-flow → redeem rejected (from-address mismatch)");
+});
+
+describe.skipIf(!ENABLED)("@p1/@p2 commit-time fulfillment — PR 7", () => {
+  it.todo("A6 — commit with `webhook` fulfillment → webhook-sink receives onCommit payload");
+  it.todo("A7 — commit with `ipfs-pointer` fulfillment → response carries valid CID");
+  it.todo("A8 — commit with `mcp` fulfillment — skipped until `@bosonprotocol/x402-agent` lands");
+});

--- a/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
@@ -1,0 +1,108 @@
+// Commit-time scenarios — section A of the e2e plan.
+//
+// Gated behind `E2E_DOCKER=1` because every test boots the buyer
+// through the in-process resource server, the facilitator service,
+// and the local Boson chain. Run with:
+//
+//   E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test
+//
+// A1 is the primary @p0 happy path: buyer pre-approves the escrow,
+// fetches the resource, the middleware emits a 402, the buyer's
+// `wrapFetchWithPayment` signs and retries with X-PAYMENT, settle
+// commits on-chain, and the response carries `X-PAYMENT-RESPONSE`
+// with the new `exchangeId`. A2–A5 cover the other commit-time
+// dimensions (atomic / token-auth strategies) and land as full tests
+// in this PR once A1 is validated against the live stack — for now
+// they're `it.todo` so the suite enumerates them.
+
+import { ExchangeState } from "@bosonprotocol/x402-actions";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { LOCAL_31337_0 } from "../../src/config/local-31337-0.js";
+import { ROLE_ACCOUNTS } from "../../src/config/accounts.js";
+import {
+  buildPublicClient,
+  buildWalletClient,
+  readXPaymentResponse,
+} from "../../src/harness/index.js";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { ensureBuyerCanPay } from "./_buyer-setup.js";
+import { createScenarioContext, type ScenarioContext } from "./_setup.js";
+
+const ENABLED = process.env.E2E_DOCKER === "1";
+
+describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
+  let ctx: ScenarioContext;
+
+  beforeAll(async () => {
+    ctx = await createScenarioContext();
+    const buyerAccount = privateKeyToAccount(ROLE_ACCOUNTS.buyer.privateKey);
+    const buyerWallet = buildWalletClient(buyerAccount);
+    const publicClient = buildPublicClient();
+    await ensureBuyerCanPay({
+      walletClient: buyerWallet,
+      publicClient,
+      buyerAddress: buyerAccount.address,
+      assetAddress: LOCAL_31337_0.contracts.testErc20,
+      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      amount: 1_000_000n,
+    });
+  });
+
+  afterAll(async () => {
+    await ctx?.teardown();
+  });
+
+  // Skipped pending x402B#73. The buyer-side flow drives correctly,
+  // but the server rejects with rule-7 `CALLDATA_MISMATCH`: the buyer
+  // signs the meta-tx with `committer: buyer`, while `assemblePayload`
+  // still ships the server's original `offerRef.fullOffer.committer
+  // = 0x0`. Once that one-line client-side fix lands, drop `.skip`
+  // and the test runs as the @p0 happy path.
+  it.skip("A1 — deferred commit with `none` strategy + inline fulfillment (#73)", async () => {
+    // Drive the full happy path through `wrapFetchWithPayment`. The
+    // first call sees a 402, the buyer signs, the retry settles
+    // on-chain, and we assert against both the HTTP response and the
+    // on-chain state via the subgraph asserter.
+    const res = await ctx.buyer.fetch(`${ctx.resourceServerUrl}/resource`);
+    expect(res.status, await res.clone().text()).toBe(200);
+
+    const body = (await res.json()) as {
+      ok?: boolean;
+      x402b?: { exchangeId?: string; txHash?: `0x${string}` };
+    };
+    expect(body.ok).toBe(true);
+    expect(typeof body.x402b?.exchangeId).toBe("string");
+
+    const decoded = readXPaymentResponse(res.headers);
+    expect(decoded, "X-PAYMENT-RESPONSE header should decode to a JSON payload").not.toBeNull();
+    expect(decoded?.exchangeId).toBe(body.x402b?.exchangeId);
+    expect(decoded?.txHash).toMatch(/^0x[0-9a-fA-F]+$/);
+
+    // On-chain state — exchange should be `COMMITTED` with seller +
+    // exchangeToken + price matching the requirements. The asserter
+    // retries on subgraph indexer lag.
+    const exchangeId = body.x402b!.exchangeId!;
+    await ctx.asserter.expect(exchangeId, {
+      state: ExchangeState.COMMITTED,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc20,
+      price: "1000000",
+    });
+  });
+
+  // Atomic commit-and-redeem (`boson-createOfferCommitAndRedeem`).
+  // Same wire path as A1 but the client selects `commit-and-redeem`
+  // via `Policy.redeemMode: "commit-and-redeem"` so the buyer ends
+  // up at `REDEEMED` in a single tx. Unblocked by Boson PR #1105.
+  it.todo("A2 — atomic commit-and-redeem with `none` strategy");
+
+  // Token-auth strategies. The resource server already advertises
+  // `["none","erc3009","permit","permit2"]`; PR6 follow-up implements
+  // these as their own beforeAll variants (different asset for
+  // erc3009 / permit, different cap for permit2).
+  it.todo("A3 — commit with `erc3009` token-auth (testErc3009)");
+  it.todo("A4 — commit with `permit` token-auth (testErc2612)");
+  it.todo("A5 — commit with `permit2` token-auth");
+});

--- a/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
@@ -11,9 +11,8 @@
 // `wrapFetchWithPayment` signs and retries with X-PAYMENT, settle
 // commits on-chain, and the response carries `X-PAYMENT-RESPONSE`
 // with the new `exchangeId`. A2–A5 cover the other commit-time
-// dimensions (atomic / token-auth strategies) and land as full tests
-// in this PR once A1 is validated against the live stack — for now
-// they're `it.todo` so the suite enumerates them.
+// dimensions (atomic / token-auth strategies); they're `it.todo`
+// in this PR and land in PR 7.
 
 import { ExchangeState } from "@bosonprotocol/x402-actions";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -53,13 +52,7 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
     await ctx?.teardown();
   });
 
-  // Skipped pending x402B#73. The buyer-side flow drives correctly,
-  // but the server rejects with rule-7 `CALLDATA_MISMATCH`: the buyer
-  // signs the meta-tx with `committer: buyer`, while `assemblePayload`
-  // still ships the server's original `offerRef.fullOffer.committer
-  // = 0x0`. Once that one-line client-side fix lands, drop `.skip`
-  // and the test runs as the @p0 happy path.
-  it.skip("A1 — deferred commit with `none` strategy + inline fulfillment (#73)", async () => {
+  it("A1 — deferred commit with `none` strategy + inline fulfillment", async () => {
     // Drive the full happy path through `wrapFetchWithPayment`. The
     // first call sees a 402, the buyer signs, the retry settles
     // on-chain, and we assert against both the HTTP response and the

--- a/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
@@ -28,9 +28,8 @@ import {
 import { privateKeyToAccount } from "viem/accounts";
 
 import { ensureBuyerCanPay } from "./_buyer-setup.js";
+import { ENABLED } from "./_flags.js";
 import { createScenarioContext, type ScenarioContext } from "./_setup.js";
-
-const ENABLED = process.env.E2E_DOCKER === "1";
 
 describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
   let ctx: ScenarioContext;

--- a/typescript/packages/x402-e2e/test/scenarios/validation-commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/validation-commit.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, it } from "vitest";
 
-const ENABLED = process.env.E2E_DOCKER === "1";
+import { ENABLED } from "./_flags.js";
 
 describe.skipIf(!ENABLED)("@p0 commit-time validations", () => {
   it.todo("C1 — tampered `functionSignature` → 400 OFFER_MISMATCH");

--- a/typescript/packages/x402-e2e/test/scenarios/validation-commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/validation-commit.test.ts
@@ -1,0 +1,25 @@
+// Commit-time validation negatives — section C of the e2e plan.
+//
+// Each scenario builds a valid `X-PAYMENT` payload then mutates a
+// single field to trip a specific server- or facilitator-side check.
+// Asserts both the HTTP status and the wire-level `code` so a future
+// rename of the error code surfaces here as a regression.
+//
+// PR 6 ships the file with `it.todo` markers so the suite enumerates
+// the planned coverage; PR 7 lands the implementations alongside the
+// post-commit lifecycle tests.
+
+import { describe, it } from "vitest";
+
+const ENABLED = process.env.E2E_DOCKER === "1";
+
+describe.skipIf(!ENABLED)("@p0 commit-time validations", () => {
+  it.todo("C1 — tampered `functionSignature` → 400 OFFER_MISMATCH");
+  it.todo("C2 — wrong meta-tx signature → BAD_META_TX_SIGNATURE, no on-chain submit");
+  it.todo("C3 — nonce replay → second submit fails (nonce consumed on chain)");
+  it.todo("C4 — expired offer (`validBefore < now`) → SIMULATION_REVERT or pre-flight reject");
+  it.todo(
+    "C5 — `maxTimeoutSeconds` exceeded (`validBefore > now + maxTimeoutSeconds`) → server reject pre-facilitator",
+  );
+  it.todo("C8 — wrong `escrowAddress` (not on facilitator allowlist) → ESCROW_NOT_ALLOWED");
+});

--- a/typescript/packages/x402-e2e/test/setup/globalSetup.ts
+++ b/typescript/packages/x402-e2e/test/setup/globalSetup.ts
@@ -1,0 +1,73 @@
+// Vitest `globalSetup` for the e2e scenario suite. Runs once before
+// every test file, gated behind `E2E_DOCKER=1` so default
+// `pnpm test` invocations stay fast.
+//
+// Responsibilities:
+//   1. `startStack({ waitForReady: true })` — bring up the canonical
+//      Boson stack + x402B services and block until the contracts +
+//      subgraph `deploy.done` markers exist.
+//   2. `seedSuite({ createSeller: buildCreateSellerCallback(...) })` —
+//      register the seller entity tied to `ROLE_ACCOUNTS.seller`.
+//      Idempotent: re-runs are no-ops because the subgraph already
+//      reports an existing seller for that assistant.
+//   3. Export the seeded state (seller id, dispute resolver id) via
+//      `process.env` so each test file's `beforeAll` can read it
+//      without re-querying the subgraph.
+//
+// Test files MUST also call `describe.skipIf(!process.env.E2E_DOCKER)`
+// or equivalent so they skip cleanly when the gate is off.
+
+import { privateKeyToAccount } from "viem/accounts";
+
+import { ROLE_ACCOUNTS } from "../../src/config/accounts.js";
+import {
+  buildCreateSellerCallback,
+  buildPublicClient,
+  buildWalletClient,
+  seedSuite,
+} from "../../src/harness/index.js";
+import { startStack, stopStack } from "../../src/stack/index.js";
+
+/** Env-var keys the scenario tests read from `process.env`. */
+export const SUITE_STATE_ENV = {
+  sellerId: "X402_E2E_SELLER_ID",
+  sellerAddress: "X402_E2E_SELLER_ADDRESS",
+  disputeResolverId: "X402_E2E_DISPUTE_RESOLVER_ID",
+} as const;
+
+const ENABLED = process.env.E2E_DOCKER === "1";
+
+export default async function globalSetup(): Promise<() => Promise<void>> {
+  if (!ENABLED) {
+    // Gate off — return a no-op teardown so vitest is happy.
+    return async () => {
+      /* no-op */
+    };
+  }
+
+  console.log("[x402-e2e/globalSetup] starting stack…");
+  await startStack({ waitForReady: true });
+
+  const sellerAccount = privateKeyToAccount(ROLE_ACCOUNTS.seller.privateKey);
+  const publicClient = buildPublicClient();
+  const walletClient = buildWalletClient(sellerAccount);
+
+  console.log(`[x402-e2e/globalSetup] seeding seller ${sellerAccount.address}…`);
+  const suite = await seedSuite({
+    sellerAddress: sellerAccount.address,
+    createSeller: buildCreateSellerCallback({ walletClient, publicClient }),
+  });
+
+  process.env[SUITE_STATE_ENV.sellerId] = suite.seller.id;
+  process.env[SUITE_STATE_ENV.sellerAddress] = suite.seller.assistant;
+  process.env[SUITE_STATE_ENV.disputeResolverId] = suite.disputeResolverId;
+
+  console.log(
+    `[x402-e2e/globalSetup] suite ready — sellerId=${suite.seller.id}, disputeResolverId=${suite.disputeResolverId}`,
+  );
+
+  return async () => {
+    console.log("[x402-e2e/globalSetup] tearing down stack…");
+    await stopStack();
+  };
+}

--- a/typescript/packages/x402-e2e/test/setup/globalSetup.ts
+++ b/typescript/packages/x402-e2e/test/setup/globalSetup.ts
@@ -1,5 +1,6 @@
-// Vitest `globalSetup` for the e2e scenario suite. Runs once before
-// every test file, gated behind `E2E_DOCKER=1` so default
+// Vitest `globalSetup` for the e2e scenario suite. Runs once per test
+// run (before any worker executes a test file) and tears down once
+// after the run completes — gated behind `E2E_DOCKER=1` so default
 // `pnpm test` invocations stay fast.
 //
 // Responsibilities:

--- a/typescript/packages/x402-e2e/test/setup/globalSetup.ts
+++ b/typescript/packages/x402-e2e/test/setup/globalSetup.ts
@@ -67,10 +67,17 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     console.log(
       `[x402-e2e/globalSetup] suite ready — sellerId=${suite.seller.id}, disputeResolverId=${suite.disputeResolverId}`,
     );
-  } catch (err) {
+  } catch (setupErr) {
     console.error("[x402-e2e/globalSetup] post-start setup failed, tearing down stack…");
-    await stopStack();
-    throw err;
+    try {
+      await stopStack();
+    } catch (teardownErr) {
+      console.error(
+        "[x402-e2e/globalSetup] stopStack() failed during teardown after setup error — original setup error will be rethrown:",
+        teardownErr,
+      );
+    }
+    throw setupErr;
   }
 
   return async () => {

--- a/typescript/packages/x402-e2e/test/setup/globalSetup.ts
+++ b/typescript/packages/x402-e2e/test/setup/globalSetup.ts
@@ -48,23 +48,29 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   console.log("[x402-e2e/globalSetup] starting stack…");
   await startStack({ waitForReady: true });
 
-  const sellerAccount = privateKeyToAccount(ROLE_ACCOUNTS.seller.privateKey);
-  const publicClient = buildPublicClient();
-  const walletClient = buildWalletClient(sellerAccount);
+  try {
+    const sellerAccount = privateKeyToAccount(ROLE_ACCOUNTS.seller.privateKey);
+    const publicClient = buildPublicClient();
+    const walletClient = buildWalletClient(sellerAccount);
 
-  console.log(`[x402-e2e/globalSetup] seeding seller ${sellerAccount.address}…`);
-  const suite = await seedSuite({
-    sellerAddress: sellerAccount.address,
-    createSeller: buildCreateSellerCallback({ walletClient, publicClient }),
-  });
+    console.log(`[x402-e2e/globalSetup] seeding seller ${sellerAccount.address}…`);
+    const suite = await seedSuite({
+      sellerAddress: sellerAccount.address,
+      createSeller: buildCreateSellerCallback({ walletClient, publicClient }),
+    });
 
-  process.env[SUITE_STATE_ENV.sellerId] = suite.seller.id;
-  process.env[SUITE_STATE_ENV.sellerAddress] = suite.seller.assistant;
-  process.env[SUITE_STATE_ENV.disputeResolverId] = suite.disputeResolverId;
+    process.env[SUITE_STATE_ENV.sellerId] = suite.seller.id;
+    process.env[SUITE_STATE_ENV.sellerAddress] = suite.seller.assistant;
+    process.env[SUITE_STATE_ENV.disputeResolverId] = suite.disputeResolverId;
 
-  console.log(
-    `[x402-e2e/globalSetup] suite ready — sellerId=${suite.seller.id}, disputeResolverId=${suite.disputeResolverId}`,
-  );
+    console.log(
+      `[x402-e2e/globalSetup] suite ready — sellerId=${suite.seller.id}, disputeResolverId=${suite.disputeResolverId}`,
+    );
+  } catch (err) {
+    console.error("[x402-e2e/globalSetup] post-start setup failed, tearing down stack…");
+    await stopStack();
+    throw err;
+  }
 
   return async () => {
     console.log("[x402-e2e/globalSetup] tearing down stack…");

--- a/typescript/packages/x402-e2e/test/stack.test.ts
+++ b/typescript/packages/x402-e2e/test/stack.test.ts
@@ -4,16 +4,21 @@
 //
 //   E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test
 //
-// The test boots the full canonical Boson stack + the three x402B
-// services, waits for the deploy.done markers
-// (`boson-protocol-node:/app/deploy.done`,
-//  `boson-subgraph:/home/deploy.done`), hits every service's
-// HTTP-level health probe, then tears the stack down.
+// **Stack lifecycle.** `test/setup/globalSetup.ts` (introduced in
+// PR 6) is the single owner of `startStack()` / `stopStack()` — it
+// runs once before any test file and tears down once after the whole
+// suite. This file used to run its own `beforeAll(startStack)` /
+// `afterAll(stopStack)`, but vitest parallelises test files by
+// default: with the smoke finishing in ~1s and scenario tests
+// running 20s+, the smoke's `afterAll` would tear the stack down
+// mid-scenario, surfacing as `FACILITATOR_UNREACHABLE` /
+// `NETWORK_ERROR` (502) in `commit.test.ts`. Removed accordingly —
+// this file now only probes services globalSetup is responsible for
+// bringing up.
 
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { LOCAL_31337_0 } from "../src/config/local-31337-0.js";
-import { startStack, stopStack } from "../src/stack/index.js";
 
 const ENABLED = process.env.E2E_DOCKER === "1";
 
@@ -67,14 +72,6 @@ function describePing(r: PingResult): string {
 }
 
 describe.skipIf(!ENABLED)("x402-e2e stack smoke", () => {
-  beforeAll(async () => {
-    await startStack({ waitForReady: true });
-  });
-
-  afterAll(async () => {
-    await stopStack();
-  });
-
   for (const target of HEALTH_TARGETS) {
     it(`${target.name} is reachable`, async () => {
       let last: PingResult = { ok: false, status: 0, error: "no attempt made" };

--- a/typescript/packages/x402-e2e/vitest.config.ts
+++ b/typescript/packages/x402-e2e/vitest.config.ts
@@ -8,5 +8,12 @@ export default defineConfig({
     // on cold/slow Docker runs due to image pull/build and multiple readiness probes.
     testTimeout: 5 * 60_000,
     hookTimeout: 12 * 60_000,
+    // `globalSetup` is gated internally on `E2E_DOCKER=1`; when that flag
+    // is off, the setup is a no-op and the docker-dependent scenarios
+    // skip themselves via `describe.skipIf(...)`. Listing the setup
+    // unconditionally keeps a single source of truth for the scenario
+    // wiring — flipping the gate runs the suite end-to-end without any
+    // config change.
+    globalSetup: ["./test/setup/globalSetup.ts"],
   },
 });


### PR DESCRIPTION
## Summary

Adds the vitest `globalSetup` + per-test scaffolding the scenario tests compose:

- **`harness/create-seller.ts`** — wallet-bound `createSeller` callback that plugs into `seedSuite`'s pluggable callback parameter (PR 5 left it stubbed).
- **`test/setup/globalSetup.ts`** — `E2E_DOCKER=1` gated. Boots the stack via `startStack({ waitForReady: true })`, runs `seedSuite` with the real `createSeller`, exports `{ sellerId, sellerAddress, disputeResolverId }` via `process.env` so scenario `beforeAll`s read them without re-querying the subgraph.
- **`test/scenarios/_setup.ts`** — per-test scaffolding. Instantiates `createResourceServerApp` in-process on an OS-assigned port (so the compose's `x402b-resource-server` baked with `SELLER_ID=1` isn't a blocker) and wires the three actors + asserter + subgraph reader.
- **`test/scenarios/_buyer-setup.ts`** — `ensureBuyerCanPay` — mints test ERC-20 via `Foreign20.mint` and approves the escrow. Idempotent; no-ops when balance + allowance suffice.

This is **PR 6 of the 6+ wave**, the first of three scenario PRs (PR 6 / PR 7 / PR 8). The plan in [`plans/i-want-to-create-lively-meerkat.md`](https://github.com/anthropics/claude-code) was updated to reflect:

- BPIP-12 and atomic commit-and-redeem **unblocked** on `main` (no more `deferred-*` files, settle routes via `coreSdk.executeMetaTransaction`), so A2–A5 are now @p0/@p1 rather than `it.skip`.
- Only agent mode (A8, D4) stays deferred — no `@bosonprotocol/x402-agent` package yet.

## A1 status — `it.skip` pending #73

A1 is written end-to-end (mint, approve, `wrapFetchWithPayment`, X-PAYMENT-RESPONSE assertions, on-chain `ExchangeState.COMMITTED` via the asserter) but currently skipped. The e2e run found a `committer` divergence between:

- [`pre-commit.ts:94`](typescript/packages/client/src/pre-commit.ts#L94) — `buildCreateOfferAndCommitArgs` sets `committer: buyer` before signing the meta-tx.
- [`payload.ts:62-65`](typescript/packages/client/src/payload.ts#L62-L65) — `assemblePayload` ships the server's **original** `offerRef.fullOffer.committer = 0x0`.

Server rule 7 byte-compares the rebuilt calldata against `metaTx.functionSignature` → `CALLDATA_MISMATCH`. Tracked in **#73**; the proposed one-line client-side fix unblocks A1. PR 7 expects A1 to be runnable.

## Coverage enumerated

| File | @p0 | @p1 | @p2 | todo |
|---|---|---|---|---|
| `commit.test.ts` | A1 (#73) | — | — | A2 A3 A4 A5 |
| `validation-commit.test.ts` | — | — | — | C1 C2 C3 C4 C5 C8 |
| `_skeletons.test.ts` (PR 7 / PR 8 anchors) | B1–B4 | B5 B6 B7 C6 C9 C10 D1 D2 D3 E1 A6 | B8 B9 C7 D4 E2 E3 F1 F2 F3 F4 A7 A8 | (all todo) |

## Test plan

- [x] `pnpm install` resolves cleanly
- [x] `pnpm --filter @bosonprotocol/x402-e2e build` (tsc --noEmit) passes
- [x] `pnpm --filter @bosonprotocol/x402-e2e test` — 19 passed, 9 skipped (gated), 37 todo, <4s
- [x] `pnpm --filter @bosonprotocol/x402-e2e lint` passes
- [x] `pnpm format:check` clean
- [ ] `E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test` — globalSetup boots the stack and seeds, the in-process resource server starts, A1 skips with the #73 reference (no failure). One-off local run to confirm before merge is welcome but not blocking — the offline gates are green and the live path will re-enable once #73 lands.

## Follow-ups

- **PR 7** (next): A1 unskipped (#73), A2–A5 implemented, B1–B7 + C6/C9/C10 + D1/D2 + E1–E3 + A6 + A7 + harness extensions (`SellerActor.revokeVoucher`, `ResolverActor.decideDispute`).
- **PR 8**: D3 (channel fallback), F1–F4 (operational), `nightly.yml`, opens the e2e job to every PR once flake rate is known. A8 / D4 stay skipped until `@bosonprotocol/x402-agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added E2E scenario scaffolding: commit-time and validation suites, skeleton placeholders, gated execution flag, buyer setup helpers (mint/approve with receipt waits), scenario context with in-process resource server, and a runnable commit scenario A1.
* **New Features**
  * Exposed a reusable harness helper to create and seed seller accounts for scenarios.
  * Added a polling wrapper for exchange reads to wait until data is available.
* **Chores**
  * Added Vitest global setup to optionally boot a local test stack, seed seller state, and export suite env for tests.
* **Documentation**
  * README updated to describe test layout, per-test setup, scenarios, and harness helpers.
* **Examples**
  * Demo resource server adjusted dispute period and fee cap in example offers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->