### PR TITLE
fix: mirror x402-client behavior by including committer address in ca…

### DIFF
--- a/examples/resource-server/test/resource-server.test.ts
+++ b/examples/resource-server/test/resource-server.test.ts
@@ -229,9 +229,15 @@ describe("resource-server example app", () => {
     const requirements = challenge.body.accepts[0];
 
     const buyer = privateKeyToAccount(BUYER_PK);
+    // Mirror the real x402-client behaviour: build calldata with
+    // `committer: buyer.address`. `committer` is an outer arg of the
+    // on-chain `createOfferAndCommit(...)`, not in the seller's
+    // EIP-712-signed FullOffer, so the buyer's client splices it in.
+    // Server-side rule 7 mirrors the same splice — see x402B#73.
     const calldata = await buildCreateOfferAndCommitCalldata({
       fullOffer: {
         ...requirements.offer.fullOffer,
+        committer: buyer.address,
         signature: requirements.offer.sellerSig,
       } as Parameters<typeof buildCreateOfferAndCommitCalldata>[0]["fullOffer"],
     });

--- a/typescript/packages/facilitator/src/verify/structural.ts
+++ b/typescript/packages/facilitator/src/verify/structural.ts
@@ -142,9 +142,24 @@ export async function validateMetaTxCalldataMatchesRequirements(input: {
   requirements: EscrowPaymentRequirements;
 }): Promise<StepResult> {
   const inner = input.payload.payload;
-  const fullOffer = withSellerSignature(
+  // Mirror the buyer-side splice: `committer` is an outer argument of
+  // `createOfferAndCommit(...)`, not in the seller's FullOffer EIP-712
+  // typed-data (see `signFullOffer` in `@bosonprotocol/core-sdk`'s
+  // `exchanges/handler.js`). The buyer's client sets
+  // `committer = buyer` before signing the meta-tx (see
+  // `@bosonprotocol/x402-client`'s `pre-commit.ts:94`), while
+  // `requirements.offer.fullOffer.committer` carries whatever the
+  // application seeded at challenge time (typically the zero
+  // address). The seller's signature is valid for any committer
+  // value, so we rebuild the expected calldata with the buyer's
+  // address — otherwise every valid payment trips this check on the
+  // committer slot. Regression: x402B#73. Server-side parallel lives
+  // in `@bosonprotocol/x402-server`'s rule 7
+  // (`validate/payment-payload.ts`).
+  const fullOffer = withSellerSignatureAndCommitter(
     input.requirements.offer.fullOffer,
     input.requirements.offer.sellerSig,
+    inner.buyer,
   ) as CalldataFullOffer;
 
   try {
@@ -249,11 +264,12 @@ export function parseChainId(
   return { ok: true, chainId: Number(m[1]) };
 }
 
-function withSellerSignature(
+function withSellerSignatureAndCommitter(
   fullOffer: Record<string, unknown>,
   sellerSig: string,
+  committer: string,
 ): Record<string, unknown> {
-  return { ...fullOffer, signature: sellerSig };
+  return { ...fullOffer, committer, signature: sellerSig };
 }
 
 function canonicalJson(value: unknown): string {

--- a/typescript/packages/facilitator/test/fixtures.ts
+++ b/typescript/packages/facilitator/test/fixtures.ts
@@ -40,6 +40,13 @@ export const SELLER_SIG: Hex = `0x${"33".repeat(65)}`;
 export const AMOUNT = "1000000";
 
 /**
+ * Distinct EOA used by negative tests that need a buyer address
+ * different from `buyer.address` — kept here so the literal is defined
+ * once and any test that swaps the buyer reuses the same value.
+ */
+export const WRONG_BUYER: Address = "0xabcdef1234567890abcdef1234567890abcdef12";
+
+/**
  * Canonical `fullOffer` literal used to build a real meta-tx calldata
  * via `buildCreateOfferAndCommitCalldata`. Both verify and settle
  * require the on-chain calldata embedded in `payload.metaTx` to match

--- a/typescript/packages/facilitator/test/fixtures.ts
+++ b/typescript/packages/facilitator/test/fixtures.ts
@@ -46,6 +46,16 @@ export const AMOUNT = "1000000";
  * what `requirements.offer.fullOffer` advertises — duplicating this
  * literal across test files would silently drift the moment the Boson
  * `FullOffer` struct changes.
+ *
+ * `committer` is kept at the zero-address placeholder here, mirroring
+ * what real challenge-time `requirements.offer.fullOffer` carries
+ * before the buyer is known. The buyer-side calldata splice
+ * (`pre-commit.ts:94`) sets `committer = buyer` on the calldata it
+ * signs; `validateMetaTxCalldataMatchesRequirements` mirrors the same
+ * splice when rebuilding the expected calldata (see
+ * `verify/structural.ts`). Anchoring the canonical fixture this way
+ * means existing tests cover the divergence as a regression for
+ * x402B#73.
  */
 export const fullOffer = {
   price: AMOUNT,
@@ -67,7 +77,10 @@ export const fullOffer = {
   collectionIndex: "0",
   feeLimit: "0",
   offerCreator: SELLER,
-  committer: buyer.address,
+  // Zero-address placeholder mirrors the server's challenge-time
+  // requirements.offer.fullOffer; the calldata builder below splices
+  // in `committer: buyer.address` to match the real client behaviour.
+  committer: "0x0000000000000000000000000000000000000000",
   condition: {
     method: 0,
     tokenType: 0,
@@ -96,8 +109,17 @@ export const fullOffer = {
  * advertises.
  */
 export async function buildValidPayload(): Promise<EscrowPaymentPayload> {
+  // Mirror `@bosonprotocol/x402-client`'s `pre-commit.ts:94` splice:
+  // the canonical `fullOffer` carries `committer: 0x0` (the server's
+  // challenge-time placeholder), but the buyer signs calldata with
+  // `committer: buyer.address`. `validateMetaTxCalldataMatchesRequirements`
+  // mirrors the same splice when rebuilding the expected calldata —
+  // regression for x402B#73.
   const calldata = await buildCreateOfferAndCommitCalldata({
-    fullOffer: fullOffer as Parameters<typeof buildCreateOfferAndCommitCalldata>[0]["fullOffer"],
+    fullOffer: {
+      ...fullOffer,
+      committer: buyer.address,
+    } as Parameters<typeof buildCreateOfferAndCommitCalldata>[0]["fullOffer"],
   });
   const typedData = await metaTransactionTypedData({
     chainId: CHAIN_ID,

--- a/typescript/packages/facilitator/test/settle.test.ts
+++ b/typescript/packages/facilitator/test/settle.test.ts
@@ -20,6 +20,7 @@ import type { FacilitatorConfig } from "../src/types.js";
 import {
   buildValidPayload,
   buildValidRequirements,
+  buyer,
   CHAIN_ID,
   ESCROW,
   NETWORK,
@@ -192,6 +193,43 @@ describe("settle()", () => {
   it("happy path: verify passes, envelope built, tx submitted, exchangeId extracted", async () => {
     const payload = await buildValidPayload();
     const requirements = buildValidRequirements();
+    const result = await settle(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toEqual({
+      ok: true,
+      exchangeId: EXPECTED_EXCHANGE_ID.toString(),
+      txHash: TX_HASH,
+    });
+  });
+
+  // Regression for x402B#73: settle() calls verify() first, and
+  // verify's `validateMetaTxCalldataMatchesRequirements` used to
+  // trip on the committer slot whenever the real-world shape was in
+  // play — `requirements.offer.fullOffer.committer = 0x0` (server
+  // placeholder) while the buyer's meta-tx calldata splices in
+  // `committer = buyer.address` (mirroring
+  // `@bosonprotocol/x402-client`'s `pre-commit.ts:94`). After the
+  // `verify/structural.ts` fix the splice is mirrored when
+  // rebuilding the expected calldata. Pin the asymmetric fixture
+  // shape + settle-side outcome here so a fixture "cleanup" that
+  // re-aligns the committers can't silently lose this coverage.
+  it("x402B#73 — placeholder offerRef committer + buyer-spliced calldata passes settle()", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+
+    // Pin the divergent shape: offerRef carries the placeholder…
+    expect(payload.payload.offerRef.fullOffer.committer).toBe(
+      "0x0000000000000000000000000000000000000000",
+    );
+    expect(requirements.offer.fullOffer.committer).toBe(
+      "0x0000000000000000000000000000000000000000",
+    );
+    // …while the meta-tx claims the real buyer.
+    expect(payload.payload.buyer.toLowerCase()).toBe(buyer.address.toLowerCase());
+    expect(payload.payload.metaTx.from.toLowerCase()).toBe(buyer.address.toLowerCase());
+
     const result = await settle(
       { scheme: "escrow", network: NETWORK, payload, requirements },
       buildConfig(),

--- a/typescript/packages/facilitator/test/verify.test.ts
+++ b/typescript/packages/facilitator/test/verify.test.ts
@@ -192,6 +192,37 @@ describe("verify()", () => {
     expect(result).toMatchObject({ ok: false, code: "INVALID_PAYLOAD" });
   });
 
+  // Regression for x402B#73: the canonical fixture's `fullOffer`
+  // carries `committer: 0x0` (the challenge-time placeholder) while
+  // the meta-tx calldata splices in `committer: buyer.address`.
+  // Before the fix in `verify/structural.ts`,
+  // `validateMetaTxCalldataMatchesRequirements` rebuilt the expected
+  // calldata from `offerRef.fullOffer` verbatim and tripped on the
+  // committer slot, rejecting every valid payment. With the fix in
+  // place, the splice is mirrored and the happy path passes — which
+  // the `buildConfig()` smoke at the top of this describe already
+  // exercises, so this test pins the *opposite* direction: if the
+  // payload claims a `buyer` that doesn't match the calldata-encoded
+  // committer, the check must still reject.
+  it("rejects when payload.buyer doesn't match the calldata-encoded committer", async () => {
+    const payload = await buildValidPayload();
+    // The fixture's calldata has `committer: buyer.address` from
+    // `buildValidPayload`; clobbering `payload.buyer` to a different
+    // EOA makes the splice mismatch.
+    const wrongBuyer: Address = "0xabcdef1234567890abcdef1234567890abcdef12";
+    payload.payload.buyer = wrongBuyer;
+    payload.payload.metaTx.from = wrongBuyer;
+    const requirements = buildValidRequirements();
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toMatchObject({ ok: false, code: "INVALID_PAYLOAD" });
+    expect((result as { ok: false; reason: string }).reason).toMatch(
+      /functionSignature does not encode/i,
+    );
+  });
+
   it("rejects when meta-tx calldata does not encode the required offer", async () => {
     const payload = await buildValidPayload();
     payload.payload.metaTx.functionSignature = "0xdeadbeef";
@@ -205,11 +236,24 @@ describe("verify()", () => {
 
   it("rejects when meta-tx signature was produced by a different signer", async () => {
     const payload = await buildValidPayload();
-    // Pretend a different EOA is the claimed buyer — recovery will then
-    // mismatch the payload.buyer.
+    // Pretend a different EOA is the claimed buyer — recovery will
+    // then mismatch `payload.buyer`. The calldata-match step (which
+    // mirrors the buyer-side committer splice — x402B#73) runs before
+    // signature recovery, so we also rebuild the meta-tx calldata
+    // with `committer = wrongBuyer` so this test isolates the
+    // BAD_META_TX_SIGNATURE failure. The sig itself stays the one
+    // `buildValidPayload` produced for the real `buyer` account — so
+    // recovery yields `buyer`, not `wrongBuyer`, and step 8 fires.
     const wrongBuyer: Address = "0xabcdef1234567890abcdef1234567890abcdef12";
+    const { buildCreateOfferAndCommitCalldata } = await import("@bosonprotocol/x402-evm/actions");
+    const reframedCalldata = await buildCreateOfferAndCommitCalldata({
+      fullOffer: { ...fullOffer, committer: wrongBuyer } as Parameters<
+        typeof buildCreateOfferAndCommitCalldata
+      >[0]["fullOffer"],
+    });
     payload.payload.buyer = wrongBuyer;
     payload.payload.metaTx.from = wrongBuyer;
+    payload.payload.metaTx.functionSignature = reframedCalldata.functionSignature;
     const requirements = buildValidRequirements();
     const result = await verify(
       { scheme: "escrow", network: NETWORK, payload, requirements },

--- a/typescript/packages/facilitator/test/verify.test.ts
+++ b/typescript/packages/facilitator/test/verify.test.ts
@@ -192,18 +192,42 @@ describe("verify()", () => {
     expect(result).toMatchObject({ ok: false, code: "INVALID_PAYLOAD" });
   });
 
-  // Regression for x402B#73: the canonical fixture's `fullOffer`
-  // carries `committer: 0x0` (the challenge-time placeholder) while
-  // the meta-tx calldata splices in `committer: buyer.address`.
-  // Before the fix in `verify/structural.ts`,
-  // `validateMetaTxCalldataMatchesRequirements` rebuilt the expected
-  // calldata from `offerRef.fullOffer` verbatim and tripped on the
-  // committer slot, rejecting every valid payment. With the fix in
-  // place, the splice is mirrored and the happy path passes — which
-  // the `buildConfig()` smoke at the top of this describe already
-  // exercises, so this test pins the *opposite* direction: if the
-  // payload claims a `buyer` that doesn't match the calldata-encoded
-  // committer, the check must still reject.
+  // Regression for x402B#73 (positive direction): the canonical
+  // `fullOffer` fixture carries `committer: 0x0` (the placeholder
+  // that real servers stamp into `requirements.offer.fullOffer` at
+  // challenge time), while `buildValidPayload` splices
+  // `committer: buyer.address` into the calldata it signs (mirroring
+  // `@bosonprotocol/x402-client`'s `pre-commit.ts:94`). Before the
+  // `verify/structural.ts` fix this asymmetric shape tripped the
+  // calldata-match check on the committer slot and rejected every
+  // valid payment. Pin the asymmetric fixture shape + happy-path
+  // outcome here so a future fixture "cleanup" that re-aligns the
+  // committers can't silently lose the regression coverage.
+  it("x402B#73 — placeholder offerRef committer + buyer-spliced calldata passes verify()", async () => {
+    const payload = await buildValidPayload();
+    const requirements = buildValidRequirements();
+
+    // Pin the divergent shape: offerRef carries the placeholder…
+    expect(payload.payload.offerRef.fullOffer.committer).toBe(
+      "0x0000000000000000000000000000000000000000",
+    );
+    expect(requirements.offer.fullOffer.committer).toBe(
+      "0x0000000000000000000000000000000000000000",
+    );
+    // …while the meta-tx claims a real buyer.
+    expect(payload.payload.buyer.toLowerCase()).toBe(buyer.address.toLowerCase());
+    expect(payload.payload.metaTx.from.toLowerCase()).toBe(buyer.address.toLowerCase());
+
+    const result = await verify(
+      { scheme: "escrow", network: NETWORK, payload, requirements },
+      buildConfig(),
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  // Regression for x402B#73 (negative direction): the structural
+  // calldata check must still reject when the buyer-side splice and
+  // the calldata-encoded committer disagree.
   it("rejects when payload.buyer doesn't match the calldata-encoded committer", async () => {
     const payload = await buildValidPayload();
     // The fixture's calldata has `committer: buyer.address` from

--- a/typescript/packages/facilitator/test/verify.test.ts
+++ b/typescript/packages/facilitator/test/verify.test.ts
@@ -22,6 +22,7 @@ import {
   fullOffer,
   NETWORK,
   relayer,
+  WRONG_BUYER,
 } from "./fixtures.js";
 
 /**
@@ -233,7 +234,7 @@ describe("verify()", () => {
     // The fixture's calldata has `committer: buyer.address` from
     // `buildValidPayload`; clobbering `payload.buyer` to a different
     // EOA makes the splice mismatch.
-    const wrongBuyer: Address = "0xabcdef1234567890abcdef1234567890abcdef12";
+    const wrongBuyer = WRONG_BUYER;
     payload.payload.buyer = wrongBuyer;
     payload.payload.metaTx.from = wrongBuyer;
     const requirements = buildValidRequirements();
@@ -268,7 +269,7 @@ describe("verify()", () => {
     // BAD_META_TX_SIGNATURE failure. The sig itself stays the one
     // `buildValidPayload` produced for the real `buyer` account — so
     // recovery yields `buyer`, not `wrongBuyer`, and step 8 fires.
-    const wrongBuyer: Address = "0xabcdef1234567890abcdef1234567890abcdef12";
+    const wrongBuyer = WRONG_BUYER;
     const { buildCreateOfferAndCommitCalldata } = await import("@bosonprotocol/x402-evm/actions");
     const reframedCalldata = await buildCreateOfferAndCommitCalldata({
       fullOffer: { ...fullOffer, committer: wrongBuyer } as Parameters<

--- a/typescript/packages/server-express/test/express.test.ts
+++ b/typescript/packages/server-express/test/express.test.ts
@@ -122,9 +122,16 @@ async function buildBuyerPayload() {
     escrow: ESCROW,
     chainId: CHAIN_ID,
   });
+  // Mirror the real x402-client behaviour: build calldata with
+  // `committer: buyer.address`. `committer` is an outer arg of the
+  // on-chain `createOfferAndCommit(...)`, not part of the seller's
+  // EIP-712 typed-data, so the buyer's client splices it in before
+  // signing. Rule 7 (in `@bosonprotocol/x402-server`) mirrors the
+  // same splice when rebuilding calldata — see x402B#73.
   const calldata = await buildCreateOfferAndCommitCalldata({
     fullOffer: {
       ...offerRef.fullOffer,
+      committer: buyer.address,
       signature: offerRef.sellerSig,
     } as Parameters<typeof buildCreateOfferAndCommitCalldata>[0]["fullOffer"],
   });

--- a/typescript/packages/server/src/validate/payment-payload.ts
+++ b/typescript/packages/server/src/validate/payment-payload.ts
@@ -259,8 +259,22 @@ async function checkFunctionSignatureAndCalldataEquality(
     );
   }
 
+  // `committer` is an outer argument of `createOfferAndCommit(...)`,
+  // not a field in the seller's FullOffer EIP-712 typed-data (see
+  // `signFullOffer` in `@bosonprotocol/core-sdk`'s
+  // `exchanges/handler.js`). The seller's signature is valid for any
+  // committer value, so the buyer's client splices `committer = buyer`
+  // into the meta-tx calldata before signing (see
+  // `@bosonprotocol/x402-client`'s `pre-commit.ts:94`). Rule 3 already
+  // enforces that `offerRef.fullOffer` matches
+  // `requirements.offer.fullOffer` byte-for-byte, so the offerRef
+  // carries whatever seed value the application chose at challenge
+  // time. Here we mirror the buyer-side splice when rebuilding the
+  // expected calldata — without it every valid payment trips rule 7
+  // on the committer slot. Regression: x402B#73.
   const fullOfferWithSig = {
     ...payload.payload.offerRef.fullOffer,
+    committer: payload.payload.buyer,
     signature: payload.payload.offerRef.sellerSig,
   } as unknown as BuilderFullOffer;
 

--- a/typescript/packages/server/test/fixtures.ts
+++ b/typescript/packages/server/test/fixtures.ts
@@ -115,7 +115,18 @@ export async function makePaymentFixture(
     chainId: CHAIN_ID,
   });
 
-  const fullOfferWithSig = { ...offerRef.fullOffer, signature: offerRef.sellerSig };
+  // Mirror the real x402-client behaviour: build calldata with
+  // `committer: buyer.address`. `committer` is an outer arg of the
+  // on-chain `createOfferAndCommit(...)`, not a field in the seller's
+  // EIP-712 FullOffer signature — the buyer's client splices in the
+  // buyer address before signing the meta-tx. Rule 7 mirrors the same
+  // splice when rebuilding the expected calldata, so this fixture
+  // reflects what real payloads carry on the wire.
+  const fullOfferWithSig = {
+    ...offerRef.fullOffer,
+    committer: buyer.address,
+    signature: offerRef.sellerSig,
+  };
   // Build the calldata that matches the requested `action`. Tests that
   // intentionally cross the wires (e.g. Flow A action with Flow B
   // calldata) override `payload.metaTx` directly after the fixture

--- a/typescript/packages/server/test/validate.test.ts
+++ b/typescript/packages/server/test/validate.test.ts
@@ -173,6 +173,53 @@ describe("validatePaymentPayload — rule failures", () => {
     expect(result).toMatchObject({ ok: false, rule: 7, code: "CALLDATA_MISMATCH" });
   });
 
+  // Regression for x402B#73: `committer` is an outer arg of the
+  // on-chain `createOfferAndCommit(...)`, not a field in the
+  // FullOffer EIP-712 the seller signs. The buyer's client splices
+  // its address in before signing the meta-tx, while the server's
+  // `offerRef.fullOffer.committer` keeps its placeholder (typically
+  // `0x0`). Rule 7 must mirror the splice when rebuilding calldata
+  // for the byte comparison; otherwise every valid payment trips on
+  // the committer slot.
+  it("rule 7 — passes when offerRef.committer differs from metaTx-encoded committer (buyer splice)", async () => {
+    const fx = await makePaymentFixture();
+    // The fixture builds calldata with `committer: buyer.address` to
+    // mirror the real client. Force `offerRef.fullOffer.committer`
+    // back to the zero-address placeholder a server would emit at
+    // challenge time.
+    const placeholderCommitter = `0x${"00".repeat(20)}` as const;
+    const withZeroOfferRefCommitter = {
+      ...fx.payload,
+      payload: {
+        ...fx.payload.payload,
+        offerRef: {
+          ...fx.payload.payload.offerRef,
+          fullOffer: {
+            ...fx.payload.payload.offerRef.fullOffer,
+            committer: placeholderCommitter,
+          },
+        },
+      },
+    };
+    const requirementsWithZeroCommitter = {
+      ...fx.requirements,
+      offer: {
+        ...fx.requirements.offer,
+        fullOffer: {
+          ...fx.requirements.offer.fullOffer,
+          committer: placeholderCommitter,
+        },
+      },
+    };
+
+    const result = await validatePaymentPayload({
+      payload: withZeroOfferRefCommitter,
+      requirements: requirementsWithZeroCommitter,
+      chainId: CHAIN_ID,
+    });
+    expect(result.ok).toBe(true);
+  });
+
   it("rule 8 — rejects when buyer.address ≠ metaTx.from", async () => {
     const fx = await makePaymentFixture();
     const tampered = {


### PR DESCRIPTION
…lldata for createOfferAndCommit

fixes #73 

This pull request addresses a regression (x402B#73) related to how the `committer` field is handled when building calldata for the `createOfferAndCommit` on-chain function. The main change is to ensure that, both in tests and validation logic, the buyer's address is spliced into the calldata as the `committer`, mirroring the real client behavior and preventing false negatives in rule 7 validation. Additionally, a regression test is added to ensure this behavior is preserved.

**Calldata construction and validation consistency:**

* Updated all test and fixture code (`resource-server.test.ts`, `express.test.ts`, `fixtures.ts`) to explicitly splice `committer: buyer.address` into the calldata, matching the real client behavior and ensuring that server-side rule 7 validation is accurate. [[1]](diffhunk://#diff-a1932814bbff44f7cf3ce5567d4f4ecf2e71c9b8a4563e63a772474f660460abR232-R240) [[2]](diffhunk://#diff-d9353bf6169f19cc139507fcb958ad669ebd07fd3d08ff9ac33650e71da67cebR125-R134) [[3]](diffhunk://#diff-de57159f06753d50e054e8f9534494ae2d76cd0591483e9f74112dfda4124977L118-R129)
* Updated the server-side validation logic (`payment-payload.ts`) to splice the buyer's address as `committer` when rebuilding expected calldata, preventing spurious rule 7 failures when the committer slot differs from the placeholder in the original offer.

**Regression test coverage:**

* Added a regression test (`validate.test.ts`) to ensure that rule 7 passes when the committer in `offerRef.fullOffer` is a placeholder but the calldata encodes the buyer's address, preventing future regressions of x402B#73.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes to payment/settlement validation so reconstructed meta-transaction calldata consistently accounts for committer values, reducing false accepts/rejects for commit-time payments.

* **Tests**
  * Added and updated regression tests and fixtures covering committer vs. buyer calldata scenarios to prevent regressions and ensure consistent validation and settlement behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->