### PR TITLE
feat(x402-e2e): post-commit lifecycle scenarios + PR6 cleanups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,15 @@ JSON schemas under `src/**/schemas/` into `dist/schemas/`.
 Tests use **vitest**. The package-level `test` script passes
 `--passWithNoTests` for empty packages, so they don't fail CI.
 
+The `x402-e2e` suite gates on `E2E_DOCKER=1` (drives a real docker
+stack via `pnpm stack:up` / `stack:down`). When iterating on a
+single scenario file against a stack you launched manually, set
+`E2E_DOCKER_KEEP_STACK=1` alongside it — `globalSetup` then skips
+both the defensive pre-start `stopStack()` and the post-suite
+teardown, leaving the stack running so the next invocation reuses
+it (seeders are idempotent; the suite mints fresh buyer EOAs each
+run).
+
 ### CI
 
 GitHub Actions matrix on the currently-supported LTS Node versions.

--- a/examples/facilitator-http/Dockerfile
+++ b/examples/facilitator-http/Dockerfile
@@ -9,24 +9,35 @@ FROM node:22-alpine AS base
 RUN corepack enable
 WORKDIR /repo
 
+# --- Stage 1: install (cache key = lockfile + workspace manifests) ---
+# Source code is NOT copied here, so this layer only invalidates when
+# pnpm-lock.yaml or a package.json changes. BuildKit's pnpm-store cache
+# mount reuses tarballs across rebuilds even when install does re-run.
 FROM base AS deps
-COPY . .
-RUN pnpm install --frozen-lockfile \
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY --parents typescript/packages/*/package.json examples/*/package.json ./
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile \
     --filter @bosonprotocol/x402-example-facilitator-http...
 
+# --- Stage 2: build + deploy (invalidated when source changes) ---
 # Build the workspace deps the example imports (tsup emits dist/ + the
 # exports map points at it). The trailing `...` includes transitive
 # workspace deps (x402-core, x402-evm, x402-actions, x402-fulfillment).
-RUN pnpm --filter @bosonprotocol/x402-facilitator-express... build
-
-# See examples/webhook-sink/Dockerfile for the rationale behind
-# `pnpm deploy --legacy` (flattens the virtual store into a self-contained
-# dir; --legacy keeps the pnpm-9 deploy semantics).
+#
+# `pnpm deploy --legacy` flattens the virtual store into a self-contained
+# dir; --legacy keeps the pnpm-9 deploy semantics. See
+# examples/webhook-sink/Dockerfile for the longer rationale.
+FROM deps AS build
+COPY . .
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm --filter @bosonprotocol/x402-facilitator-express... build
 RUN pnpm --filter @bosonprotocol/x402-example-facilitator-http deploy --legacy /deploy
 
+# --- Stage 3: runtime ---
 FROM node:22-alpine AS runtime
 WORKDIR /app
-COPY --from=deps /deploy ./
+COPY --from=build /deploy ./
 
 ENV PORT=8889
 EXPOSE 8889

--- a/examples/facilitator-http/Dockerfile
+++ b/examples/facilitator-http/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.7-labs
 #
 # Build from the monorepo root so the root pnpm-lock.yaml is in context:
 #   docker build -t x402b-facilitator-http -f examples/facilitator-http/Dockerfile .

--- a/examples/facilitator-http/Dockerfile
+++ b/examples/facilitator-http/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /repo
 # pnpm-lock.yaml or a package.json changes. BuildKit's pnpm-store cache
 # mount reuses tarballs across rebuilds even when install does re-run.
 FROM base AS deps
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY --parents typescript/packages/*/package.json examples/*/package.json ./
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile \

--- a/examples/facilitator-http/src/config.ts
+++ b/examples/facilitator-http/src/config.ts
@@ -10,7 +10,7 @@ import {
   type PublicClient,
   type WalletClient,
 } from "viem";
-import { privateKeyToAccount } from "viem/accounts";
+import { nonceManager, privateKeyToAccount } from "viem/accounts";
 
 export interface FacilitatorEnv {
   /** Public URL the facilitator service is reachable at; populates `nextActions[].endpoints.facilitator`. */
@@ -86,7 +86,14 @@ function chainFor(chainId: number, rpcNode: string): Chain {
 export function buildFacilitatorConfig(env: FacilitatorEnv): FacilitatorConfig {
   const chain = chainFor(env.chainId, env.rpcNode);
   const network = `eip155:${env.chainId}` as const;
-  const account = privateKeyToAccount(env.relayerPk);
+  // Wrap the relayer with viem's built-in `nonceManager` so concurrent
+  // `executeMetaTransaction(...)` submissions are serialised on the
+  // relayer's nonce. Without this, parallel HTTP requests race
+  // `eth_getTransactionCount` and the chain rejects the loser as
+  // `Nonce too low` — surfaces as INTERNAL_ERROR / FACILITATOR_REJECTED
+  // for buyers retrying in parallel (e.g. the e2e suite running
+  // multiple test files at once).
+  const account = privateKeyToAccount(env.relayerPk, { nonceManager });
 
   const walletClient: WalletClient = createWalletClient({
     account,

--- a/examples/resource-server/src/app.ts
+++ b/examples/resource-server/src/app.ts
@@ -177,6 +177,7 @@ export function createResourceServerApp(
           env,
           sellerAddress: seller.address,
           now: now(),
+          sessionId,
           ...(protocolConfig !== undefined ? { protocolConfig } : {}),
         }),
       },

--- a/examples/resource-server/src/app.ts
+++ b/examples/resource-server/src/app.ts
@@ -92,14 +92,41 @@ export function createResourceServerApp(
   // retries with `X-PAYMENT`). The validator deep-equals
   // `payload.offerRef.fullOffer` against `requirements.offer.fullOffer`
   // and strict-equals the `sellerSig`, so the settle call must see the
-  // same signed offer the challenge emitted. Cache it and refresh
-  // lazily a few minutes before the offer's on-chain validity ends so
-  // an in-flight buyer commit can't race the expiry boundary.
-  const REFRESH_MARGIN_MS = 5 * 60 * 1000;
-  let cached: { promise: Promise<EscrowPaymentRequirements>; expiresAt: number } | undefined;
+  // same signed offer the challenge emitted.
+  //
+  // We scope that "same signed offer" to a single buyer flow via the
+  // `X-X402-Boson-Session-Id` header `@bosonprotocol/x402-client-fetch`
+  // stamps on both requests of a 402-retry pair. A short per-session
+  // TTL bounds memory and lets the cache invalidate naturally between
+  // unrelated commits (without it, a sequential second commit hits the
+  // cached offer and reverts `OfferSoldOut` on a single-quantity
+  // template). Clients that don't honour the header share the
+  // `FALLBACK_KEY` slot and get the previous time-based behaviour, so
+  // the change is backwards-compatible for non-x402b consumers.
+  const SESSION_ID_HEADER = "x-x402-boson-session-id";
+  const FALLBACK_KEY = "__no_session__";
+  const SESSION_CACHE_TTL_MS = 60_000;
+  const sessionCache = new Map<
+    string,
+    { promise: Promise<EscrowPaymentRequirements>; expiresAt: number }
+  >();
 
-  const resolveRequirements = async (_req: Request) => {
-    if (cached !== undefined && now() < cached.expiresAt) return cached.promise;
+  const resolveRequirements = async (req: Request) => {
+    // Express lowercases incoming header names. Coerce to string and
+    // trim — empty / whitespace-only ids fall through to the shared slot.
+    const rawSessionId = req.header(SESSION_ID_HEADER);
+    const sessionId =
+      typeof rawSessionId === "string" && rawSessionId.trim().length > 0
+        ? rawSessionId.trim()
+        : FALLBACK_KEY;
+
+    const existing = sessionCache.get(sessionId);
+    if (existing !== undefined && now() < existing.expiresAt) {
+      return existing.promise;
+    }
+    if (existing !== undefined) {
+      sessionCache.delete(sessionId);
+    }
 
     const promise = server.buildPaymentRequirements({
       offer: {
@@ -120,16 +147,16 @@ export function createResourceServerApp(
       maxTimeoutSeconds: env.maxTimeoutSeconds,
     });
 
-    // Assign before awaiting so concurrent challenge/settle callers
-    // join the same in-flight build; `expiresAt` is provisional until
+    // Assign before awaiting so a concurrent retry on the same session
+    // id joins the in-flight build; `expiresAt` is provisional until
     // the build resolves.
     const entry = { promise, expiresAt: Number.MAX_SAFE_INTEGER };
-    cached = entry;
+    sessionCache.set(sessionId, entry);
     try {
-      const requirements = await promise;
-      entry.expiresAt = Number(requirements.offer.fullOffer.validUntilDateInMS) - REFRESH_MARGIN_MS;
+      await promise;
+      entry.expiresAt = now() + SESSION_CACHE_TTL_MS;
     } catch (e) {
-      if (cached === entry) cached = undefined;
+      if (sessionCache.get(sessionId) === entry) sessionCache.delete(sessionId);
       throw e;
     }
     return promise;

--- a/examples/resource-server/src/app.ts
+++ b/examples/resource-server/src/app.ts
@@ -107,7 +107,13 @@ export function createResourceServerApp(
   // previous time-based behaviour, so the change is backwards-
   // compatible for non-x402b consumers.
   const FALLBACK_KEY = "__no_session__";
-  const SESSION_CACHE_TTL_MS = 60_000;
+  const SESSION_CACHE_TTL_BUFFER_MS = 5_000;
+  const SESSION_CACHE_MIN_TTL_MS = 60_000;
+  const derivedSessionCacheTtlMs = env.maxTimeoutSeconds * 1_000 + SESSION_CACHE_TTL_BUFFER_MS;
+  const SESSION_CACHE_TTL_MS =
+    Number.isFinite(derivedSessionCacheTtlMs) && derivedSessionCacheTtlMs > 0
+      ? Math.max(SESSION_CACHE_MIN_TTL_MS, derivedSessionCacheTtlMs)
+      : SESSION_CACHE_MIN_TTL_MS;
   const MAX_SESSION_ID_LENGTH = 128;
   const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
   const MAX_SESSION_CACHE_ENTRIES = 256;

--- a/examples/resource-server/src/app.ts
+++ b/examples/resource-server/src/app.ts
@@ -33,6 +33,7 @@ import { privateKeyToAccount, type LocalAccount } from "viem/accounts";
 import { buildExampleChannelRegistry } from "./channel-registry.js";
 import type { ResourceServerEnv } from "./config.js";
 import { buildUnsignedOffer } from "./offer.js";
+import type { ProtocolConfig } from "./protocol-config.js";
 
 export interface ResourceServerAppOptions {
   /**
@@ -43,6 +44,13 @@ export interface ResourceServerAppOptions {
   exchangeReader: ExchangeReader;
   /** Replace `Date.now()` for deterministic offer-validity windows in tests. */
   now?: () => number;
+  /**
+   * Optional on-chain `ConfigHandlerFacet` slice for tightening
+   * `feeLimit` and flooring `disputePeriodDurationInMS`. Production
+   * forks should fetch this once at boot via `fetchProtocolConfig`.
+   * Omitted in unit tests that don't have a live chain.
+   */
+  protocolConfig?: ProtocolConfig;
 }
 
 export interface ResourceServerAppBundle {
@@ -75,6 +83,7 @@ export function createResourceServerApp(
   const seller = privateKeyToAccount(env.sellerPk);
   const exchangeReader = options.exchangeReader;
   const now = options.now ?? Date.now;
+  const protocolConfig = options.protocolConfig;
 
   const server = createX402bServer(buildServerConfig(env, seller, exchangeReader));
 
@@ -93,7 +102,14 @@ export function createResourceServerApp(
     if (cached !== undefined && now() < cached.expiresAt) return cached.promise;
 
     const promise = server.buildPaymentRequirements({
-      offer: { unsigned: buildUnsignedOffer({ env, sellerAddress: seller.address, now: now() }) },
+      offer: {
+        unsigned: buildUnsignedOffer({
+          env,
+          sellerAddress: seller.address,
+          now: now(),
+          ...(protocolConfig !== undefined ? { protocolConfig } : {}),
+        }),
+      },
       asset: env.assetAddress,
       amount: env.amount,
       // Settle path is end-to-end runnable only for `none` today; the

--- a/examples/resource-server/src/app.ts
+++ b/examples/resource-server/src/app.ts
@@ -19,6 +19,7 @@
 //    this function, and listens. The binary refuses to start if no
 //    reader can be built from the env (see README).
 
+import { SESSION_ID_HEADER } from "@bosonprotocol/x402-core";
 import type { EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
 import {
   createX402bServer,
@@ -95,15 +96,16 @@ export function createResourceServerApp(
   // same signed offer the challenge emitted.
   //
   // We scope that "same signed offer" to a single buyer flow via the
-  // `X-X402-Boson-Session-Id` header `@bosonprotocol/x402-client-fetch`
-  // stamps on both requests of a 402-retry pair. A short per-session
-  // TTL bounds memory and lets the cache invalidate naturally between
-  // unrelated commits (without it, a sequential second commit hits the
-  // cached offer and reverts `OfferSoldOut` on a single-quantity
-  // template). Clients that don't honour the header share the
-  // `FALLBACK_KEY` slot and get the previous time-based behaviour, so
-  // the change is backwards-compatible for non-x402b consumers.
-  const SESSION_ID_HEADER = "x-x402-boson-session-id";
+  // `SESSION_ID_HEADER` `@bosonprotocol/x402-client-fetch` stamps on
+  // both requests of a 402-retry pair (Express's `req.header()` is
+  // case-insensitive, so the canonical mixed-case constant works for
+  // the lookup). A short per-session TTL bounds memory and lets the
+  // cache invalidate naturally between unrelated commits (without it,
+  // a sequential second commit hits the cached offer and reverts
+  // `OfferSoldOut` on a single-quantity template). Clients that don't
+  // honour the header share the `FALLBACK_KEY` slot and get the
+  // previous time-based behaviour, so the change is backwards-
+  // compatible for non-x402b consumers.
   const FALLBACK_KEY = "__no_session__";
   const SESSION_CACHE_TTL_MS = 60_000;
   const MAX_SESSION_ID_LENGTH = 128;

--- a/examples/resource-server/src/app.ts
+++ b/examples/resource-server/src/app.ts
@@ -106,26 +106,69 @@ export function createResourceServerApp(
   const SESSION_ID_HEADER = "x-x402-boson-session-id";
   const FALLBACK_KEY = "__no_session__";
   const SESSION_CACHE_TTL_MS = 60_000;
-  const sessionCache = new Map<
-    string,
-    { promise: Promise<EscrowPaymentRequirements>; expiresAt: number }
-  >();
+  const MAX_SESSION_ID_LENGTH = 128;
+  const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+  const MAX_SESSION_CACHE_ENTRIES = 256;
+  type SessionCacheEntry = {
+    promise: Promise<EscrowPaymentRequirements>;
+    expiresAt: number;
+  };
+  const sessionCache = new (class extends Map<string, SessionCacheEntry> {
+    override set(key: string, value: SessionCacheEntry) {
+      const currentTime = now();
+      for (const [cacheKey, entry] of this) {
+        if (currentTime >= entry.expiresAt) {
+          this.delete(cacheKey);
+        }
+      }
+      if (this.has(key)) {
+        this.delete(key);
+      } else {
+        while (this.size >= MAX_SESSION_CACHE_ENTRIES) {
+          const oldestKey = this.keys().next().value;
+          if (typeof oldestKey !== "string") {
+            break;
+          }
+          this.delete(oldestKey);
+        }
+      }
+      return super.set(key, value);
+    }
+  })();
+
+  const pruneExpiredSessions = () => {
+    const currentTime = now();
+    for (const [cacheKey, entry] of sessionCache) {
+      if (currentTime >= entry.expiresAt) {
+        sessionCache.delete(cacheKey);
+      }
+    }
+  };
+
+  const normalizeSessionId = (req: Request) => {
+    // Express lowercases incoming header names. Coerce to string and
+    // trim — empty / whitespace-only / invalid ids fall through to the
+    // shared slot to avoid unbounded attacker-controlled key growth.
+    const rawSessionId = req.header(SESSION_ID_HEADER);
+    const trimmedSessionId = typeof rawSessionId === "string" ? rawSessionId.trim() : "";
+    if (
+      trimmedSessionId.length === 0 ||
+      trimmedSessionId.length > MAX_SESSION_ID_LENGTH ||
+      !SESSION_ID_PATTERN.test(trimmedSessionId)
+    ) {
+      return FALLBACK_KEY;
+    }
+    return trimmedSessionId;
+  };
 
   const resolveRequirements = async (req: Request) => {
-    // Express lowercases incoming header names. Coerce to string and
-    // trim — empty / whitespace-only ids fall through to the shared slot.
-    const rawSessionId = req.header(SESSION_ID_HEADER);
-    const sessionId =
-      typeof rawSessionId === "string" && rawSessionId.trim().length > 0
-        ? rawSessionId.trim()
-        : FALLBACK_KEY;
+    pruneExpiredSessions();
+    const sessionId = normalizeSessionId(req);
 
     const existing = sessionCache.get(sessionId);
-    if (existing !== undefined && now() < existing.expiresAt) {
-      return existing.promise;
-    }
     if (existing !== undefined) {
-      sessionCache.delete(sessionId);
+      sessionCache.set(sessionId, existing);
+      return existing.promise;
     }
 
     const promise = server.buildPaymentRequirements({

--- a/examples/resource-server/src/index.ts
+++ b/examples/resource-server/src/index.ts
@@ -31,6 +31,8 @@ if (isMain) {
 //     );
 //   });
 //
-// `createResourceServerApp` and `readEnv` are re-exported so the fork
-// only needs to add the reader.
+// `createResourceServerApp`, `readEnv`, and `fetchProtocolConfig` are
+// re-exported so the fork only needs to add the reader (and,
+// optionally, the on-chain protocol-config slice).
 export { createResourceServerApp, readEnv };
+export { fetchProtocolConfig, type ProtocolConfig } from "./protocol-config.js";

--- a/examples/resource-server/src/offer.ts
+++ b/examples/resource-server/src/offer.ts
@@ -25,6 +25,17 @@ export interface BuildOfferArgs {
   /** Wall-clock time to anchor offer validity windows. Injectable for tests. */
   now?: number;
   /**
+   * Per-request session id — folded into `metadataUri` / `metadataHash`
+   * so concurrent buyers (each with a distinct session id) never
+   * produce byte-identical `UnsignedFullOffer` structs. Without this
+   * salt, two requests hitting the server within the same millisecond
+   * share `validFromDateInMS` and every other field, the seller signs
+   * the same offer twice, and the second commit reverts `OfferSoldOut`
+   * on the single-quantity template. Defaults to `"no-session"` for
+   * callers that don't track sessions.
+   */
+  sessionId?: string;
+  /**
    * On-chain `ConfigHandlerFacet` slice — when supplied, the builder
    * tightens `feeLimit` and floors `disputePeriodDurationInMS` against
    * the actual on-chain values instead of using the conservative
@@ -87,11 +98,21 @@ export interface BuildOfferArgs {
  *
  * ## Customising for your catalogue
  *
- * The demo uses deliberately short windows (offer 1 h, redemption 1 h,
- * dispute 1 d, resolution 1 w) so e2e runs finish quickly. Real
- * catalogues should widen all four to whatever fits the product. The
- * only hard constraints are the validation rules in
- * `IBosonOfferHandler` and core-sdk's `CreateOfferArgs`:
+ * The defaults below are deliberately wide — offer + redemption open
+ * 1 day in the past and run 30 days into the future. Two reasons:
+ *
+ * 1. **Local-stack chain-time drift tolerance.** Hardhat under
+ *    interval mining advances `block.timestamp` 1 s per block, so at
+ *    a 50 ms interval chain time runs ~20× wall-clock. A 1-hour
+ *    validity window expires in ~3 min of wall-clock; a 30-day
+ *    window survives any realistic suite run.
+ * 2. **Drop-in for varied catalogue lifetimes.** Real catalogues
+ *    pick whatever fits the product; "30 days" is a sane upper
+ *    default that won't surprise demos.
+ *
+ * Forks can narrow these to fit their flow — the only hard
+ * constraints are the validation rules in `IBosonOfferHandler` and
+ * core-sdk's `CreateOfferArgs`:
  *
  * - `validFromDateInMS < validUntilDateInMS`, and `validUntilDateInMS`
  *   must be in the future at submission time.
@@ -103,12 +124,15 @@ export function buildUnsignedOffer({
   env,
   sellerAddress,
   now,
+  sessionId,
   protocolConfig,
 }: BuildOfferArgs): UnsignedFullOffer {
   const t = now ?? Date.now();
+  const salt = sessionId ?? "no-session";
   const oneHour = 60 * 60 * 1000;
   const oneDay = 24 * oneHour;
   const oneWeek = 7 * oneDay;
+  const thirtyDays = 30 * oneDay;
 
   // `disputePeriodDurationInMS`: prefer the demo's 1-week target but
   // floor it against the protocol's `getMinDisputePeriod()` when the
@@ -140,17 +164,17 @@ export function buildUnsignedOffer({
     agentId: "0",
     buyerCancelPenalty: "0",
     quantityAvailable: "1",
-    validFromDateInMS: String(t),
-    validUntilDateInMS: String(t + oneHour),
-    voucherRedeemableFromDateInMS: String(t),
-    voucherRedeemableUntilDateInMS: String(t + oneHour),
+    validFromDateInMS: String(t - oneDay),
+    validUntilDateInMS: String(t + thirtyDays),
+    voucherRedeemableFromDateInMS: String(t - oneDay),
+    voucherRedeemableUntilDateInMS: String(t + thirtyDays),
     disputePeriodDurationInMS: String(disputePeriodDurationInMS),
     voucherValidDurationInMS: "0",
     resolutionPeriodDurationInMS: String(oneWeek),
     exchangeToken: env.assetAddress,
     disputeResolverId: env.disputeResolverId,
-    metadataUri: "ipfs://x402b-example",
-    metadataHash: "x402b-example",
+    metadataUri: `ipfs://x402b-example/${salt}`,
+    metadataHash: `x402b-example-${salt}`,
     collectionIndex: "0",
     feeLimit,
     offerCreator: sellerAddress,

--- a/examples/resource-server/src/offer.ts
+++ b/examples/resource-server/src/offer.ts
@@ -14,6 +14,7 @@ import type { UnsignedFullOffer } from "@bosonprotocol/x402-core/eip712";
 import type { Address } from "viem";
 
 import type { ResourceServerEnv } from "./config.js";
+import type { ProtocolConfig } from "./protocol-config.js";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
 
@@ -23,6 +24,15 @@ export interface BuildOfferArgs {
   sellerAddress: Address;
   /** Wall-clock time to anchor offer validity windows. Injectable for tests. */
   now?: number;
+  /**
+   * On-chain `ConfigHandlerFacet` slice — when supplied, the builder
+   * tightens `feeLimit` and floors `disputePeriodDurationInMS` against
+   * the actual on-chain values instead of using the conservative
+   * defaults. Forks should fetch this via `fetchProtocolConfig` at
+   * boot and pass it in. The unit-test friendly safe defaults stay
+   * in place when omitted.
+   */
+  protocolConfig?: ProtocolConfig;
 }
 
 /**
@@ -89,11 +99,40 @@ export interface BuildOfferArgs {
  *   when the absolute form is used.
  * - `buyerCancelPenalty <= price`.
  */
-export function buildUnsignedOffer({ env, sellerAddress, now }: BuildOfferArgs): UnsignedFullOffer {
+export function buildUnsignedOffer({
+  env,
+  sellerAddress,
+  now,
+  protocolConfig,
+}: BuildOfferArgs): UnsignedFullOffer {
   const t = now ?? Date.now();
   const oneHour = 60 * 60 * 1000;
   const oneDay = 24 * oneHour;
   const oneWeek = 7 * oneDay;
+
+  // `disputePeriodDurationInMS`: prefer the demo's 1-week target but
+  // floor it against the protocol's `getMinDisputePeriod()` when the
+  // caller supplied a `protocolConfig`. Without the on-chain value
+  // we keep 1 week as the safe upper bound; the local
+  // `boson-protocol-node` enforces the minimum via
+  // `InvalidDisputePeriod`, so any value below it would revert.
+  const desiredDisputePeriodMs = oneWeek;
+  const disputePeriodDurationInMS =
+    protocolConfig === undefined
+      ? desiredDisputePeriodMs
+      : Math.max(desiredDisputePeriodMs, protocolConfig.minDisputePeriodMs);
+
+  // `feeLimit` is an absolute uint256 in payment-asset units. The
+  // worst case the protocol can charge is `price * maxFeeBps /
+  // 10000`; setting `feeLimit` to exactly that absorbs the full
+  // on-chain fee without leaving the seller exposed to a future
+  // `getMaxTotalOfferFeePercentage` bump. When the on-chain cap
+  // isn't known, fall back to the previous demo behaviour of
+  // accepting up to the entire price (worst case: zero net revenue).
+  const feeLimit =
+    protocolConfig === undefined
+      ? env.amount
+      : ((BigInt(env.amount) * BigInt(protocolConfig.maxOfferFeeBps)) / 10000n).toString();
 
   return {
     price: env.amount,
@@ -105,14 +144,7 @@ export function buildUnsignedOffer({ env, sellerAddress, now }: BuildOfferArgs):
     validUntilDateInMS: String(t + oneHour),
     voucherRedeemableFromDateInMS: String(t),
     voucherRedeemableUntilDateInMS: String(t + oneHour),
-    // 1 week clears the protocol's `minDisputePeriod` floor on every
-    // shipped Boson deployment seen so far. The local
-    // `boson-protocol-node` enforces it via `InvalidDisputePeriod`;
-    // a previous `oneDay` value tripped that revert. PR 7 (e2e
-    // robustness work) will read the actual floor from
-    // `ConfigHandlerFacet.getMinDisputePeriod()` and pick
-    // `max(envValue, minDisputePeriod)`.
-    disputePeriodDurationInMS: String(oneWeek),
+    disputePeriodDurationInMS: String(disputePeriodDurationInMS),
     voucherValidDurationInMS: "0",
     resolutionPeriodDurationInMS: String(oneWeek),
     exchangeToken: env.assetAddress,
@@ -120,14 +152,7 @@ export function buildUnsignedOffer({ env, sellerAddress, now }: BuildOfferArgs):
     metadataUri: "ipfs://x402b-example",
     metadataHash: "x402b-example",
     collectionIndex: "0",
-    // Max protocol + agent fee the seller will accept on this offer.
-    // `"0"` reverts every commit with `TotalFeeExceedsLimit` because
-    // the protocol fee is non-zero on every shipped Boson deployment
-    // seen so far. Setting the cap to the full price means the
-    // seller absorbs whatever the protocol charges (worst case:
-    // their entire revenue) — fine for the demo. Production sellers
-    // should pin a tighter cap based on their margin model.
-    feeLimit: env.amount,
+    feeLimit,
     offerCreator: sellerAddress,
     committer: ZERO_ADDRESS,
     condition: {

--- a/examples/resource-server/src/protocol-config.ts
+++ b/examples/resource-server/src/protocol-config.ts
@@ -50,6 +50,13 @@ export interface FetchProtocolConfigArgs {
   escrowAddress: Address;
 }
 
+// `getMinDisputePeriod()` returns a `uint256`. Converting straight to
+// `Number` and then multiplying by 1000 would silently lose precision —
+// or overflow — for values past `MAX_SAFE_INTEGER / 1000`. Guard the
+// conversion so misconfigured chains surface a clear error instead of
+// returning a wrong `minDisputePeriodMs`.
+const MAX_DISPUTE_PERIOD_SECONDS = BigInt(Math.floor(Number.MAX_SAFE_INTEGER / 1000));
+
 /**
  * Fetch the two `ConfigHandlerFacet` values the example offer builder
  * needs. Both are `view` calls; one block round-trip total.
@@ -67,7 +74,14 @@ export async function fetchProtocolConfig(args: FetchProtocolConfigArgs): Promis
       functionName: "getMinDisputePeriod",
     }),
   ]);
+  if (minDisputePeriodSeconds > MAX_DISPUTE_PERIOD_SECONDS) {
+    throw new RangeError(
+      `[fetchProtocolConfig] getMinDisputePeriod() returned ${minDisputePeriodSeconds}s, ` +
+        `which exceeds the safe-integer range for ms conversion (max ${MAX_DISPUTE_PERIOD_SECONDS}s)`,
+    );
+  }
   return {
+    // `maxFeeBps` is a `uint16` (max 65535) — `Number(...)` is always safe.
     maxOfferFeeBps: Number(maxFeeBps),
     minDisputePeriodMs: Number(minDisputePeriodSeconds) * 1000,
   };

--- a/examples/resource-server/src/protocol-config.ts
+++ b/examples/resource-server/src/protocol-config.ts
@@ -1,0 +1,74 @@
+// Read the small slice of `ConfigHandlerFacet` state the offer builder
+// needs to set tight, on-chain-grounded values for `feeLimit` and
+// `disputePeriodDurationInMS`. Both functions are pure-view; the
+// numbers don't change between blocks under normal operation, so
+// callers fetch once at boot and thread the result through to
+// `buildUnsignedOffer`.
+//
+// `getMaxTotalOfferFeePercentage()` returns a `uint16` cap in basis
+// points (e.g. `1000` = 10 %). The offer's `feeLimit` is an absolute
+// uint256 in payment-asset units; the worst-case actual fee charged
+// is `floor(price * maxFeeBps / 10000)`, so setting `feeLimit` to
+// exactly that lets the offer accept whatever the protocol will
+// actually charge without leaving the seller exposed to a future
+// fee-cap bump.
+//
+// `getMinDisputePeriod()` returns a `uint256` in **seconds** (the
+// on-chain unit). Convert to ms before comparing against the
+// caller's wall-clock-ms target — `buildUnsignedOffer` always emits
+// `*InMS` fields per the core-sdk wire convention.
+
+import type { Address, PublicClient } from "viem";
+
+const CONFIG_HANDLER_VIEW_ABI = [
+  {
+    type: "function",
+    name: "getMaxTotalOfferFeePercentage",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint16" }],
+  },
+  {
+    type: "function",
+    name: "getMinDisputePeriod",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint256" }],
+  },
+] as const;
+
+export interface ProtocolConfig {
+  /** Protocol-wide cap on the sum of protocol fee + agent fee, in basis points (`10000` = 100 %). */
+  maxOfferFeeBps: number;
+  /** Protocol minimum for `disputePeriodDurationInMS` on a new offer, expressed in milliseconds. */
+  minDisputePeriodMs: number;
+}
+
+export interface FetchProtocolConfigArgs {
+  publicClient: PublicClient;
+  /** `ConfigHandlerFacet` is exposed on the Diamond, so pass the protocol Diamond address. */
+  escrowAddress: Address;
+}
+
+/**
+ * Fetch the two `ConfigHandlerFacet` values the example offer builder
+ * needs. Both are `view` calls; one block round-trip total.
+ */
+export async function fetchProtocolConfig(args: FetchProtocolConfigArgs): Promise<ProtocolConfig> {
+  const [maxFeeBps, minDisputePeriodSeconds] = await Promise.all([
+    args.publicClient.readContract({
+      address: args.escrowAddress,
+      abi: CONFIG_HANDLER_VIEW_ABI,
+      functionName: "getMaxTotalOfferFeePercentage",
+    }),
+    args.publicClient.readContract({
+      address: args.escrowAddress,
+      abi: CONFIG_HANDLER_VIEW_ABI,
+      functionName: "getMinDisputePeriod",
+    }),
+  ]);
+  return {
+    maxOfferFeeBps: Number(maxFeeBps),
+    minDisputePeriodMs: Number(minDisputePeriodSeconds) * 1000,
+  };
+}

--- a/examples/webhook-sink/Dockerfile
+++ b/examples/webhook-sink/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.7-labs
 #
 # Build from the monorepo root so the root pnpm-lock.yaml is in context:
 #   docker build -t x402b-webhook-sink -f examples/webhook-sink/Dockerfile .

--- a/examples/webhook-sink/Dockerfile
+++ b/examples/webhook-sink/Dockerfile
@@ -9,22 +9,32 @@ FROM node:22-alpine AS base
 RUN corepack enable
 WORKDIR /repo
 
+# --- Stage 1: install (cache key = lockfile + workspace manifests) ---
+# Source code is NOT copied here, so this layer only invalidates when
+# pnpm-lock.yaml or a package.json changes. BuildKit's pnpm-store cache
+# mount reuses tarballs across rebuilds even when install does re-run.
 FROM base AS deps
-COPY . .
-RUN pnpm install --frozen-lockfile \
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY --parents typescript/packages/*/package.json examples/*/package.json ./
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile \
     --filter @bosonprotocol/x402-example-webhook-sink...
 
+# --- Stage 2: deploy (invalidated when source changes) ---
 # `pnpm deploy` materializes a self-contained directory with a flat
 # node_modules — required because the workspace install uses a virtual
 # store, and the symlinks under examples/webhook-sink/node_modules point
 # back into /repo/node_modules/.pnpm/... which wouldn't exist in the
 # runtime stage. --legacy keeps the pnpm-9 behavior (includes
 # devDependencies so `tsx` is available at runtime).
+FROM deps AS build
+COPY . .
 RUN pnpm --filter @bosonprotocol/x402-example-webhook-sink deploy --legacy /deploy
 
+# --- Stage 3: runtime ---
 FROM node:22-alpine AS runtime
 WORKDIR /app
-COPY --from=deps /deploy ./
+COPY --from=build /deploy ./
 
 ENV PORT=4000
 EXPOSE 4000

--- a/examples/webhook-sink/Dockerfile
+++ b/examples/webhook-sink/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /repo
 # pnpm-lock.yaml or a package.json changes. BuildKit's pnpm-store cache
 # mount reuses tarballs across rebuilds even when install does re-run.
 FROM base AS deps
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY --parents typescript/packages/*/package.json examples/*/package.json ./
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile \

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       '@bosonprotocol/x402-client':
         specifier: workspace:^
         version: link:../client
+      '@bosonprotocol/x402-core':
+        specifier: workspace:^
+        version: link:../core
     devDependencies:
       '@types/node':
         specifier: ^20.17.10

--- a/typescript/packages/client-fetch/package.json
+++ b/typescript/packages/client-fetch/package.json
@@ -47,7 +47,8 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
-    "@bosonprotocol/x402-client": "workspace:^"
+    "@bosonprotocol/x402-client": "workspace:^",
+    "@bosonprotocol/x402-core": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "^20.17.10",

--- a/typescript/packages/client-fetch/src/index.ts
+++ b/typescript/packages/client-fetch/src/index.ts
@@ -4,5 +4,5 @@
 // installing just this package gets `createX402bClient`, error classes,
 // types, and the fetch wrapper in one import path.
 
-export { wrapFetchWithPayment } from "./wrap.js";
+export { wrapFetchWithPayment, SESSION_ID_HEADER } from "./wrap.js";
 export * from "@bosonprotocol/x402-client";

--- a/typescript/packages/client-fetch/src/wrap.ts
+++ b/typescript/packages/client-fetch/src/wrap.ts
@@ -28,17 +28,15 @@
 // see distinct offers so a single-quantity offer isn't served to two
 // commits in a row.
 
+import { SESSION_ID_HEADER } from "@bosonprotocol/x402-core";
 import type { X402bClient } from "@bosonprotocol/x402-client";
 
-const X_PAYMENT_HEADER = "X-PAYMENT";
+// Re-exported below so existing `@bosonprotocol/x402-client-fetch`
+// importers keep working without having to add a direct dep on
+// `@bosonprotocol/x402-core`.
+export { SESSION_ID_HEADER };
 
-/**
- * Custom header the wrapper stamps on both the initial request and the
- * X-PAYMENT retry, scoping the resource server's offer cache to one
- * buyer flow. Resource servers that don't honour the header fall back
- * to whatever cache strategy they implement.
- */
-export const SESSION_ID_HEADER = "X-X402-Boson-Session-Id";
+const X_PAYMENT_HEADER = "X-PAYMENT";
 
 function newSessionId(): string {
   // `globalThis.crypto.randomUUID()` works in modern browsers and Node 19+

--- a/typescript/packages/client-fetch/src/wrap.ts
+++ b/typescript/packages/client-fetch/src/wrap.ts
@@ -18,10 +18,34 @@
 //     method, body, and every other init field.
 //  6. Return the retry response. A second `402` is NOT re-retried — the
 //     server has spoken twice, surface the error.
+//
+// Each wrapper invocation is tagged with a fresh
+// `X-X402-Boson-Session-Id` header on BOTH the initial request and the
+// retry. The example resource server uses this id to scope its
+// `FullOffer` cache: the 402 challenge and the X-PAYMENT retry share
+// one offer (the validator deep-equals `payload.offerRef.fullOffer`
+// against `requirements.offer.fullOffer`), while distinct buyer flows
+// see distinct offers so a single-quantity offer isn't served to two
+// commits in a row.
 
 import type { X402bClient } from "@bosonprotocol/x402-client";
 
 const X_PAYMENT_HEADER = "X-PAYMENT";
+
+/**
+ * Custom header the wrapper stamps on both the initial request and the
+ * X-PAYMENT retry, scoping the resource server's offer cache to one
+ * buyer flow. Resource servers that don't honour the header fall back
+ * to whatever cache strategy they implement.
+ */
+export const SESSION_ID_HEADER = "X-X402-Boson-Session-Id";
+
+function newSessionId(): string {
+  // `globalThis.crypto.randomUUID()` works in modern browsers and Node 19+
+  // (the engines this repo targets). No `node:crypto` import keeps the
+  // module isomorphic — browser bundlers don't need a node polyfill.
+  return globalThis.crypto.randomUUID();
+}
 
 /**
  * Wrap a `fetch` implementation so 402 responses carrying the Boson
@@ -34,6 +58,12 @@ export function wrapFetchWithPayment(
 ): typeof fetch {
   return async function fetchWithPayment(input, init) {
     const initialRequest = new Request(input, init);
+    // Stamp a fresh session id on this buyer flow's headers so the
+    // resource server's offer cache scopes the 402 challenge and the
+    // X-PAYMENT retry to the same offer. `Headers.set` mutates the
+    // Request's headers in place; the `clone()` below carries the id
+    // onto `retryBase`.
+    initialRequest.headers.set(SESSION_ID_HEADER, newSessionId());
     const retryBase = initialRequest.clone();
 
     const initial = await originalFetch(initialRequest);

--- a/typescript/packages/client/src/token-auth/deadline.ts
+++ b/typescript/packages/client/src/token-auth/deadline.ts
@@ -1,0 +1,24 @@
+// Client-side deadline for token-auth signatures (ERC-3009 `validBefore`,
+// EIP-2612 `deadline`, Permit2 `deadline`).
+//
+// The facilitator validates strictly: `deadline − facilitatorNow ≤
+// requirements.maxTimeoutSeconds`. If the client signs at the boundary
+// (`floor(clientNow) + maxTimeoutSeconds`), any moment where the
+// verifier's wall-clock lags the signer's by ≥ 1 s pushes the gap
+// over `maxTimeoutSeconds` and the facilitator rejects with
+// BAD_TOKEN_AUTH_SIGNATURE. Docker Desktop's container clock drifting
+// behind the host clock makes this happen randomly in the e2e suite.
+//
+// We pull the deadline closer to `clientNow` by a small margin so the
+// facilitator's check tolerates that backward skew. 60 s comfortably
+// covers Docker drift and leaves a useful validity window even at the
+// spec's example `maxTimeoutSeconds = 300`.
+
+export const TOKEN_AUTH_DEADLINE_SAFETY_MARGIN_SECONDS = 60;
+
+export function computeTokenAuthDeadline(
+  maxTimeoutSeconds: number,
+  now: () => number = Date.now,
+): number {
+  return Math.floor(now() / 1000) + maxTimeoutSeconds - TOKEN_AUTH_DEADLINE_SAFETY_MARGIN_SECONDS;
+}

--- a/typescript/packages/client/src/token-auth/deadline.ts
+++ b/typescript/packages/client/src/token-auth/deadline.ts
@@ -20,5 +20,13 @@ export function computeTokenAuthDeadline(
   maxTimeoutSeconds: number,
   now: () => number = Date.now,
 ): number {
-  return Math.floor(now() / 1000) + maxTimeoutSeconds - TOKEN_AUTH_DEADLINE_SAFETY_MARGIN_SECONDS;
+  // Clamp so the margin can never make the deadline retroactive — if
+  // the caller's `maxTimeoutSeconds < 60`, subtracting the full margin
+  // would emit an already-expired signature.
+  const timeoutSeconds = Math.max(1, Math.floor(maxTimeoutSeconds));
+  const safetyMarginSeconds = Math.min(
+    TOKEN_AUTH_DEADLINE_SAFETY_MARGIN_SECONDS,
+    Math.max(0, timeoutSeconds - 1),
+  );
+  return Math.floor(now() / 1000) + timeoutSeconds - safetyMarginSeconds;
 }

--- a/typescript/packages/client/src/token-auth/erc3009.ts
+++ b/typescript/packages/client/src/token-auth/erc3009.ts
@@ -18,6 +18,8 @@ import type { Address, Hex } from "viem";
 import { parseChainId } from "../core-sdk-factory.js";
 import type { TokenDomainResolver } from "../types.js";
 
+import { computeTokenAuthDeadline } from "./deadline.js";
+
 export interface SignErc3009Args {
   requirements: EscrowPaymentRequirements;
   buyer: Address;
@@ -42,7 +44,7 @@ export async function signErc3009({
   const domain = await tokenDomainResolver(requirements.asset as Address, chainId);
 
   const validAfter = 0;
-  const validBefore = Math.floor(now() / 1000) + requirements.maxTimeoutSeconds;
+  const validBefore = computeTokenAuthDeadline(requirements.maxTimeoutSeconds, now);
 
   const result = await coreSdk.signReceiveWithErc3009Authorization(
     requirements.asset,

--- a/typescript/packages/client/src/token-auth/permit.ts
+++ b/typescript/packages/client/src/token-auth/permit.ts
@@ -35,6 +35,8 @@ import { parseChainId } from "../core-sdk-factory.js";
 import { UnsupportedTokenAuthError } from "../errors.js";
 import type { TokenDomainResolver } from "../types.js";
 
+import { computeTokenAuthDeadline } from "./deadline.js";
+
 const NONCES_ABI = [
   {
     type: "function",
@@ -73,7 +75,7 @@ export async function signPermit({
   const domain = await tokenDomainResolver(requirements.asset as Address, chainId);
 
   const noncePreSign = await readNonce(publicClient, requirements.asset as Address, buyer);
-  const deadline = Math.floor(now() / 1000) + requirements.maxTimeoutSeconds;
+  const deadline = computeTokenAuthDeadline(requirements.maxTimeoutSeconds, now);
 
   const result = await coreSdk.signReceiveWithErc2612Permit(
     requirements.asset,

--- a/typescript/packages/client/src/token-auth/permit2.ts
+++ b/typescript/packages/client/src/token-auth/permit2.ts
@@ -23,6 +23,8 @@ import type { Address, Hex } from "viem";
 
 import { randomUint256 } from "../utils/crypto.js";
 
+import { computeTokenAuthDeadline } from "./deadline.js";
+
 export interface SignPermit2Args {
   requirements: EscrowPaymentRequirements;
   buyer: Address;
@@ -42,7 +44,7 @@ export async function signPermit2({
   coreSdk,
   now = Date.now,
 }: SignPermit2Args): Promise<Permit2AuthData> {
-  const deadline = Math.floor(now() / 1000) + requirements.maxTimeoutSeconds;
+  const deadline = computeTokenAuthDeadline(requirements.maxTimeoutSeconds, now);
   const permit2Nonce = randomUint256();
 
   // `buyer` is exposed in the call site for symmetry with the other

--- a/typescript/packages/core/src/eip712/meta-transaction.ts
+++ b/typescript/packages/core/src/eip712/meta-transaction.ts
@@ -133,3 +133,175 @@ export async function recoverMetaTransactionSigner(
     signature,
   } as unknown as Parameters<typeof recoverTypedDataAddress>[0]);
 }
+
+// ===========================================================================
+// Action-specific MetaTx variants.
+//
+// core-sdk's `metaTx.handler.signMetaTx*` methods use different EIP-712
+// primary types for different action families. The recovery side MUST
+// reconstruct the same typed-data structure or `ecrecover` yields a
+// garbage address. The basic `MetaTransaction` type (handled by
+// `metaTransactionTypedData` above) only covers the commit-time actions
+// and `revokeVoucher`; the three builders below cover the rest. Each
+// routes through the corresponding core-sdk `signMetaTx*({…,
+// returnTypedDataToSign: true})` so the typed-data shape stays in
+// lock-step with the deployed protocol — no manual re-derivation of
+// types, domain, or message structure on our side.
+// ===========================================================================
+
+/** Loose typed-data shape — covers the action-specific variants below. */
+export interface ActionMetaTransactionTypedData {
+  domain: Record<string, unknown>;
+  types: Record<string, readonly TypedDataField[]>;
+  primaryType: string;
+  message: Record<string, unknown>;
+}
+
+interface BaseActionArgs {
+  chainId: number;
+  /** Address of the Boson escrow contract — the EIP-712 verifyingContract. */
+  verifyingContract: Address;
+  /** Boson `MetaTransactionsHandlerFacet.usedNonce[from][nonce]` replay-protection slot. */
+  nonce: bigint;
+  /** Buyer / signer EOA — populates the typed-data `message.from`. */
+  from: Address;
+}
+
+/**
+ * Build the EIP-712 typed-data for an EXCHANGE-keyed post-commit meta-tx
+ * (`redeemVoucher`, `cancelVoucher`, `completeExchange`,
+ * `raiseDispute`, `retractDispute`, `escalateDispute`). All six share
+ * the `MetaTxExchange` primary type and `exchangeDetails: {exchangeId}`
+ * sub-struct; the only difference between them is `message.functionName`.
+ */
+export async function metaTransactionExchangeTypedData(
+  args: BaseActionArgs & {
+    /** Boson function signature, e.g. `"redeemVoucher(uint256)"`. */
+    functionName: string;
+    /** Exchange the action targets. */
+    exchangeId: bigint;
+  },
+): Promise<ActionMetaTransactionTypedData> {
+  return callCoreSdkForTypedData(args.from, args.chainId, async (web3Lib) =>
+    metaTx.handler.signMetaTxRedeemVoucher({
+      web3Lib,
+      nonce: args.nonce.toString(),
+      metaTxHandlerAddress: args.verifyingContract,
+      chainId: args.chainId,
+      exchangeId: args.exchangeId.toString(),
+      returnTypedDataToSign: true,
+    }),
+  ).then((td) => withOverriddenFunctionName(td, args.functionName));
+}
+
+/**
+ * Build the EIP-712 typed-data for `resolveDispute` — `MetaTxDisputeResolution`
+ * primary type with a nested `disputeResolutionDetails` struct carrying
+ * the exchange id, the buyer's percent split, and the counterparty's
+ * signature.
+ */
+export async function metaTransactionDisputeResolutionTypedData(
+  args: BaseActionArgs & {
+    exchangeId: bigint;
+    buyerPercentBasisPoints: bigint;
+    /** Counterparty's signature over the resolution proposal — packed `r||s||v` hex. */
+    counterpartySig: Hex;
+  },
+): Promise<ActionMetaTransactionTypedData> {
+  return callCoreSdkForTypedData(args.from, args.chainId, async (web3Lib) =>
+    metaTx.handler.signMetaTxResolveDispute({
+      web3Lib,
+      nonce: args.nonce.toString(),
+      metaTxHandlerAddress: args.verifyingContract,
+      chainId: args.chainId,
+      exchangeId: args.exchangeId.toString(),
+      buyerPercent: args.buyerPercentBasisPoints.toString(),
+      counterpartySig: args.counterpartySig,
+      returnTypedDataToSign: true,
+    }),
+  );
+}
+
+/**
+ * Build the EIP-712 typed-data for `withdrawFunds` — `MetaTxFund` primary
+ * type with a nested `fundDetails` struct carrying the entity id, the
+ * token-address list, and the per-token amounts.
+ */
+export async function metaTransactionFundTypedData(
+  args: BaseActionArgs & {
+    entityId: bigint;
+    tokenList: readonly Address[];
+    tokenAmounts: readonly bigint[];
+  },
+): Promise<ActionMetaTransactionTypedData> {
+  return callCoreSdkForTypedData(args.from, args.chainId, async (web3Lib) =>
+    metaTx.handler.signMetaTxWithdrawFunds({
+      web3Lib,
+      nonce: args.nonce.toString(),
+      metaTxHandlerAddress: args.verifyingContract,
+      chainId: args.chainId,
+      entityId: args.entityId.toString(),
+      tokenList: args.tokenList as string[],
+      tokenAmounts: args.tokenAmounts.map((amount) => amount.toString()),
+      returnTypedDataToSign: true,
+    }),
+  );
+}
+
+/**
+ * Drive a core-sdk `signMetaTx*({…, returnTypedDataToSign: true})` and
+ * strip the convenience fields (`functionName`, `functionSignature`)
+ * the SDK appends — only the EIP-712 typed-data shape is needed for
+ * recovery.
+ *
+ * core-sdk's `returnTypedDataToSign: true` path short-circuits before
+ * `eth_signTypedData_v4` is invoked, so we only need a `Web3LibAdapter`
+ * that can answer `getSignerAddress()` and `getChainId()`. Any other
+ * method invocation indicates core-sdk's internals changed and surfaces
+ * loudly through {@link createTypedDataInterceptAdapter}'s stubs.
+ */
+async function callCoreSdkForTypedData(
+  from: Address,
+  chainId: number,
+  invoke: (web3Lib: Parameters<typeof metaTx.handler.signMetaTx>[0]["web3Lib"]) => Promise<{
+    domain: Record<string, unknown>;
+    types: Record<string, readonly TypedDataField[]>;
+    primaryType: string;
+    message: Record<string, unknown>;
+  }>,
+): Promise<ActionMetaTransactionTypedData> {
+  const intercept = createTypedDataInterceptAdapter<ActionMetaTransactionTypedData>({
+    callerTag: STUB_CALLER_TAG,
+    signerAddress: from,
+    chainId,
+    // `parse` is wired up but never called — `returnTypedDataToSign: true`
+    // short-circuits in core-sdk before `eth_signTypedData_v4` would fire.
+    parse: (json) => JSON.parse(json) as ActionMetaTransactionTypedData,
+  });
+  const result = await invoke(intercept.adapter);
+  return {
+    domain: result.domain,
+    types: result.types,
+    primaryType: result.primaryType,
+    message: result.message,
+  };
+}
+
+/**
+ * Substitute the typed-data's `message.functionName` for the action's
+ * specific value. `metaTransactionExchangeTypedData` routes every
+ * exchange-keyed action through `signMetaTxRedeemVoucher` (the six
+ * methods produce identical types/domain/primaryType, differing only in
+ * the hard-coded `functionName`); this override restores the correct
+ * value so the recovered EIP-712 hash matches whatever the signer
+ * actually signed.
+ */
+function withOverriddenFunctionName(
+  td: ActionMetaTransactionTypedData,
+  functionName: string,
+): ActionMetaTransactionTypedData {
+  return {
+    ...td,
+    message: { ...td.message, functionName },
+  };
+}

--- a/typescript/packages/core/src/headers.ts
+++ b/typescript/packages/core/src/headers.ts
@@ -1,0 +1,18 @@
+// Shared HTTP header names that span the buyer-side fetch wrapper and
+// any resource server / facilitator implementing the x402B escrow
+// scheme. Centralising them here keeps the wire contract single-sourced
+// across packages.
+
+/**
+ * Custom header `@bosonprotocol/x402-client-fetch` stamps on both the
+ * initial request and the X-PAYMENT retry. Resource servers that scope
+ * their `FullOffer` cache per buyer flow key the cache off this id so
+ * the 402 challenge and the X-PAYMENT retry share one signed offer.
+ *
+ * The canonical value uses mixed case for header readability; HTTP
+ * header lookups are case-insensitive on both Node (`req.headers[…]`
+ * are already lowercased) and Express (`req.header(…)`), so importers
+ * can pass the constant verbatim regardless of which lookup style they
+ * use.
+ */
+export const SESSION_ID_HEADER = "X-X402-Boson-Session-Id";

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -1,8 +1,8 @@
 // Public API for @bosonprotocol/x402-core.
 //
-// This package is intentionally empty in the initial skeleton. The escrow
-// scheme types/schemas, EIP-712 builders, and state machine model land in
-// follow-up changes; this stub exists so the workspace, build, and publish
-// pipelines can be exercised end-to-end before any consumer-facing API
-// surface is introduced.
-export {};
+// Shared types, EIP-712 builders, and state machine live under their
+// own subpath exports (`/eip712`, `/schemes/escrow`, `/state-machine`,
+// …); the root entry point exposes only constants that are part of the
+// cross-package wire contract.
+
+export { SESSION_ID_HEADER } from "./headers.js";

--- a/typescript/packages/facilitator/src/perform-action/index.ts
+++ b/typescript/packages/facilitator/src/perform-action/index.ts
@@ -56,7 +56,7 @@ import type {
   FacilitatorPerformActionInput,
   FacilitatorPerformActionResult,
 } from "../types.js";
-import { recoverMetaTxSigner } from "../verify/meta-tx-signature.js";
+import { recoverActionMetaTxSigner } from "../verify/meta-tx-signature.js";
 import { simulateExecuteMetaTransaction } from "../verify/simulate.js";
 import { parseChainId } from "../verify/structural.js";
 import { verifyTokenAuthSignature } from "../verify/token-auth-signature.js";
@@ -203,10 +203,11 @@ export async function performAction(
     // 7. Signature recovery — for performAction we just confirm the sig
     //    is self-consistent (recovered === metaTx.from). The role check
     //    (buyer vs seller vs assistant) is the protocol's job.
-    const recovery = await recoverMetaTxSigner({
+    const recovery = await recoverActionMetaTxSigner({
       chainId: chain.chainId,
       escrowAddress,
       metaTx,
+      action: input.action,
     });
     if (!recovery.ok) return recovery;
     if (recovery.recovered.toLowerCase() !== metaTx.from.toLowerCase()) {

--- a/typescript/packages/facilitator/src/verify/meta-tx-signature.ts
+++ b/typescript/packages/facilitator/src/verify/meta-tx-signature.ts
@@ -240,6 +240,20 @@ const ACTION_ARGS_ABI = parseAbi([
 
 type DecodeFailure = { ok: false; code: "BAD_META_TX_SIGNATURE"; reason: string };
 
+// The exchange-keyed actions whose typed-data carries a single
+// `exchangeId` (`MetaTxExchange` primary type). Used to gate
+// `decodeExchangeIdArg` so a calldata buffer for a different ABI member
+// of `ACTION_ARGS_ABI` (e.g. `withdrawFunds`) can't slip through just
+// because its first argument also happens to be a `uint256`.
+const EXCHANGE_KEYED_FUNCTION_NAMES = new Set<string>([
+  "redeemVoucher",
+  "cancelVoucher",
+  "completeExchange",
+  "raiseDispute",
+  "retractDispute",
+  "escalateDispute",
+]);
+
 function decodeExchangeIdArg(
   functionSignature: string,
 ): { ok: true; value: bigint } | DecodeFailure {
@@ -248,6 +262,13 @@ function decodeExchangeIdArg(
       abi: ACTION_ARGS_ABI,
       data: functionSignature as `0x${string}`,
     });
+    if (!EXCHANGE_KEYED_FUNCTION_NAMES.has(decoded.functionName)) {
+      return {
+        ok: false,
+        code: "BAD_META_TX_SIGNATURE",
+        reason: `expected exchange-keyed action calldata, got "${decoded.functionName}"`,
+      };
+    }
     const exchangeId = decoded.args?.[0];
     if (typeof exchangeId !== "bigint") {
       return {

--- a/typescript/packages/facilitator/src/verify/meta-tx-signature.ts
+++ b/typescript/packages/facilitator/src/verify/meta-tx-signature.ts
@@ -1,15 +1,40 @@
 // Meta-tx signature recovery.
 //
-// The buyer signs the Boson `MetaTransaction` EIP-712 typed-data with
-// the Diamond as the verifying contract. We reconstruct the same
-// typed-data via `metaTransactionTypedData()` from
-// `@bosonprotocol/x402-core/eip712` (which delegates the EIP-712 domain
-// to `@bosonprotocol/core-sdk` so we stay in lock-step with the deployed
-// protocol), then recover the signer with viem.
+// The signer (buyer or seller) signs a Boson EIP-712 typed-data with
+// the Diamond as the verifying contract. core-sdk uses FOUR distinct
+// primary types depending on the action family:
+//
+//   - `MetaTransaction` — commit-time (`createOfferAndCommit`,
+//     `createOfferCommitAndRedeem`), `revokeVoucher`,
+//     `extendDisputeTimeout`, `depositFunds`. Message carries the raw
+//     `functionSignature: bytes`.
+//   - `MetaTxExchange` — exchange-keyed post-commit actions
+//     (`redeemVoucher`, `cancelVoucher`, `completeExchange`,
+//     `raiseDispute`, `retractDispute`, `escalateDispute`). Message
+//     carries `exchangeDetails: {exchangeId}`.
+//   - `MetaTxDisputeResolution` — `resolveDispute`. Message carries
+//     `disputeResolutionDetails: {exchangeId, buyerPercentBasisPoints,
+//     signature}`.
+//   - `MetaTxFund` — `withdrawFunds`. Message carries `fundDetails:
+//     {entityId, tokenList, tokenAmounts}`.
+//
+// We MUST reconstruct the same typed-data the signer used or
+// `ecrecover` yields a garbage address. Each variant routes through
+// the corresponding `@bosonprotocol/x402-core/eip712` builder which
+// delegates to core-sdk's `signMetaTx*({returnTypedDataToSign: true})`
+// — that keeps the reconstructed shape in lock-step with what
+// `MetaTransactionsHandlerFacet` verifies on-chain.
 
-import { metaTransactionTypedData } from "@bosonprotocol/x402-core/eip712";
+import {
+  metaTransactionDisputeResolutionTypedData,
+  metaTransactionExchangeTypedData,
+  metaTransactionFundTypedData,
+  metaTransactionTypedData,
+  type ActionMetaTransactionTypedData,
+} from "@bosonprotocol/x402-core/eip712";
 import type { Address, BosonMetaTx, Hex } from "@bosonprotocol/x402-core/schemes/escrow";
-import { recoverTypedDataAddress } from "viem";
+import type { ActionId } from "@bosonprotocol/x402-core/state-machine";
+import { decodeFunctionData, parseAbi, recoverTypedDataAddress } from "viem";
 
 import type { StepResult } from "./structural.js";
 
@@ -28,12 +53,18 @@ export type RecoverMetaTxSignerResult =
   | { ok: false; code: "BAD_META_TX_SIGNATURE"; reason: string };
 
 /**
- * Recover the meta-tx signer from the EIP-712 typed-data. Does **not**
- * check who the signer should be — that's the caller's job. The on-chain
- * `MetaTransactionsHandlerFacet.executeMetaTransaction` recovers
- * signatures with `LibSignature.recover`, which accepts only the legacy
- * `v ∈ {27, 28}` form — reject `v ∈ {0, 1}` upfront with a clear error
- * rather than letting the simulation fail later.
+ * Recover the meta-tx signer from the `MetaTransaction` (basic) EIP-712
+ * typed-data — used by the commit-time `verify()` path and by
+ * post-commit actions that share that primary type (`revokeVoucher`,
+ * `extendDisputeTimeout`, `depositFunds`). Other post-commit actions
+ * must route through {@link recoverActionMetaTxSigner}, which dispatches
+ * on the action id and rebuilds the matching primary type.
+ *
+ * Does **not** check who the signer should be — that's the caller's job.
+ * The on-chain `MetaTransactionsHandlerFacet.executeMetaTransaction`
+ * recovers signatures with `LibSignature.recover`, which accepts only
+ * the legacy `v ∈ {27, 28}` form — reject `v ∈ {0, 1}` upfront with a
+ * clear error rather than letting the simulation fail later.
  */
 export async function recoverMetaTxSigner(args: {
   chainId: number;
@@ -41,13 +72,8 @@ export async function recoverMetaTxSigner(args: {
   metaTx: BosonMetaTx;
 }): Promise<RecoverMetaTxSignerResult> {
   const { v, r, s } = args.metaTx.sig;
-  if (v !== 27 && v !== 28) {
-    return {
-      ok: false,
-      code: "BAD_META_TX_SIGNATURE",
-      reason: `meta-tx signature v must be 27 or 28, got ${v}`,
-    };
-  }
+  const vCheck = checkV(v);
+  if (vCheck !== null) return vCheck;
   const typedData = await metaTransactionTypedData({
     chainId: args.chainId,
     verifyingContract: args.escrowAddress as `0x${string}`,
@@ -59,7 +85,126 @@ export async function recoverMetaTxSigner(args: {
       functionSignature: args.metaTx.functionSignature as `0x${string}`,
     },
   });
+  return recoverFromTypedData(typedData, packRsv(r as Hex, s as Hex, v));
+}
+
+/**
+ * Action-aware variant of {@link recoverMetaTxSigner}. Dispatches on
+ * `args.action` to reconstruct the EIP-712 typed-data the buyer / seller
+ * actually signed:
+ *
+ *   - Exchange-keyed family (`boson-redeem`, `boson-cancelVoucher`,
+ *     `boson-completeExchange`, `boson-raiseDispute`,
+ *     `boson-retractDispute`, `boson-escalateDispute`) → `MetaTxExchange`
+ *     primary type, message carries `exchangeDetails: {exchangeId}`.
+ *   - `boson-resolveDispute` → `MetaTxDisputeResolution`, message carries
+ *     `disputeResolutionDetails: {exchangeId, buyerPercentBasisPoints,
+ *     signature}`.
+ *   - `boson-withdrawFunds` → `MetaTxFund`, message carries
+ *     `fundDetails: {entityId, tokenList, tokenAmounts}`.
+ *   - Anything else (`boson-revokeVoucher`, commit-time actions) →
+ *     falls through to {@link recoverMetaTxSigner}'s basic
+ *     `MetaTransaction` recovery.
+ *
+ * The action-specific args (`exchangeId`, `buyerPercent`, …) are
+ * decoded from `metaTx.functionSignature` so callers only need to pass
+ * the action id and the raw meta-tx envelope.
+ */
+export async function recoverActionMetaTxSigner(args: {
+  chainId: number;
+  escrowAddress: Address;
+  metaTx: BosonMetaTx;
+  action: ActionId;
+}): Promise<RecoverMetaTxSignerResult> {
+  const { v, r, s } = args.metaTx.sig;
+  const vCheck = checkV(v);
+  if (vCheck !== null) return vCheck;
+
+  const escrow = args.escrowAddress as `0x${string}`;
+  const baseArgs = {
+    chainId: args.chainId,
+    verifyingContract: escrow,
+    nonce: BigInt(args.metaTx.nonce),
+    from: args.metaTx.from as `0x${string}`,
+  };
   const signature = packRsv(r as Hex, s as Hex, v);
+
+  try {
+    let typedData: ActionMetaTransactionTypedData;
+    switch (args.action) {
+      case "boson-redeem":
+      case "boson-cancelVoucher":
+      case "boson-completeExchange":
+      case "boson-raiseDispute":
+      case "boson-retractDispute":
+      case "boson-escalateDispute": {
+        const exchangeId = decodeExchangeIdArg(args.metaTx.functionSignature);
+        if (!exchangeId.ok) return exchangeId;
+        typedData = await metaTransactionExchangeTypedData({
+          ...baseArgs,
+          functionName: args.metaTx.functionName,
+          exchangeId: exchangeId.value,
+        });
+        break;
+      }
+      case "boson-resolveDispute": {
+        const decoded = decodeResolveDisputeArgs(args.metaTx.functionSignature);
+        if (!decoded.ok) return decoded;
+        typedData = await metaTransactionDisputeResolutionTypedData({
+          ...baseArgs,
+          exchangeId: decoded.exchangeId,
+          buyerPercentBasisPoints: decoded.buyerPercentBasisPoints,
+          counterpartySig: decoded.counterpartySig as `0x${string}`,
+        });
+        break;
+      }
+      case "boson-withdrawFunds": {
+        const decoded = decodeWithdrawFundsArgs(args.metaTx.functionSignature);
+        if (!decoded.ok) return decoded;
+        typedData = await metaTransactionFundTypedData({
+          ...baseArgs,
+          entityId: decoded.entityId,
+          tokenList: decoded.tokenList as readonly `0x${string}`[],
+          tokenAmounts: decoded.tokenAmounts,
+        });
+        break;
+      }
+      default:
+        // `boson-revokeVoucher`, `boson-createOfferAndCommit`,
+        // `boson-createOfferCommitAndRedeem`, and any future action that
+        // uses the basic `MetaTransaction` primary type fall through to
+        // the existing recovery path.
+        return recoverMetaTxSigner({
+          chainId: args.chainId,
+          escrowAddress: args.escrowAddress,
+          metaTx: args.metaTx,
+        });
+    }
+    return recoverFromTypedData(typedData, signature);
+  } catch (e) {
+    return {
+      ok: false,
+      code: "BAD_META_TX_SIGNATURE",
+      reason: e instanceof Error ? `recovery failed: ${e.message}` : "recovery failed",
+    };
+  }
+}
+
+function checkV(v: number): RecoverMetaTxSignerResult | null {
+  if (v !== 27 && v !== 28) {
+    return {
+      ok: false,
+      code: "BAD_META_TX_SIGNATURE",
+      reason: `meta-tx signature v must be 27 or 28, got ${v}`,
+    };
+  }
+  return null;
+}
+
+async function recoverFromTypedData(
+  typedData: ActionMetaTransactionTypedData,
+  signature: Hex,
+): Promise<RecoverMetaTxSignerResult> {
   try {
     const recovered = await recoverTypedDataAddress({
       domain: typedData.domain,
@@ -67,13 +212,145 @@ export async function recoverMetaTxSigner(args: {
       primaryType: typedData.primaryType,
       message: typedData.message,
       signature: signature as `0x${string}`,
-    });
+    } as Parameters<typeof recoverTypedDataAddress>[0]);
     return { ok: true, recovered };
   } catch (e) {
     return {
       ok: false,
       code: "BAD_META_TX_SIGNATURE",
       reason: e instanceof Error ? `recovery failed: ${e.message}` : "recovery failed",
+    };
+  }
+}
+
+// ABI used to decode the action-specific arguments out of
+// `metaTx.functionSignature`. Only the actions that need their args fed
+// into a typed-data builder are listed; commit-time and revoke skip
+// straight to the basic-MetaTransaction path.
+const ACTION_ARGS_ABI = parseAbi([
+  "function redeemVoucher(uint256 exchangeId)",
+  "function cancelVoucher(uint256 exchangeId)",
+  "function completeExchange(uint256 exchangeId)",
+  "function raiseDispute(uint256 exchangeId)",
+  "function retractDispute(uint256 exchangeId)",
+  "function escalateDispute(uint256 exchangeId)",
+  "function resolveDispute(uint256 exchangeId, uint256 buyerPercent, bytes counterpartySig)",
+  "function withdrawFunds(uint256 entityId, address[] tokenList, uint256[] tokenAmounts)",
+]);
+
+type DecodeFailure = { ok: false; code: "BAD_META_TX_SIGNATURE"; reason: string };
+
+function decodeExchangeIdArg(
+  functionSignature: string,
+): { ok: true; value: bigint } | DecodeFailure {
+  try {
+    const decoded = decodeFunctionData({
+      abi: ACTION_ARGS_ABI,
+      data: functionSignature as `0x${string}`,
+    });
+    const exchangeId = decoded.args?.[0];
+    if (typeof exchangeId !== "bigint") {
+      return {
+        ok: false,
+        code: "BAD_META_TX_SIGNATURE",
+        reason: "metaTx.functionSignature does not encode exchangeId as the first uint256 argument",
+      };
+    }
+    return { ok: true, value: exchangeId };
+  } catch (e) {
+    return {
+      ok: false,
+      code: "BAD_META_TX_SIGNATURE",
+      reason:
+        e instanceof Error
+          ? `metaTx.functionSignature decode failed: ${e.message}`
+          : "metaTx.functionSignature decode failed",
+    };
+  }
+}
+
+function decodeResolveDisputeArgs(functionSignature: string):
+  | {
+      ok: true;
+      exchangeId: bigint;
+      buyerPercentBasisPoints: bigint;
+      counterpartySig: Hex;
+    }
+  | DecodeFailure {
+  try {
+    const decoded = decodeFunctionData({
+      abi: ACTION_ARGS_ABI,
+      data: functionSignature as `0x${string}`,
+    });
+    if (decoded.functionName !== "resolveDispute") {
+      return {
+        ok: false,
+        code: "BAD_META_TX_SIGNATURE",
+        reason: `expected resolveDispute calldata, got "${decoded.functionName}"`,
+      };
+    }
+    const [exchangeId, buyerPercent, counterpartySig] = decoded.args as readonly [
+      bigint,
+      bigint,
+      `0x${string}`,
+    ];
+    return {
+      ok: true,
+      exchangeId,
+      buyerPercentBasisPoints: buyerPercent,
+      counterpartySig: counterpartySig as Hex,
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      code: "BAD_META_TX_SIGNATURE",
+      reason:
+        e instanceof Error
+          ? `metaTx.functionSignature decode failed: ${e.message}`
+          : "metaTx.functionSignature decode failed",
+    };
+  }
+}
+
+function decodeWithdrawFundsArgs(functionSignature: string):
+  | {
+      ok: true;
+      entityId: bigint;
+      tokenList: readonly Address[];
+      tokenAmounts: readonly bigint[];
+    }
+  | DecodeFailure {
+  try {
+    const decoded = decodeFunctionData({
+      abi: ACTION_ARGS_ABI,
+      data: functionSignature as `0x${string}`,
+    });
+    if (decoded.functionName !== "withdrawFunds") {
+      return {
+        ok: false,
+        code: "BAD_META_TX_SIGNATURE",
+        reason: `expected withdrawFunds calldata, got "${decoded.functionName}"`,
+      };
+    }
+    const [entityId, tokenList, tokenAmounts] = decoded.args as readonly [
+      bigint,
+      readonly `0x${string}`[],
+      readonly bigint[],
+    ];
+    return {
+      ok: true,
+      entityId,
+      tokenList: tokenList as readonly Address[],
+      tokenAmounts,
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      code: "BAD_META_TX_SIGNATURE",
+      reason:
+        e instanceof Error
+          ? `metaTx.functionSignature decode failed: ${e.message}`
+          : "metaTx.functionSignature decode failed",
     };
   }
 }

--- a/typescript/packages/facilitator/test/perform-action.test.ts
+++ b/typescript/packages/facilitator/test/perform-action.test.ts
@@ -1,10 +1,16 @@
-import { metaTransactionTypedData } from "@bosonprotocol/x402-core/eip712";
+import {
+  metaTransactionDisputeResolutionTypedData,
+  metaTransactionExchangeTypedData,
+  metaTransactionFundTypedData,
+  metaTransactionTypedData,
+} from "@bosonprotocol/x402-core/eip712";
 import { permit2TypedData } from "@bosonprotocol/x402-core/eip712/token-auth";
 import { ACTION_POST_STATE, type ActionId } from "@bosonprotocol/x402-core/state-machine";
 import { describe, expect, it } from "vitest";
 import {
   BaseError,
   RawContractError,
+  decodeFunctionData,
   encodeFunctionData,
   parseAbi,
   parseSignature,
@@ -147,7 +153,17 @@ function buildPostCommitCalldata(functionName: string, exchangeId = EXCHANGE_ID)
   }
 }
 
-/** Sign a BosonMetaTx for the given action against the Diamond domain. */
+/**
+ * Sign a BosonMetaTx for the given action against the Diamond domain.
+ *
+ * core-sdk uses four different EIP-712 primary types depending on the
+ * action family — `MetaTransaction` (commit-time + revokeVoucher),
+ * `MetaTxExchange` (redeem / cancel / complete / raise / retract /
+ * escalate), `MetaTxDisputeResolution` (resolveDispute), and
+ * `MetaTxFund` (withdrawFunds). The fixture mirrors that dispatch so
+ * the tests exercise the facilitator's `recoverActionMetaTxSigner`
+ * against the same typed-data shape a real client would produce.
+ */
 async function buildSignedPayload(
   opts: {
     signer?: ReturnType<typeof privateKeyToAccount>;
@@ -162,16 +178,11 @@ async function buildSignedPayload(
   const functionSignature: Hex =
     opts.functionSignature ?? buildPostCommitCalldata(functionName, opts.exchangeId);
   const nonce = opts.nonce ?? "7";
-  const typedData = await metaTransactionTypedData({
-    chainId: CHAIN_ID,
-    verifyingContract: ESCROW,
-    message: {
-      nonce: BigInt(nonce),
-      from: signer.address,
-      contractAddress: ESCROW,
-      functionName,
-      functionSignature,
-    },
+  const typedData = await buildActionTypedData({
+    functionName,
+    functionSignature,
+    nonce,
+    from: signer.address,
   });
   const sig = await signer.signTypedData({
     domain: typedData.domain,
@@ -188,6 +199,98 @@ async function buildSignedPayload(
     functionSignature,
     sig: { v, r: parsed.r, s: parsed.s },
   });
+}
+
+/**
+ * Dispatch the action's `functionName` to the matching typed-data
+ * builder. Mirrors `recoverActionMetaTxSigner`'s dispatch so signing
+ * and recovery hash the same EIP-712 structure.
+ */
+async function buildActionTypedData(args: {
+  functionName: string;
+  functionSignature: Hex;
+  nonce: string;
+  from: Address;
+}): Promise<{
+  domain: Record<string, unknown>;
+  types: Record<string, readonly { name: string; type: string }[]>;
+  primaryType: string;
+  message: Record<string, unknown>;
+}> {
+  const base = {
+    chainId: CHAIN_ID,
+    verifyingContract: ESCROW,
+    nonce: BigInt(args.nonce),
+    from: args.from,
+  };
+
+  switch (args.functionName) {
+    case "redeemVoucher(uint256)":
+    case "cancelVoucher(uint256)":
+    case "completeExchange(uint256)":
+    case "raiseDispute(uint256)":
+    case "retractDispute(uint256)":
+    case "escalateDispute(uint256)": {
+      const decoded = decodeFunctionData({
+        abi: POST_COMMIT_ABI,
+        data: args.functionSignature,
+      });
+      const exchangeId = decoded.args[0] as bigint;
+      return metaTransactionExchangeTypedData({
+        ...base,
+        functionName: args.functionName,
+        exchangeId,
+      });
+    }
+    case "resolveDispute(uint256,uint256,bytes)": {
+      const decoded = decodeFunctionData({
+        abi: POST_COMMIT_ABI,
+        data: args.functionSignature,
+      });
+      const [exchangeId, buyerPercent, counterpartySig] = decoded.args as readonly [
+        bigint,
+        bigint,
+        `0x${string}`,
+      ];
+      return metaTransactionDisputeResolutionTypedData({
+        ...base,
+        exchangeId,
+        buyerPercentBasisPoints: buyerPercent,
+        counterpartySig,
+      });
+    }
+    case "withdrawFunds(uint256,address[],uint256[])": {
+      const decoded = decodeFunctionData({
+        abi: POST_COMMIT_ABI,
+        data: args.functionSignature,
+      });
+      const [entityId, tokenList, tokenAmounts] = decoded.args as readonly [
+        bigint,
+        readonly `0x${string}`[],
+        readonly bigint[],
+      ];
+      return metaTransactionFundTypedData({
+        ...base,
+        entityId,
+        tokenList,
+        tokenAmounts,
+      });
+    }
+    default:
+      // `revokeVoucher(uint256)` and any future action that uses the
+      // basic `MetaTransaction` primary type.
+      return metaTransactionTypedData({
+        chainId: CHAIN_ID,
+        verifyingContract: ESCROW,
+        message: {
+          nonce: BigInt(args.nonce),
+          from: args.from,
+          contractAddress: ESCROW,
+          functionName: args.functionName,
+          functionSignature: args.functionSignature,
+        },
+      });
+  }
 }
 
 function buildPublicClient(

--- a/typescript/packages/server-express/src/middleware.ts
+++ b/typescript/packages/server-express/src/middleware.ts
@@ -10,6 +10,7 @@
 
 import type { EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
 import {
+  decodeXPaymentHeader,
   encodeXPaymentResponse,
   X_PAYMENT_RESPONSE_HEADER,
   type CommitOk,
@@ -35,10 +36,15 @@ export interface ExpressMiddlewareOptions {
     mode: "challenge" | "settle",
   ) => Promise<EscrowPaymentRequirements> | EscrowPaymentRequirements;
   /**
-   * Optional flow selector — defaults to `commit` (Flow A, deferred
-   * redeem). Flow B (`commit-and-redeem`) is opt-in and routes the
-   * commit through the atomic `createOfferCommitAndRedeem` entry
-   * point so the buyer redeems in the same transaction.
+   * Optional flow restriction. When omitted the middleware peeks at
+   * the buyer's `X-PAYMENT` action and dispatches to the matching
+   * handler — Flow A (`boson-createOfferAndCommit` → `commit`) or
+   * Flow B (`boson-createOfferCommitAndRedeem` → `commitAndRedeem`).
+   * That mirrors the 402 contract, which advertises BOTH commit-time
+   * actions; the buyer picks one based on policy. Set this option
+   * only when the resource server wants to enforce a single flow —
+   * payloads carrying the other action then fail at the handler with
+   * `ACTION_ROUTE_MISMATCH`.
    */
   flow?: "commit" | "commit-and-redeem";
 }
@@ -70,7 +76,6 @@ export function expressMiddleware(
   server: X402bServer,
   opts: ExpressMiddlewareOptions,
 ): RequestHandler {
-  const flow = opts.flow ?? "commit";
   return async (req: Request, res: Response, next: NextFunction) => {
     const header = req.header("x-payment");
     if (header === undefined || header.length === 0) {
@@ -85,6 +90,13 @@ export function expressMiddleware(
 
     try {
       const requirements = await opts.resolveRequirements(req, "settle");
+      // When `opts.flow` is set, honour it strictly — payloads
+      // carrying the other action will surface `ACTION_ROUTE_MISMATCH`
+      // at the handler. When it's omitted, peek at the buyer's chosen
+      // action and dispatch accordingly; a malformed header falls
+      // through to the commit handler so the buyer sees a structured
+      // decode error rather than a silent flow swap.
+      const flow = opts.flow ?? detectFlowFromHeader(header);
       const handler = flow === "commit" ? server.handlers.commit : server.handlers.commitAndRedeem;
       const result = await handler({ paymentHeader: header, requirements });
       if (!result.ok) {
@@ -101,4 +113,18 @@ export function expressMiddleware(
       next(e);
     }
   };
+}
+
+/**
+ * Peek at the action in an `X-PAYMENT` header to decide which commit
+ * handler to dispatch to. A malformed header (bad base64, bad JSON,
+ * schema violation) returns `"commit"` so the commit handler's own
+ * structured error surfaces to the buyer instead of a silent swap.
+ */
+function detectFlowFromHeader(header: string): "commit" | "commit-and-redeem" {
+  const decoded = decodeXPaymentHeader(header);
+  if (!decoded.ok) return "commit";
+  return decoded.payload.payload.action === "boson-createOfferCommitAndRedeem"
+    ? "commit-and-redeem"
+    : "commit";
 }

--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -104,7 +104,13 @@ The `up` flow runs in two phases:
 | `typescript/packages/x402-e2e/src/bin/**` or `examples/resource-server/src/**` or `typescript/packages/{server-express,server,core,evm,actions,fulfillment}/src/**` | `x402b-resource-server` |
 | `examples/webhook-sink/src/**` | `x402b-webhook-sink` |
 | Only `typescript/packages/x402-e2e/test/**` (scenario / harness tests) | nothing — tests run out-of-container |
-| Only docs, CI, or `.dockerignore` | nothing |
+| Only docs or CI | nothing |
+| `.dockerignore` | `--build` all three (`x402b-facilitator-http`, `x402b-resource-server`, `x402b-webhook-sink`) |
+
+`.dockerignore` shapes the build context itself, so changes to it commonly
+require a rebuild when Dockerfiles use `COPY . .` (as ours do) — files newly
+included or excluded by the ignore rules will only appear in / disappear from
+the image after `--build`.
 
 The Dockerfiles are layered so that **passing `--build` when nothing actually
 changed is near-free**: BuildKit reuses every cached layer up to the first

--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -114,11 +114,12 @@ Without `E2E_DOCKER=1`, the suite skips itself so the repo-wide
   seller, buyer, resolver) live in the `ROLE_ACCOUNTS` map; distinct
   account per role so concurrent meta-tx submissions never share a
   nonce.
-- **Per-describe seed wallets** — Vitest runs test FILES in parallel.
-  Each chain-touching describe block picks one slot from
+- **Per-test-file seed wallets** — Vitest runs test FILES in parallel.
+  Each chain-touching test file picks one slot from
   [`test/scenarios/_seed-wallets.ts`](./test/scenarios/_seed-wallets.ts)
-  and uses it to fund a freshly-generated random buyer EOA (via
-  `createFundedBuyer`). Two describes that run in parallel must never
+  and uses it to fund freshly-generated random buyer EOAs (via
+  `createFundedBuyer`). Multiple describes in the same file may share
+  that file's slot, but two files that run in parallel must never
   share a slot — a shared EOA races the chain nonce and cascades into
   `NonceTooLow` / `BAD_META_TX_SIGNATURE` / `OfferSoldOut` failures.
   Mirrors the `seedWalletN` pattern from

--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -85,6 +85,36 @@ The `up` flow runs in two phases:
    Matches `bosonprotocol/core-components:e2e/prepare-e2e-services.sh`.
    Pass `--no-wait` if you only need IPFS + RPC.
 
+### When to rebuild
+
+`stack:up` accepts two refresh flags that target different layers:
+
+- `--pull` — refreshes the **upstream** Boson images (`boson-protocol-node`,
+  `boson-subgraph`, `boson-mcp-server`, `postgres`, `ipfs`, `meta-tx-gateway`).
+  Use it after a new tag lands on `main` upstream, or periodically.
+- `--build` — rebuilds the **local** x402B images
+  (`x402b-facilitator-http`, `x402b-resource-server`, `x402b-webhook-sink`)
+  from their Dockerfiles in this repo.
+
+`--build` is needed when any source the image bundles has changed:
+
+| Changed files | Service to rebuild |
+|---|---|
+| `examples/facilitator-http/src/**` or `typescript/packages/{facilitator-express,facilitator,core,evm,actions,fulfillment}/src/**` | `x402b-facilitator-http` |
+| `typescript/packages/x402-e2e/src/bin/**` or `examples/resource-server/src/**` or `typescript/packages/{server-express,server,core,evm,actions,fulfillment}/src/**` | `x402b-resource-server` |
+| `examples/webhook-sink/src/**` | `x402b-webhook-sink` |
+| Only `typescript/packages/x402-e2e/test/**` (scenario / harness tests) | nothing — tests run out-of-container |
+| Only docs, CI, or `.dockerignore` | nothing |
+
+The Dockerfiles are layered so that **passing `--build` when nothing actually
+changed is near-free**: BuildKit reuses every cached layer up to the first
+invalidated one. If you're unsure whether you need it, just pass it — that's
+the recommended default for inner-loop work.
+
+`pnpm-lock.yaml` changes invalidate the install layer (~30–45s of rebuild),
+but the pnpm content-addressable store is cached via BuildKit cache mounts,
+so no network downloads happen on a warm cache.
+
 ```sh
 pnpm --filter @bosonprotocol/x402-e2e stack:down [--keep-volumes] [--rmi]
 ```

--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -108,12 +108,25 @@ Without `E2E_DOCKER=1`, the suite skips itself so the repo-wide
 ## Conventions
 
 - **Test accounts** — `src/config/accounts.ts` carries the verbatim
-  `ACCOUNT_1`…`ACCOUNT_9` keys from
+  `ACCOUNT_1`…`ACCOUNT_15` keys from
   [`bosonprotocol/core-components:contracts/accounts.js`](https://github.com/bosonprotocol/core-components/blob/main/contracts/accounts.js).
   Test keys only. Role assignments (gateway, facilitator relayer,
   seller, buyer, resolver) live in the `ROLE_ACCOUNTS` map; distinct
   account per role so concurrent meta-tx submissions never share a
   nonce.
+- **Per-describe seed wallets** — Vitest runs test FILES in parallel.
+  Each chain-touching describe block picks one slot from
+  [`test/scenarios/_seed-wallets.ts`](./test/scenarios/_seed-wallets.ts)
+  and uses it to fund a freshly-generated random buyer EOA (via
+  `createFundedBuyer`). Two describes that run in parallel must never
+  share a slot — a shared EOA races the chain nonce and cascades into
+  `NonceTooLow` / `BAD_META_TX_SIGNATURE` / `OfferSoldOut` failures.
+  Mirrors the `seedWalletN` pattern from
+  [`bosonprotocol/core-components/e2e/tests/utils.ts`](https://github.com/bosonprotocol/core-components/blob/main/e2e/tests/utils.ts).
+- **Sequential fallback** — set `E2E_SEQUENTIAL=1` to disable
+  cross-file parallelism when debugging chain-state interactions. The
+  default suite is designed to be parallel-safe via the seed-wallet
+  pool above; the knob is purely an escape hatch.
 - **Addresses + URLs** — `src/config/local-31337-0.ts` is a typed copy
   of the `local-31337-0` entry from `@bosonprotocol/core-sdk`'s
   `defaultConfig`. Source-of-truth comment cites the upstream file so

--- a/typescript/packages/x402-e2e/src/bin/resource-server.Dockerfile
+++ b/typescript/packages/x402-e2e/src/bin/resource-server.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.7-labs
 #
 # Build from the monorepo root so the root pnpm-lock.yaml is in context:
 #   docker build -t x402b-e2e-resource-server -f typescript/packages/x402-e2e/src/bin/resource-server.Dockerfile .

--- a/typescript/packages/x402-e2e/src/bin/resource-server.Dockerfile
+++ b/typescript/packages/x402-e2e/src/bin/resource-server.Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /repo
 # pnpm-lock.yaml or a package.json changes. BuildKit's pnpm-store cache
 # mount reuses tarballs across rebuilds even when install does re-run.
 FROM base AS deps
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY --parents typescript/packages/*/package.json examples/*/package.json ./
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile \

--- a/typescript/packages/x402-e2e/src/bin/resource-server.Dockerfile
+++ b/typescript/packages/x402-e2e/src/bin/resource-server.Dockerfile
@@ -11,22 +11,32 @@ FROM node:22-alpine AS base
 RUN corepack enable
 WORKDIR /repo
 
+# --- Stage 1: install (cache key = lockfile + workspace manifests) ---
+# Source code is NOT copied here, so this layer only invalidates when
+# pnpm-lock.yaml or a package.json changes. BuildKit's pnpm-store cache
+# mount reuses tarballs across rebuilds even when install does re-run.
 FROM base AS deps
-COPY . .
-RUN pnpm install --frozen-lockfile \
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY --parents typescript/packages/*/package.json examples/*/package.json ./
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile \
     --filter @bosonprotocol/x402-e2e...
 
+# --- Stage 2: build + deploy (invalidated when source changes) ---
 # Build the workspace deps the bin entrypoint imports (tsup emits dist/
 # + the exports map points at it). The trailing `...` includes the
 # transitive workspace chain (x402-core, x402-evm, x402-actions,
 # x402-fulfillment, x402-server, x402-server-express, x402-example-resource-server).
-RUN pnpm --filter @bosonprotocol/x402-example-resource-server... build
-
+FROM deps AS build
+COPY . .
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm --filter @bosonprotocol/x402-example-resource-server... build
 RUN pnpm --filter @bosonprotocol/x402-e2e deploy --legacy /deploy
 
+# --- Stage 3: runtime ---
 FROM node:22-alpine AS runtime
 WORKDIR /app
-COPY --from=deps /deploy ./
+COPY --from=build /deploy ./
 
 ENV PORT=4001
 EXPOSE 4001

--- a/typescript/packages/x402-e2e/src/bin/resource-server.ts
+++ b/typescript/packages/x402-e2e/src/bin/resource-server.ts
@@ -11,6 +11,8 @@
 // canonical compose already wires to the in-container subgraph
 // endpoint (`http://host.docker.internal:8000/subgraphs/name/boson/corecomponents`).
 
+import type { Address, PublicClient } from "viem";
+
 import {
   createResourceServerApp,
   fetchProtocolConfig,
@@ -19,6 +21,48 @@ import {
 
 import { buildPublicClient } from "../harness/clients.js";
 import { createSubgraphExchangeReader } from "../harness/exchange-reader.js";
+
+// `docker compose up --wait` only blocks until each container reports
+// healthy; the contracts inside `boson-protocol-node` are still
+// deploying asynchronously when this entrypoint starts. Poll
+// `eth_getCode` until the Diamond is on chain before calling
+// `fetchProtocolConfig`, otherwise the first `readContract` returns
+// `0x` and the boot crashes (matches the docker-exec-based readiness
+// probe in `src/stack/readiness.ts`, but RPC-based because we run from
+// inside the network).
+const ESCROW_DEPLOY_TIMEOUT_MS = 10 * 60_000;
+const ESCROW_DEPLOY_POLL_INTERVAL_MS = 2_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForEscrowDeployed(args: {
+  publicClient: PublicClient;
+  escrowAddress: Address;
+}): Promise<void> {
+  const deadline = Date.now() + ESCROW_DEPLOY_TIMEOUT_MS;
+  console.log(
+    `[x402-e2e/resource-server] waiting for escrow ${args.escrowAddress} to be deployed…`,
+  );
+  while (true) {
+    try {
+      const code = await args.publicClient.getCode({ address: args.escrowAddress });
+      if (code !== undefined && code !== "0x") {
+        console.log(`[x402-e2e/resource-server] escrow ${args.escrowAddress} is deployed`);
+        return;
+      }
+    } catch {
+      // RPC not ready (boson-protocol-node still booting) — keep polling.
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `[x402-e2e/resource-server] timed out after ${ESCROW_DEPLOY_TIMEOUT_MS / 1000}s waiting for escrow ${args.escrowAddress} to be deployed`,
+      );
+    }
+    await sleep(ESCROW_DEPLOY_POLL_INTERVAL_MS);
+  }
+}
 
 async function main(): Promise<void> {
   const env = readEnv();
@@ -34,6 +78,8 @@ async function main(): Promise<void> {
   // harness's viem builder so the chain id / RPC URL stay consistent
   // with the rest of the suite.
   const publicClient = buildPublicClient({ rpcUrl: env.rpcNode });
+
+  await waitForEscrowDeployed({ publicClient, escrowAddress: env.escrowAddress });
 
   const exchangeReader = createSubgraphExchangeReader({
     subgraphUrl: env.subgraphUrl,

--- a/typescript/packages/x402-e2e/src/bin/resource-server.ts
+++ b/typescript/packages/x402-e2e/src/bin/resource-server.ts
@@ -17,6 +17,7 @@ import {
   createResourceServerApp,
   fetchProtocolConfig,
   readEnv,
+  type ProtocolConfig,
 } from "@bosonprotocol/x402-example-resource-server";
 
 import { buildPublicClient } from "../harness/clients.js";
@@ -24,12 +25,21 @@ import { createSubgraphExchangeReader } from "../harness/exchange-reader.js";
 
 // `docker compose up --wait` only blocks until each container reports
 // healthy; the contracts inside `boson-protocol-node` are still
-// deploying asynchronously when this entrypoint starts. Poll
-// `eth_getCode` until the Diamond is on chain before calling
-// `fetchProtocolConfig`, otherwise the first `readContract` returns
-// `0x` and the boot crashes (matches the docker-exec-based readiness
-// probe in `src/stack/readiness.ts`, but RPC-based because we run from
-// inside the network).
+// deploying asynchronously when this entrypoint starts. The deploy
+// script proceeds in stages — Diamond bytecode appears first, then
+// each facet is cut into the Diamond, and finally `ConfigHandlerFacet`
+// is initialized — so we gate boot in two stages:
+//
+//   1. Poll `eth_getCode` until the Diamond is on chain (otherwise the
+//      first `readContract` returns `0x` and crashes).
+//   2. Poll `fetchProtocolConfig` until the call succeeds AND returns
+//      non-zero values — facet-cut races surface as `readContract`
+//      reverts ("Diamond: Function does not exist"), and an
+//      uninitialized `ConfigHandlerFacet` returns `0` for both fields.
+//
+// Mirrors the docker-exec-based `/app/deploy.done` probe in
+// `src/stack/readiness.ts` over RPC, since the compose-service
+// entrypoint can't `docker compose exec` against the protocol node.
 const ESCROW_DEPLOY_TIMEOUT_MS = 10 * 60_000;
 const ESCROW_DEPLOY_POLL_INTERVAL_MS = 2_000;
 
@@ -64,6 +74,38 @@ async function waitForEscrowDeployed(args: {
   }
 }
 
+async function waitForProtocolConfigInitialized(args: {
+  publicClient: PublicClient;
+  escrowAddress: Address;
+}): Promise<ProtocolConfig> {
+  const deadline = Date.now() + ESCROW_DEPLOY_TIMEOUT_MS;
+  console.log(
+    `[x402-e2e/resource-server] waiting for ConfigHandlerFacet at ${args.escrowAddress} to be initialized…`,
+  );
+  while (true) {
+    try {
+      const config = await fetchProtocolConfig({
+        publicClient: args.publicClient,
+        escrowAddress: args.escrowAddress,
+      });
+      if (config.maxOfferFeeBps > 0 && config.minDisputePeriodMs > 0) {
+        console.log(
+          `[x402-e2e/resource-server] ConfigHandlerFacet initialized (maxOfferFeeBps=${config.maxOfferFeeBps}, minDisputePeriodMs=${config.minDisputePeriodMs})`,
+        );
+        return config;
+      }
+    } catch {
+      // Facet not yet cut into the Diamond — readContract reverts. Keep polling.
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `[x402-e2e/resource-server] timed out after ${ESCROW_DEPLOY_TIMEOUT_MS / 1000}s waiting for ConfigHandlerFacet at ${args.escrowAddress} to be initialized`,
+      );
+    }
+    await sleep(ESCROW_DEPLOY_POLL_INTERVAL_MS);
+  }
+}
+
 async function main(): Promise<void> {
   const env = readEnv();
 
@@ -81,20 +123,21 @@ async function main(): Promise<void> {
 
   await waitForEscrowDeployed({ publicClient, escrowAddress: env.escrowAddress });
 
+  // Tighten the offer's `feeLimit` cap and floor its
+  // `disputePeriodDurationInMS` against the live `ConfigHandlerFacet`
+  // values, instead of the hand-picked safe defaults baked into
+  // `buildUnsignedOffer`. Reuses the polled fetch result so we don't
+  // call the view twice.
+  const protocolConfig = await waitForProtocolConfigInitialized({
+    publicClient,
+    escrowAddress: env.escrowAddress,
+  });
+
   const exchangeReader = createSubgraphExchangeReader({
     subgraphUrl: env.subgraphUrl,
     escrowAddress: env.escrowAddress,
     chainId: env.chainId,
     publicClient,
-  });
-
-  // Tighten the offer's `feeLimit` cap and floor its
-  // `disputePeriodDurationInMS` against the live `ConfigHandlerFacet`
-  // values, instead of the hand-picked safe defaults baked into
-  // `buildUnsignedOffer`.
-  const protocolConfig = await fetchProtocolConfig({
-    publicClient,
-    escrowAddress: env.escrowAddress,
   });
 
   const { app, seller } = createResourceServerApp(env, { exchangeReader, protocolConfig });

--- a/typescript/packages/x402-e2e/src/bin/resource-server.ts
+++ b/typescript/packages/x402-e2e/src/bin/resource-server.ts
@@ -11,35 +11,63 @@
 // canonical compose already wires to the in-container subgraph
 // endpoint (`http://host.docker.internal:8000/subgraphs/name/boson/corecomponents`).
 
-import { createResourceServerApp, readEnv } from "@bosonprotocol/x402-example-resource-server";
+import {
+  createResourceServerApp,
+  fetchProtocolConfig,
+  readEnv,
+} from "@bosonprotocol/x402-example-resource-server";
 
+import { buildPublicClient } from "../harness/clients.js";
 import { createSubgraphExchangeReader } from "../harness/exchange-reader.js";
 
-const env = readEnv();
+async function main(): Promise<void> {
+  const env = readEnv();
 
-if (env.subgraphUrl === undefined) {
-  throw new Error(
-    "[x402-e2e/resource-server] SUBGRAPH_URL is required so the entrypoint can construct the subgraph-backed ExchangeReader",
-  );
+  if (env.subgraphUrl === undefined) {
+    throw new Error(
+      "[x402-e2e/resource-server] SUBGRAPH_URL is required so the entrypoint can construct the subgraph-backed ExchangeReader",
+    );
+  }
+
+  // Reader uses the chain head to wait for the subgraph indexer to
+  // catch up on a `null` lookup (see `exchange-reader.ts`). Reuse the
+  // harness's viem builder so the chain id / RPC URL stay consistent
+  // with the rest of the suite.
+  const publicClient = buildPublicClient({ rpcUrl: env.rpcNode });
+
+  const exchangeReader = createSubgraphExchangeReader({
+    subgraphUrl: env.subgraphUrl,
+    escrowAddress: env.escrowAddress,
+    chainId: env.chainId,
+    publicClient,
+  });
+
+  // Tighten the offer's `feeLimit` cap and floor its
+  // `disputePeriodDurationInMS` against the live `ConfigHandlerFacet`
+  // values, instead of the hand-picked safe defaults baked into
+  // `buildUnsignedOffer`.
+  const protocolConfig = await fetchProtocolConfig({
+    publicClient,
+    escrowAddress: env.escrowAddress,
+  });
+
+  const { app, seller } = createResourceServerApp(env, { exchangeReader, protocolConfig });
+
+  const server = app.listen(env.port, () => {
+    console.log(
+      `[x402-e2e/resource-server] listening on :${env.port} (chain ${env.chainId}, seller ${seller.address}, asset ${env.assetAddress}, subgraph ${env.subgraphUrl})`,
+    );
+  });
+
+  server.on("error", (err: Error) => {
+    console.error(
+      `[x402-e2e/resource-server] failed to bind on :${env.port} (chain ${env.chainId}, seller ${seller.address}, asset ${env.assetAddress}): ${err.message}`,
+    );
+    process.exit(1);
+  });
 }
 
-const exchangeReader = createSubgraphExchangeReader({
-  subgraphUrl: env.subgraphUrl,
-  escrowAddress: env.escrowAddress,
-  chainId: env.chainId,
-});
-
-const { app, seller } = createResourceServerApp(env, { exchangeReader });
-
-const server = app.listen(env.port, () => {
-  console.log(
-    `[x402-e2e/resource-server] listening on :${env.port} (chain ${env.chainId}, seller ${seller.address}, asset ${env.assetAddress}, subgraph ${env.subgraphUrl})`,
-  );
-});
-
-server.on("error", (err: Error) => {
-  console.error(
-    `[x402-e2e/resource-server] failed to bind on :${env.port} (chain ${env.chainId}, seller ${seller.address}, asset ${env.assetAddress}): ${err.message}`,
-  );
+main().catch((err: unknown) => {
+  console.error("[x402-e2e/resource-server] boot failed:", err);
   process.exit(1);
 });

--- a/typescript/packages/x402-e2e/src/config/accounts.ts
+++ b/typescript/packages/x402-e2e/src/config/accounts.ts
@@ -61,6 +61,36 @@ export const ACCOUNT_9: TestAccount = {
   privateKey: "0x316b234f5fea007dcc40404188b588fb90cb9bb1e33fc163e212eab2f8565293",
 };
 
+export const ACCOUNT_10: TestAccount = {
+  address: "0x5a928D9a61d0c245362f7B41076b674C49FFd492",
+  privateKey: "0xbf1bbaeabb036f080dccf9589db26471057f9dc6dcb4bfc87f08dfd2326f648d",
+};
+
+export const ACCOUNT_11: TestAccount = {
+  address: "0x85aa07b513803d30373B2FeCA308b8d1c45Ea893",
+  privateKey: "0x6d677479a1304dae02ffd06656ebe408e6aaa014dca8238b3917080213117c25",
+};
+
+export const ACCOUNT_12: TestAccount = {
+  address: "0xf5bBA1aA5f84484137c2eeC6312F1993709E759B",
+  privateKey: "0x35253a0b89df66fa7c4fb98e46925f6e8804b55a80e2e1c3f22cb1b90a11567b",
+};
+
+export const ACCOUNT_13: TestAccount = {
+  address: "0xC448891cE3d85d141C43E9D95236B7C735bd74BB",
+  privateKey: "0x23b745a17fdcdfcc13a8d5af456898700cd798b25ef5ef3767ae859cc8114df1",
+};
+
+export const ACCOUNT_14: TestAccount = {
+  address: "0xb8a7e554798738Bd0A94c2e2288e73f5bee65295",
+  privateKey: "0x1527fa84bbd0be4ca5663856fcea5dabd3c27cd888a02ae98dc4a178326d6f2f",
+};
+
+export const ACCOUNT_15: TestAccount = {
+  address: "0x7c5F377448811512AcCE2ca1F30c1BCd351ee4f9",
+  privateKey: "0xf7ac2238f7b83f16d7f584c291c495bf75d6a0abe36d3b430d0beb2a145df4fd",
+};
+
 /**
  * Role assignments for the x402B e2e stack. Distinct accounts per role so
  * concurrent meta-tx submissions never share a relayer nonce.

--- a/typescript/packages/x402-e2e/src/harness/buyer-actor.ts
+++ b/typescript/packages/x402-e2e/src/harness/buyer-actor.ts
@@ -14,7 +14,12 @@
 // edge cases the harness doesn't yet bake in (e.g. custom fulfillment
 // selection or post-commit action signing).
 
-import { createX402bClient, type Signer, type X402bClient } from "@bosonprotocol/x402-client";
+import {
+  createX402bClient,
+  type Policy,
+  type Signer,
+  type X402bClient,
+} from "@bosonprotocol/x402-client";
 import { wrapFetchWithPayment } from "@bosonprotocol/x402-client-fetch";
 import type { Address, Hex, LocalAccount, PublicClient } from "viem";
 
@@ -33,6 +38,12 @@ export interface BuyerActorArgs {
   subgraphUrl?: string;
   /** Chain id the buyer signs against. Defaults to `LOCAL_31337_0.chainId`. */
   chainId?: number;
+  /**
+   * Optional `Policy` override — controls e.g. `redeemMode` for
+   * scenarios that need atomic `boson-createOfferCommitAndRedeem`
+   * instead of the default `auto` (which prefers deferred commit).
+   */
+  policy?: Policy;
 }
 
 /** Wrap a viem `LocalAccount` so it satisfies `@bosonprotocol/x402-client`'s `Signer` interface. */
@@ -66,6 +77,7 @@ export function createBuyerActor(args: BuyerActorArgs): BuyerActor {
     signer: signerFromAccount(args.account),
     subgraphUrls: { [chainId]: args.subgraphUrl ?? LOCAL_31337_0.urls.subgraph },
     publicClients: { [chainId]: publicClient },
+    ...(args.policy !== undefined ? { policy: args.policy } : {}),
   });
 
   return {

--- a/typescript/packages/x402-e2e/src/harness/exchange-reader.ts
+++ b/typescript/packages/x402-e2e/src/harness/exchange-reader.ts
@@ -12,13 +12,16 @@
 //
 // Subgraph indexer lag is the dominant failure mode immediately after
 // a settle: `coreSdk.getExchangeById(id)` returns `null` until the
-// indexer ingests the block. The server's `verifyExchange` already
-// retries on `null` with a bounded wait — this reader just forwards
-// `null` so that retry path kicks in.
+// indexer ingests the block. When a `PublicClient` is supplied the
+// reader asks core-sdk to wait for the indexer to catch up to the
+// current chain head before forwarding `null` — that is the canonical
+// "indexer is behind" recovery path; the older polling wrapper
+// (`withPollUntilFound`) remains for callers that don't have an
+// `PublicClient` to hand.
 
 import { CoreSDK } from "@bosonprotocol/core-sdk";
 import type { ExchangeReader, ExchangeSnapshot } from "@bosonprotocol/x402-server";
-import type { Address } from "viem";
+import type { Address, PublicClient } from "viem";
 
 import { LOCAL_31337_0 } from "../config/local-31337-0.js";
 
@@ -46,6 +49,15 @@ export interface SubgraphExchangeReaderArgs {
   escrowAddress?: Address;
   /** Chain id. Defaults to `LOCAL_31337_0.chainId`. */
   chainId?: number;
+  /**
+   * Optional read-only chain client. When supplied, the reader queries
+   * the chain head on a `null` subgraph result and waits for the
+   * indexer to catch up before returning. Without it the reader
+   * forwards `null` immediately (the server's own retry budget then
+   * decides how long to wait, which is short — see
+   * `withPollUntilFound`).
+   */
+  publicClient?: PublicClient;
 }
 
 /** Shape returned by `coreSdk.getExchangeById`. Narrowed to the fields the snapshot needs. */
@@ -102,10 +114,22 @@ export function withPollUntilFound(
   };
 }
 
+/** CoreSDK exposes `waitForGraphNodeIndexing` via the subgraph mixin; narrow to that surface. */
+interface CoreSdkWithIndexerWait {
+  waitForGraphNodeIndexing(blockNumber?: number): Promise<void>;
+  getExchangeById(id: string): Promise<unknown>;
+}
+
 /**
  * Build an `ExchangeReader` that resolves snapshots through the local
  * Boson subgraph. The CoreSDK is constructed with a throwing web3Lib
  * stub so any accidental write attempt surfaces immediately.
+ *
+ * When `args.publicClient` is set, a `null` from the subgraph is
+ * treated as "indexer is behind" — the reader fetches the current
+ * chain head and calls `coreSdk.waitForGraphNodeIndexing(blockNumber)`
+ * before trying once more. The second `null` is forwarded so the
+ * server's own retry path can take over.
  */
 export function createSubgraphExchangeReader(
   args: SubgraphExchangeReaderArgs = {},
@@ -113,32 +137,51 @@ export function createSubgraphExchangeReader(
   const subgraphUrl = args.subgraphUrl ?? LOCAL_31337_0.urls.subgraph;
   const escrowAddress = args.escrowAddress ?? LOCAL_31337_0.contracts.protocolDiamond;
   const chainId = args.chainId ?? LOCAL_31337_0.chainId;
+  const publicClient = args.publicClient;
 
   const sdk = new CoreSDK({
     web3Lib: createReadOnlyWeb3LibStub() as never,
     subgraphUrl,
     protocolDiamond: escrowAddress,
     chainId,
-  });
+  }) as unknown as CoreSdkWithIndexerWait;
+
+  const fetchSnapshot = async (exchangeId: string): Promise<ExchangeSnapshot | null> => {
+    const raw = (await sdk.getExchangeById(exchangeId)) as CoreSdkExchangeEntity | null;
+    if (raw === null) return null;
+    const snapshot: ExchangeSnapshot = {
+      state: raw.state,
+      seller: raw.offer.seller.assistant as Address,
+      exchangeToken: raw.offer.exchangeToken.address as Address,
+      price: raw.offer.price,
+    };
+    if (raw.disputed === true && raw.dispute?.state !== undefined) {
+      snapshot.disputeState = raw.dispute.state;
+    }
+    return snapshot;
+  };
 
   return {
     read: async (exchangeId: string): Promise<ExchangeSnapshot | null> => {
-      // `getExchangeById` returns `null` when the subgraph hasn't yet
-      // indexed the commit transaction. Forward the null so the server's
-      // bounded retry path can resolve once the indexer catches up.
-      const raw = (await sdk.getExchangeById(exchangeId)) as CoreSdkExchangeEntity | null;
-      if (raw === null) return null;
+      const first = await fetchSnapshot(exchangeId);
+      if (first !== null) return first;
+      if (publicClient === undefined) return null;
 
-      const snapshot: ExchangeSnapshot = {
-        state: raw.state,
-        seller: raw.offer.seller.assistant as Address,
-        exchangeToken: raw.offer.exchangeToken.address as Address,
-        price: raw.offer.price,
-      };
-      if (raw.disputed === true && raw.dispute?.state !== undefined) {
-        snapshot.disputeState = raw.dispute.state;
+      // Indexer lag recovery: get the current chain head and ask
+      // core-sdk to wait until the subgraph has ingested at least that
+      // block. Any tx already mined has block <= head, so once the
+      // indexer reaches `head`, our exchange (if it exists on chain)
+      // is guaranteed visible. Cap the wait with `Promise.race` so a
+      // stuck indexer doesn't pin a scenario indefinitely.
+      try {
+        const head = await publicClient.getBlockNumber();
+        await sdk.waitForGraphNodeIndexing(Number(head));
+      } catch {
+        // Network hiccup against the indexer or the RPC — fall through
+        // to a final read so the caller's retry budget (or
+        // `withPollUntilFound`) can decide what to do.
       }
-      return snapshot;
+      return fetchSnapshot(exchangeId);
     },
   };
 }

--- a/typescript/packages/x402-e2e/src/harness/exchange-reader.ts
+++ b/typescript/packages/x402-e2e/src/harness/exchange-reader.ts
@@ -10,14 +10,20 @@
 // `@bosonprotocol/core-sdk`'s `getExchangeById` and maps the result to
 // the `ExchangeSnapshot` shape the server expects.
 //
-// Subgraph indexer lag is the dominant failure mode immediately after
-// a settle: `coreSdk.getExchangeById(id)` returns `null` until the
-// indexer ingests the block. When a `PublicClient` is supplied the
-// reader asks core-sdk to wait for the indexer to catch up to the
-// current chain head before forwarding `null` — that is the canonical
-// "indexer is behind" recovery path; the older polling wrapper
-// (`withPollUntilFound`) remains for callers that don't have an
-// `PublicClient` to hand.
+// Subgraph indexer lag affects every read after a fresh on-chain
+// write: `coreSdk.getExchangeById(id)` either returns `null` (the id
+// doesn't exist yet) or — more subtly — returns a STALE snapshot
+// (the indexer reports the previous state because the new state's
+// block hasn't been ingested). The "still says COMMITTED" right after
+// a `redeemVoucher` tx is the canonical example.
+//
+// When a `PublicClient` is supplied the reader unconditionally calls
+// `coreSdk.waitForGraphNodeIndexing(chainHead)` BEFORE every read so
+// both failure modes collapse into "the reader returns the freshest
+// snapshot the subgraph can provide". Without a `PublicClient` the
+// reader forwards whatever the subgraph has and the older polling
+// wrapper (`withPollUntilFound`) is the only recovery — kept for
+// backwards compatibility but generally outclassed by the wait path.
 
 import { CoreSDK } from "@bosonprotocol/core-sdk";
 import type { ExchangeReader, ExchangeSnapshot } from "@bosonprotocol/x402-server";
@@ -50,12 +56,13 @@ export interface SubgraphExchangeReaderArgs {
   /** Chain id. Defaults to `LOCAL_31337_0.chainId`. */
   chainId?: number;
   /**
-   * Optional read-only chain client. When supplied, the reader queries
-   * the chain head on a `null` subgraph result and waits for the
-   * indexer to catch up before returning. Without it the reader
-   * forwards `null` immediately (the server's own retry budget then
-   * decides how long to wait, which is short — see
-   * `withPollUntilFound`).
+   * Optional read-only chain client. When supplied, the reader calls
+   * `coreSdk.waitForGraphNodeIndexing(chainHead)` **before every read**
+   * so the returned snapshot reflects the latest block, not a stale
+   * pre-action state. Without it the reader returns whatever the
+   * subgraph has at query time, and the server's bounded retry budget
+   * (`verifyExchange` defaults to 3 attempts × 50 ms) decides whether
+   * to ask again — usually too short for an indexer that needs 1-5 s.
    */
   publicClient?: PublicClient;
 }
@@ -125,11 +132,15 @@ interface CoreSdkWithIndexerWait {
  * Boson subgraph. The CoreSDK is constructed with a throwing web3Lib
  * stub so any accidental write attempt surfaces immediately.
  *
- * When `args.publicClient` is set, a `null` from the subgraph is
- * treated as "indexer is behind" — the reader fetches the current
+ * When `args.publicClient` is set, the reader fetches the current
  * chain head and calls `coreSdk.waitForGraphNodeIndexing(blockNumber)`
- * before trying once more. The second `null` is forwarded so the
- * server's own retry path can take over.
+ * BEFORE every subgraph read. That guarantees the returned snapshot
+ * reflects the freshest on-chain state — necessary after a
+ * post-commit action (redeem / complete / dispute family) whose tx
+ * has been mined but whose block the indexer hasn't yet ingested,
+ * which would otherwise surface as a `STATE_VERIFY_STATE_MISMATCH`
+ * (e.g. the subgraph still reports `COMMITTED` immediately after a
+ * `redeemVoucher` tx confirms).
  */
 export function createSubgraphExchangeReader(
   args: SubgraphExchangeReaderArgs = {},
@@ -163,23 +174,29 @@ export function createSubgraphExchangeReader(
 
   return {
     read: async (exchangeId: string): Promise<ExchangeSnapshot | null> => {
-      const first = await fetchSnapshot(exchangeId);
-      if (first !== null) return first;
-      if (publicClient === undefined) return null;
-
-      // Indexer lag recovery: get the current chain head and ask
-      // core-sdk to wait until the subgraph has ingested at least that
-      // block. Any tx already mined has block <= head, so once the
-      // indexer reaches `head`, our exchange (if it exists on chain)
-      // is guaranteed visible. Cap the wait with `Promise.race` so a
-      // stuck indexer doesn't pin a scenario indefinitely.
-      try {
-        const head = await publicClient.getBlockNumber();
-        await sdk.waitForGraphNodeIndexing(Number(head));
-      } catch {
-        // Network hiccup against the indexer or the RPC — fall through
-        // to a final read so the caller's retry budget (or
-        // `withPollUntilFound`) can decide what to do.
+      // Wait for the subgraph to ingest the current chain head before
+      // reading. The on-chain tx for any in-flight action has a block
+      // number ≤ head, so once the indexer reaches `head` the
+      // resulting state transition is guaranteed visible. Both lag
+      // modes — missing entity (NULL row) and stale snapshot
+      // (previous state still indexed) — are covered by this single
+      // wait. Failures here (e.g. RPC hiccup) fall through to a
+      // best-effort read so a network blip doesn't break the suite.
+      if (publicClient !== undefined) {
+        try {
+          // `cacheTime: 0` defeats viem's default block-number cache
+          // (≈ pollingInterval, 4 s for chain 31337). Without it, a
+          // post-action read inside the same test reuses the
+          // pre-action block N as the head, `waitForGraphNodeIndexing(N)`
+          // is a no-op (subgraph already past N), and we get the
+          // pre-action state for the post-action verify.
+          const head = await publicClient.getBlockNumber({ cacheTime: 0 });
+          await sdk.waitForGraphNodeIndexing(Number(head));
+        } catch {
+          // Continue with the read; the caller's retry budget
+          // (`withPollUntilFound` or `verifyExchange`) decides what
+          // to do with a stale or missing result.
+        }
       }
       return fetchSnapshot(exchangeId);
     },

--- a/typescript/packages/x402-e2e/src/harness/facilitator-perform-action.ts
+++ b/typescript/packages/x402-e2e/src/harness/facilitator-perform-action.ts
@@ -1,0 +1,137 @@
+// Drive a post-commit action straight through the facilitator's
+// `POST /perform-action` route — bypasses the resource server entirely.
+//
+// Why this exists: `@bosonprotocol/x402-server-express` only mounts
+// HTTP routes for buyer-initiated post-commit actions that fit the
+// "resource purchase" workflow (`redeem`, `complete`, `dispute/*`).
+// The protocol also supports `boson-cancelVoucher` (buyer ends the
+// exchange before redeeming, e.g. abandoned cart) and
+// `boson-revokeVoucher` (seller-initiated cancellation), but no
+// resource-server route was added for either — they're outside the
+// "happy path" purchase flow. The facilitator's `perform-action`
+// endpoint accepts them anyway via its generic action dispatcher,
+// so the harness reaches them directly. Production integrators
+// would presumably mount their own routes or call this endpoint
+// from their own backend.
+
+import type { ExchangeState, DisputeState } from "@bosonprotocol/x402-actions";
+import type { Address, Hex } from "viem";
+
+import type { BuyerActor } from "./buyer-actor.js";
+import type { SellerActor } from "./seller-actor.js";
+
+/** Subset of action ids the facilitator's `/perform-action` route exposes that this helper drives. */
+export type FacilitatorOnlyActionId = "boson-cancelVoucher" | "boson-revokeVoucher";
+
+export interface FacilitatorPerformArgs {
+  /** Facilitator service URL (e.g. `http://127.0.0.1:8889`). */
+  facilitatorUrl: string;
+  /** Disputed/committed exchange id. */
+  exchangeId: string;
+  /** CAIP-2 network id (e.g. `"eip155:31337"`). */
+  network: string;
+  /** Escrow address (Boson Diamond). */
+  escrowAddress: Address;
+}
+
+export interface CancelVoucherArgs extends FacilitatorPerformArgs {
+  /** Buyer signs `cancelVoucher` (it ends *their* commitment). */
+  buyer: BuyerActor;
+}
+
+export interface RevokeVoucherArgs extends FacilitatorPerformArgs {
+  /** Seller signs `revokeVoucher` (only the seller can revoke their own offer). */
+  seller: SellerActor;
+}
+
+/** Successful facilitator response (mirrors `FacilitatorPerformExchangeActionOk`). */
+export interface FacilitatorPerformResult {
+  ok: true;
+  txHash: Hex;
+  newExchangeState: ExchangeState;
+  newDisputeState?: DisputeState;
+}
+
+/** Thrown when the facilitator returns a non-2xx or `{ ok: false }` envelope. */
+export class FacilitatorPerformError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+  constructor(action: FacilitatorOnlyActionId, status: number, body: unknown) {
+    super(`[x402-e2e/facilitator] ${action} → HTTP ${status}: ${safeStringify(body)}`);
+    this.name = "FacilitatorPerformError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Sign `cancelVoucher` with the buyer's key and submit through the
+ * facilitator's perform-action route. Returns the parsed success body.
+ */
+export async function performCancelVoucher(
+  args: CancelVoucherArgs,
+): Promise<FacilitatorPerformResult> {
+  const signed = await args.buyer.client.signAction({
+    actionId: "boson-cancelVoucher",
+    exchangeId: args.exchangeId,
+    network: args.network,
+    escrowAddress: args.escrowAddress,
+  });
+  return postPerformAction("boson-cancelVoucher", args, signed.signedPayload);
+}
+
+/**
+ * Sign `revokeVoucher` with the seller's key and submit through the
+ * facilitator's perform-action route. Returns the parsed success body.
+ *
+ * The seller's BuyerActor twin doesn't exist in the harness — sellers
+ * don't fetch HTTP resources — so the signing path is implemented
+ * inline here against the seller's viem account.
+ *
+ * **TODO**: This currently isn't wired (B8 deferred in PR7a). When B8
+ * lands, the seller-side meta-tx signing needs the `signMetaTxRevoke
+ * Voucher` core-sdk surface plumbed through `SellerActor`.
+ */
+export async function performRevokeVoucher(
+  _args: RevokeVoucherArgs,
+): Promise<FacilitatorPerformResult> {
+  throw new Error(
+    "[x402-e2e/facilitator] performRevokeVoucher is not yet wired — needs SellerActor.signMetaTxRevokeVoucher (see PR7 follow-up)",
+  );
+}
+
+async function postPerformAction(
+  actionId: FacilitatorOnlyActionId,
+  args: FacilitatorPerformArgs,
+  signedPayload: string,
+): Promise<FacilitatorPerformResult> {
+  const url = new URL("/perform-action", args.facilitatorUrl).toString();
+  const body = {
+    action: actionId,
+    exchangeId: args.exchangeId,
+    network: args.network,
+    escrowAddress: args.escrowAddress,
+    signedPayload,
+  };
+  const res = await globalThis.fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const parsed = (await res.json().catch(() => null)) as
+    | { ok: true; txHash: Hex; newExchangeState: ExchangeState; newDisputeState?: DisputeState }
+    | { ok: false; code?: string; reason?: string }
+    | null;
+  if (!res.ok || parsed === null || parsed.ok !== true) {
+    throw new FacilitatorPerformError(actionId, res.status, parsed);
+  }
+  return parsed;
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/typescript/packages/x402-e2e/src/harness/facilitator-perform-action.ts
+++ b/typescript/packages/x402-e2e/src/harness/facilitator-perform-action.ts
@@ -18,6 +18,7 @@ import type { ExchangeState, DisputeState } from "@bosonprotocol/x402-actions";
 import type { Address, Hex } from "viem";
 
 import type { BuyerActor } from "./buyer-actor.js";
+import { safeStringify } from "./http-error-utils.js";
 import type { SellerActor } from "./seller-actor.js";
 
 /** Subset of action ids the facilitator's `/perform-action` route exposes that this helper drives. */
@@ -126,12 +127,4 @@ async function postPerformAction(
     throw new FacilitatorPerformError(actionId, res.status, parsed);
   }
   return parsed;
-}
-
-function safeStringify(value: unknown): string {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
 }

--- a/typescript/packages/x402-e2e/src/harness/http-error-utils.ts
+++ b/typescript/packages/x402-e2e/src/harness/http-error-utils.ts
@@ -1,0 +1,17 @@
+// Shared helpers for the harness's HTTP error types
+// (`PostCommitActionError`, `FacilitatorPerformError`). Kept internal
+// to the harness — not re-exported from the package's public `index.ts`.
+
+/**
+ * `JSON.stringify(value)` that falls back to `String(value)` when the
+ * value contains a cycle or otherwise can't be serialised. Used to
+ * build error messages from parsed HTTP error envelopes without
+ * letting a stringify failure mask the original HTTP error.
+ */
+export function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/typescript/packages/x402-e2e/src/harness/http-error-utils.ts
+++ b/typescript/packages/x402-e2e/src/harness/http-error-utils.ts
@@ -7,10 +7,16 @@
  * value contains a cycle or otherwise can't be serialised. Used to
  * build error messages from parsed HTTP error envelopes without
  * letting a stringify failure mask the original HTTP error.
+ *
+ * `JSON.stringify` returns `undefined` (not a string) for top-level
+ * `undefined` / function / symbol values without throwing, so the
+ * null-coalesce on the success path is required to honour the
+ * `: string` return type.
  */
 export function safeStringify(value: unknown): string {
   try {
-    return JSON.stringify(value);
+    const json = JSON.stringify(value);
+    return json ?? String(value);
   } catch {
     return String(value);
   }

--- a/typescript/packages/x402-e2e/src/harness/index.ts
+++ b/typescript/packages/x402-e2e/src/harness/index.ts
@@ -31,3 +31,19 @@ export {
 
 export { seedSuite, type SeedArgs, type SeededSeller, type SuiteState } from "./seed.js";
 export { buildCreateSellerCallback, type BuildCreateSellerCallbackArgs } from "./create-seller.js";
+
+export {
+  performBuyerPostCommitAction,
+  PostCommitActionError,
+  type BuyerPostCommitActionId,
+  type PerformBuyerPostCommitActionArgs,
+  type PostCommitActionResult,
+} from "./post-commit-http.js";
+
+export {
+  performCancelVoucher,
+  FacilitatorPerformError,
+  type CancelVoucherArgs,
+  type FacilitatorOnlyActionId,
+  type FacilitatorPerformResult,
+} from "./facilitator-perform-action.js";

--- a/typescript/packages/x402-e2e/src/harness/post-commit-http.ts
+++ b/typescript/packages/x402-e2e/src/harness/post-commit-http.ts
@@ -21,6 +21,7 @@ import type { ExchangeState, DisputeState } from "@bosonprotocol/x402-actions";
 import type { Address, Hex } from "viem";
 
 import type { BuyerActor } from "./buyer-actor.js";
+import { safeStringify } from "./http-error-utils.js";
 
 /** Buyer-driven post-commit actions the server-express router mounts. */
 export type BuyerPostCommitActionId =
@@ -187,12 +188,4 @@ function flattenServerResponse(
     result.newDisputeState = newDisputeState as DisputeState;
   }
   return result;
-}
-
-function safeStringify(value: unknown): string {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
 }

--- a/typescript/packages/x402-e2e/src/harness/post-commit-http.ts
+++ b/typescript/packages/x402-e2e/src/harness/post-commit-http.ts
@@ -1,0 +1,160 @@
+// Drive a post-commit buyer action through the example resource
+// server's `/x402B/<route>` HTTP surface (mounted by
+// `@bosonprotocol/x402-server-express`). Wraps:
+//
+//   1. `BuyerActor.client.signAction(...)` → produces the `signedPayload`
+//      hex the server route expects.
+//   2. `fetch(...)` POST to the right route — the mapping from
+//      `actionId` → URL path mirrors `server-express/src/mount.ts`.
+//   3. JSON parse + minimal shape coerce so scenarios can assert on
+//      `txHash` / `newExchangeState` / `newDisputeState` directly.
+//
+// Scoped to buyer-initiated actions today: `boson-redeem`,
+// `boson-completeExchange`, `boson-raiseDispute`, `boson-resolveDispute`,
+// `boson-retractDispute`, `boson-escalateDispute`. The server-express
+// router does not expose `cancelVoucher` / `revokeVoucher` /
+// `decideDispute` — those routes don't exist, so scenarios reach
+// them via the facilitator's `POST /perform-action` directly (see
+// `facilitator-perform-action.ts`).
+
+import type { ExchangeState, DisputeState } from "@bosonprotocol/x402-actions";
+import type { Address, Hex } from "viem";
+
+import type { BuyerActor } from "./buyer-actor.js";
+
+/** Buyer-driven post-commit actions the server-express router mounts. */
+export type BuyerPostCommitActionId =
+  | "boson-redeem"
+  | "boson-completeExchange"
+  | "boson-raiseDispute"
+  | "boson-resolveDispute"
+  | "boson-retractDispute"
+  | "boson-escalateDispute";
+
+/** Path segment under `/x402B/` for each supported action. */
+const POST_COMMIT_ROUTE: Record<BuyerPostCommitActionId, string> = {
+  "boson-redeem": "redeem",
+  "boson-completeExchange": "complete",
+  "boson-raiseDispute": "dispute/raise",
+  "boson-resolveDispute": "dispute/resolve",
+  "boson-retractDispute": "dispute/retract",
+  "boson-escalateDispute": "dispute/escalate",
+};
+
+/** Counterparty (seller) signature shape — matches `SignedResolutionProposal` or a raw hex. */
+type CounterpartySig = Hex | { r: Hex; s: Hex; v: number };
+
+/**
+ * Args to `performBuyerPostCommitAction`. `boson-resolveDispute` is the
+ * one action that needs extra fields (`buyerPercent`, `counterpartySig`);
+ * every other id sticks to the base set.
+ */
+export type PerformBuyerPostCommitActionArgs =
+  | (BasePerformArgs & {
+      actionId: Exclude<BuyerPostCommitActionId, "boson-resolveDispute">;
+    })
+  | (BasePerformArgs & {
+      actionId: "boson-resolveDispute";
+      buyerPercent: bigint | string | number;
+      counterpartySig: CounterpartySig;
+    });
+
+interface BasePerformArgs {
+  buyer: BuyerActor;
+  /** Resource server's base URL (e.g. `http://127.0.0.1:<port>`). */
+  resourceServerUrl: string;
+  /** Disputed/committed exchange id. */
+  exchangeId: string;
+  /** Escrow address (Boson Diamond) — the EIP-712 verifyingContract. */
+  escrowAddress: Address;
+  /** CAIP-2 network id (e.g. `"eip155:31337"`). */
+  network: string;
+  /** Optional redeem-only fulfillment payload, forwarded verbatim to the server route. */
+  fulfillment?: { option: string; data: Record<string, unknown> | null };
+}
+
+/** Successful post-commit response (mirrors `PerformActionOk` in the server handlers). */
+export interface PostCommitActionResult {
+  txHash: Hex;
+  newExchangeState: ExchangeState;
+  newDisputeState?: DisputeState;
+}
+
+/**
+ * Thrown when the server responds with a non-2xx status. The
+ * `body` field carries the parsed JSON error envelope (`{ code, reason }`)
+ * so scenarios can assert against `error.body.code` for validation
+ * negatives without having to re-parse the response.
+ */
+export class PostCommitActionError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+  constructor(actionId: BuyerPostCommitActionId, status: number, body: unknown) {
+    super(`[x402-e2e/post-commit-http] ${actionId} → HTTP ${status}: ${safeStringify(body)}`);
+    this.name = "PostCommitActionError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Sign the action through the buyer's client, POST it to the right
+ * `/x402B/<route>`, and return the parsed success body. Throws
+ * `PostCommitActionError` on non-2xx so scenarios don't need to
+ * decode error envelopes by hand.
+ */
+export async function performBuyerPostCommitAction(
+  args: PerformBuyerPostCommitActionArgs,
+): Promise<PostCommitActionResult> {
+  const { buyer, resourceServerUrl, exchangeId, escrowAddress, network, actionId } = args;
+
+  const signed =
+    actionId === "boson-resolveDispute"
+      ? await buyer.client.signAction({
+          actionId,
+          exchangeId,
+          network,
+          escrowAddress,
+          buyerPercent: args.buyerPercent,
+          counterpartySig: args.counterpartySig,
+        })
+      : await buyer.client.signAction({
+          actionId,
+          exchangeId,
+          network,
+          escrowAddress,
+        });
+
+  const route = POST_COMMIT_ROUTE[actionId];
+  const url = `${resourceServerUrl}/x402B/${route}`;
+  const body: Record<string, unknown> = {
+    exchangeId,
+    signedPayload: signed.signedPayload,
+  };
+  if (actionId === "boson-redeem" && args.fulfillment !== undefined) {
+    body.fulfillment = args.fulfillment;
+  }
+
+  const res = await globalThis.fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  const parsed = (await res.json().catch(() => null)) as unknown;
+  if (!res.ok) {
+    throw new PostCommitActionError(actionId, res.status, parsed);
+  }
+  if (parsed === null || typeof parsed !== "object") {
+    throw new PostCommitActionError(actionId, res.status, parsed);
+  }
+  return parsed as PostCommitActionResult;
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/typescript/packages/x402-e2e/src/harness/post-commit-http.ts
+++ b/typescript/packages/x402-e2e/src/harness/post-commit-http.ts
@@ -73,7 +73,14 @@ interface BasePerformArgs {
   fulfillment?: { option: string; data: Record<string, unknown> | null };
 }
 
-/** Successful post-commit response (mirrors `PerformActionOk` in the server handlers). */
+/**
+ * Successful post-commit response — flattened view over the server's
+ * `{ txHash, nextActions }` body. The server stamps the new state on
+ * the `nextActions` envelope (`exchangeState`, `disputeState`) rather
+ * than as top-level `newExchangeState` / `newDisputeState` fields; the
+ * harness exposes them under the latter names so scenarios stay
+ * symmetric with the facilitator-direct `performCancelVoucher` result.
+ */
 export interface PostCommitActionResult {
   txHash: Hex;
   newExchangeState: ExchangeState;
@@ -148,7 +155,38 @@ export async function performBuyerPostCommitAction(
   if (parsed === null || typeof parsed !== "object") {
     throw new PostCommitActionError(actionId, res.status, parsed);
   }
-  return parsed as PostCommitActionResult;
+  return flattenServerResponse(actionId, res.status, parsed);
+}
+
+/**
+ * Coerce the server's `{ txHash, nextActions: { exchangeState, disputeState? } }`
+ * body into the flat `PostCommitActionResult` shape scenarios expect.
+ * Throws `PostCommitActionError` if the response is missing fields
+ * required for assertion (txHash, exchangeState).
+ */
+function flattenServerResponse(
+  actionId: BuyerPostCommitActionId,
+  status: number,
+  body: object,
+): PostCommitActionResult {
+  const raw = body as {
+    txHash?: unknown;
+    nextActions?: { exchangeState?: unknown; disputeState?: unknown };
+  };
+  const txHash = raw.txHash;
+  const newExchangeState = raw.nextActions?.exchangeState;
+  if (typeof txHash !== "string" || typeof newExchangeState !== "string") {
+    throw new PostCommitActionError(actionId, status, body);
+  }
+  const result: PostCommitActionResult = {
+    txHash: txHash as Hex,
+    newExchangeState: newExchangeState as ExchangeState,
+  };
+  const newDisputeState = raw.nextActions?.disputeState;
+  if (typeof newDisputeState === "string") {
+    result.newDisputeState = newDisputeState as DisputeState;
+  }
+  return result;
 }
 
 function safeStringify(value: unknown): string {

--- a/typescript/packages/x402-e2e/src/harness/seller-actor.ts
+++ b/typescript/packages/x402-e2e/src/harness/seller-actor.ts
@@ -10,20 +10,50 @@
 //     through `@bosonprotocol/core-sdk` so the EIP-712 domain stays in
 //     lock-step with the deployed protocol.
 //
-// Future PRs (when scenarios exercise them) extend this with
-// `revokeVoucher`, `decideDisputeSig`, etc.
+//   - `signResolutionProposal({ exchangeId, buyerPercentBasisPoints })` —
+//     sign the `Resolution(uint256 exchangeId, uint256 buyerPercentBasisPoints)`
+//     proposal the buyer needs as `counterpartySig` when calling
+//     `client.signAction({ actionId: "boson-resolveDispute", … })`.
+//     Routes through `coreSdk.signDisputeResolutionProposal` so the
+//     EIP-712 domain + type-list stay in lock-step with the deployed
+//     protocol (per CLAUDE.md "reuse > re-implementation").
 //
 // The seller's `entityId` (the `sellerId` field on the `FullOffer`) is
 // **not** owned by this actor — it's a property of the on-chain seller
 // entity associated with the wallet, created at suite-seed time. See
 // `./seed.ts`.
 
+import { CoreSDK } from "@bosonprotocol/core-sdk";
 import { signFullOffer, type SellerSigner } from "@bosonprotocol/x402-server";
 import type { UnsignedFullOffer } from "@bosonprotocol/x402-core/eip712";
 import type { Address, BosonOfferRef } from "@bosonprotocol/x402-core/schemes/escrow";
-import type { LocalAccount } from "viem";
+import type { Hex, LocalAccount, TypedDataDomain, TypedDataParameter } from "viem";
+
+// Minimal duck-typed `Web3LibAdapter` shape — core-sdk's exported type
+// lives in `@bosonprotocol/common`, but pulling that in as a direct
+// dependency would balloon the harness's footprint just for one
+// interface. The constructor only inspects the methods at runtime, so
+// a structural type here is enough.
+interface MinimalWeb3LibAdapter {
+  uuid: string;
+  getSignerAddress: () => Promise<string>;
+  isSignerContract: () => Promise<boolean>;
+  getChainId: () => Promise<number>;
+  send: (method: string, params: unknown[]) => Promise<string>;
+  call: (req: { to: string; data?: string }) => Promise<string>;
+  getBalance: (...args: unknown[]) => Promise<unknown>;
+  estimateGas: (...args: unknown[]) => Promise<unknown>;
+  sendTransaction: (...args: unknown[]) => Promise<unknown>;
+  getTransactionReceipt: (...args: unknown[]) => Promise<unknown>;
+  getCurrentTimeMs: () => Promise<number>;
+}
 
 import { LOCAL_31337_0 } from "../config/local-31337-0.js";
+
+// Sentinel used when constructing the seller-side CoreSDK for
+// resolution-proposal signing — the proposal path never touches the
+// subgraph but `CoreSDK`'s constructor still requires a string.
+const PLACEHOLDER_SUBGRAPH_URL = "https://x402-e2e.placeholder.invalid/subgraph";
 
 export interface SellerActorArgs {
   /** Seller's signing key. Defaults to `ROLE_ACCOUNTS.seller` in callers. */
@@ -34,6 +64,28 @@ export interface SellerActorArgs {
   chainId?: number;
 }
 
+/** Args to `SellerActor.signResolutionProposal`. */
+export interface SignResolutionProposalArgs {
+  /** Disputed exchange id (decimal string or bigint). */
+  exchangeId: bigint | string;
+  /** Buyer share of the resolution in basis points (`10000` = 100 %). */
+  buyerPercentBasisPoints: bigint | string;
+}
+
+/**
+ * Signed resolution proposal — split into `{ r, s, v }` and the
+ * concatenated `signature` hex. Either form satisfies the buyer's
+ * `counterpartySig: Hex | { r, s, v }` parameter on
+ * `client.signAction({ actionId: "boson-resolveDispute", … })`.
+ */
+export interface SignedResolutionProposal {
+  r: Hex;
+  s: Hex;
+  v: number;
+  /** 65-byte concatenated signature, `0x`-prefixed. */
+  signature: Hex;
+}
+
 export interface SellerActor {
   readonly address: Address;
   readonly account: LocalAccount;
@@ -41,6 +93,14 @@ export interface SellerActor {
   readonly signer: SellerSigner;
   /** Sign an unsigned FullOffer; returns a `BosonOfferRef` ready for `PaymentRequirements`. */
   signOffer: (unsigned: UnsignedFullOffer) => Promise<BosonOfferRef>;
+  /**
+   * Sign the `Resolution` EIP-712 message the buyer must aggregate as
+   * `counterpartySig` to call `boson-resolveDispute`. Mirrors the
+   * `signFullOffer` pattern — instantiates a one-shot `CoreSDK` with a
+   * forwarding `Web3LibAdapter` so the typed-data shape stays in
+   * lock-step with the deployed protocol.
+   */
+  signResolutionProposal: (args: SignResolutionProposalArgs) => Promise<SignedResolutionProposal>;
 }
 
 export function createSellerActor(args: SellerActorArgs): SellerActor {
@@ -58,5 +118,102 @@ export function createSellerActor(args: SellerActorArgs): SellerActor {
     account: args.account,
     signer,
     signOffer: (unsigned) => signFullOffer({ fullOffer: unsigned, signer, escrow, chainId }),
+
+    async signResolutionProposal({ exchangeId, buyerPercentBasisPoints }) {
+      const web3Lib = buildSellerForwardingAdapter(args.account, chainId);
+      const sdk = new CoreSDK({
+        // Cast through `never` — the adapter's tx-flavour methods are
+        // typed to reject, but core-sdk's `Web3LibAdapter` requires
+        // concrete `BigNumberish`/`TransactionResponse` returns. Those
+        // paths are unreachable here (the proposal signer only invokes
+        // `send("eth_signTypedData_v4", …)`), so the strict shape just
+        // forces a no-op cast.
+        web3Lib: web3Lib as never,
+        subgraphUrl: PLACEHOLDER_SUBGRAPH_URL,
+        protocolDiamond: escrow,
+        chainId,
+      });
+      // `returnTypedDataToSign` defaults to `false` here so core-sdk
+      // builds the typed data internally, routes it through
+      // `web3Lib.send("eth_signTypedData_v4", …)` (→ seller account),
+      // and returns `{ r, s, v, signature }`. The seller never has to
+      // know the `Resolution` type-list — core-sdk owns it.
+      const signed = await sdk.signDisputeResolutionProposal({
+        exchangeId: typeof exchangeId === "bigint" ? exchangeId.toString() : exchangeId,
+        buyerPercentBasisPoints:
+          typeof buyerPercentBasisPoints === "bigint"
+            ? buyerPercentBasisPoints.toString()
+            : buyerPercentBasisPoints,
+      });
+      return {
+        r: signed.r as Hex,
+        s: signed.s as Hex,
+        v: Number(signed.v),
+        signature: signed.signature as Hex,
+      };
+    },
+  };
+}
+
+/**
+ * Forwarding `Web3LibAdapter` that routes core-sdk's
+ * `eth_signTypedData_v4` RPC straight to the seller's viem
+ * `LocalAccount`. Every other adapter method rejects — the seller
+ * never goes on-chain through this path, so any leak into a tx-flavour
+ * method should fail loudly rather than silently.
+ */
+function buildSellerForwardingAdapter(
+  account: LocalAccount,
+  chainId: number,
+): MinimalWeb3LibAdapter {
+  const unreachable = (method: string): Promise<never> =>
+    Promise.reject(
+      new Error(
+        `[x402-e2e/seller-actor] stub Web3LibAdapter.${method}() is not implemented — the seller-side proposal signer is read-only`,
+      ),
+    );
+  return {
+    uuid: "x402-e2e:seller-resolution-adapter",
+    getSignerAddress: async () => account.address,
+    isSignerContract: async () => false,
+    getChainId: async () => chainId,
+    send: async (method, params) => {
+      if (method !== "eth_signTypedData_v4") {
+        throw new Error(
+          `[x402-e2e/seller-actor] seller adapter does not support RPC method '${method}'; only eth_signTypedData_v4 is implemented`,
+        );
+      }
+      const raw = (params as unknown[])[1];
+      if (typeof raw !== "string") {
+        throw new Error(
+          "[x402-e2e/seller-actor] eth_signTypedData_v4 payload[1] is not a JSON string — core-sdk internals may have changed",
+        );
+      }
+      const td = JSON.parse(raw) as {
+        domain: TypedDataDomain;
+        types: Record<string, readonly TypedDataParameter[]>;
+        primaryType: string;
+        message: Record<string, unknown>;
+      };
+      // viem rejects an explicit `EIP712Domain` entry in `types` — it
+      // derives the domain layout from the `domain` object itself.
+      const { EIP712Domain: _drop, ...messageTypes } = td.types;
+      // `signTypedData`'s overload set is strictly typed against
+      // ahead-of-time `types`; we're routing a runtime-shaped payload
+      // so a single `as never` lets viem's generic overload pick the
+      // permissive path.
+      return account.signTypedData({
+        domain: td.domain,
+        types: messageTypes,
+        primaryType: td.primaryType,
+        message: td.message,
+      } as never);
+    },
+    call: () => unreachable("call"),
+    getBalance: () => unreachable("getBalance"),
+    estimateGas: () => unreachable("estimateGas"),
+    sendTransaction: () => unreachable("sendTransaction"),
+    getTransactionReceipt: () => unreachable("getTransactionReceipt"),
+    getCurrentTimeMs: () => unreachable("getCurrentTimeMs"),
   };
 }

--- a/typescript/packages/x402-e2e/test/harness/actors.test.ts
+++ b/typescript/packages/x402-e2e/test/harness/actors.test.ts
@@ -31,6 +31,21 @@ describe("SellerActor", () => {
     expect(actor.signer.address.toLowerCase()).toBe(account.address.toLowerCase());
     expect(typeof actor.signer.signTypedData).toBe("function");
     expect(typeof actor.signOffer).toBe("function");
+    expect(typeof actor.signResolutionProposal).toBe("function");
+  });
+
+  it("signResolutionProposal returns a 65-byte signature + split { r, s, v }", async () => {
+    const account = privateKeyToAccount(ROLE_ACCOUNTS.seller.privateKey);
+    const actor = createSellerActor({ account });
+    const signed = await actor.signResolutionProposal({
+      exchangeId: "1",
+      buyerPercentBasisPoints: "5000",
+    });
+    // 0x + 64 r + 64 s + 2 v = 132 chars
+    expect(signed.signature).toMatch(/^0x[0-9a-fA-F]{130}$/);
+    expect(signed.r).toMatch(/^0x[0-9a-fA-F]{64}$/);
+    expect(signed.s).toMatch(/^0x[0-9a-fA-F]{64}$/);
+    expect(signed.v === 27 || signed.v === 28).toBe(true);
   });
 });
 

--- a/typescript/packages/x402-e2e/test/scenarios/_assertion-constants.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_assertion-constants.ts
@@ -1,0 +1,13 @@
+// Shared assertion literals reused across the scenario test files.
+// Centralised so a single change (e.g. switching the default scenario
+// amount) doesn't need to be hunted across every scenario file.
+
+/** Matches any `0x`-prefixed hex string — used to spot-check tx hashes. */
+export const TX_HASH_REGEX = /^0x[0-9a-fA-F]+$/;
+
+/**
+ * Default scenario commit amount in atomic units (1 USDC at 6dp).
+ * Mirrors the `_setup.ts` default and matches what the resource server
+ * advertises in its 402 challenge.
+ */
+export const EXPECTED_PRICE = "1000000";

--- a/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
@@ -11,7 +11,14 @@
 // scenario amount before approving. Both calls are no-ops when
 // re-run with already-sufficient balance / allowance.
 
-import type { Address, PublicClient, WalletClient } from "viem";
+import {
+  parseEther,
+  type Address,
+  type LocalAccount,
+  type PublicClient,
+  type WalletClient,
+} from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 const ERC20_TEST_ABI = [
   {
@@ -113,4 +120,37 @@ export async function ensureBuyerCanPay(args: BuyerSetupArgs): Promise<void> {
     });
     await args.publicClient.waitForTransactionReceipt({ hash: approveHash });
   }
+}
+
+export interface CreateFundedBuyerArgs {
+  /** WalletClient built from one of `SEED_WALLETS` (see `_seed-wallets.ts`). */
+  funder: WalletClient;
+  /** Read-side client used to await the funding tx receipt. */
+  publicClient: PublicClient;
+  /** Native ETH to send to the new EOA, as a decimal string. Defaults to `"0.5"`. */
+  fundEth?: string;
+}
+
+/**
+ * Generate a fresh viem `LocalAccount`, fund it from `funder` with
+ * native ETH for gas, and return the account. Used by chain-touching
+ * scenario describes so each describe transacts from its own EOA —
+ * Vitest runs test files in parallel, and a shared buyer EOA races
+ * the chain nonce across parallel files.
+ *
+ * The mock `Foreign20` ERC-20 the local stack ships has a public
+ * `mint(to, amount)`, so the returned account self-funds payment
+ * tokens via `ensureBuyerCanPay`; the seed wallet only needs to
+ * cover gas.
+ */
+export async function createFundedBuyer(args: CreateFundedBuyerArgs): Promise<LocalAccount> {
+  const account = privateKeyToAccount(generatePrivateKey());
+  const hash = await args.funder.sendTransaction({
+    account: args.funder.account!,
+    chain: args.funder.chain!,
+    to: account.address,
+    value: parseEther(args.fundEth ?? "0.5"),
+  });
+  await args.publicClient.waitForTransactionReceipt({ hash });
+  return account;
 }

--- a/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
@@ -144,10 +144,22 @@ export interface CreateFundedBuyerArgs {
  * cover gas.
  */
 export async function createFundedBuyer(args: CreateFundedBuyerArgs): Promise<LocalAccount> {
+  // `WalletClient` doesn't require `account` / `chain` at the type
+  // level, so unguarded non-null assertions would crash with an opaque
+  // viem error if a caller passed a bare client. Surface a clear
+  // harness-side message instead.
+  const funderAccount = args.funder.account;
+  const funderChain = args.funder.chain;
+  if (funderAccount === undefined || funderChain === undefined) {
+    throw new Error(
+      "[x402-e2e/_buyer-setup] createFundedBuyer requires a WalletClient with both `account` and `chain` set " +
+        "(use `buildWalletClient(SEED_WALLETS.<slot>.account)`)",
+    );
+  }
   const account = privateKeyToAccount(generatePrivateKey());
   const hash = await args.funder.sendTransaction({
-    account: args.funder.account!,
-    chain: args.funder.chain!,
+    account: funderAccount,
+    chain: funderChain,
     to: account.address,
     value: parseEther(args.fundEth ?? "0.5"),
   });

--- a/typescript/packages/x402-e2e/test/scenarios/_seed-wallets.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_seed-wallets.ts
@@ -1,0 +1,50 @@
+// Per-describe seed wallets for the chain-touching scenario suite.
+//
+// Vitest runs test FILES in parallel by default. Each chain-touching
+// describe in each file is wired up against a freshly-generated random
+// buyer EOA that the slot below funds with native ETH for gas. Two
+// slots that run in parallel must never reuse the same account —
+// concurrent funding transactions on a shared EOA collide on tx nonce
+// and cascade into `NonceTooLow` / `BAD_META_TX_SIGNATURE` /
+// `OfferSoldOut` failures.
+//
+// Mirrors `bosonprotocol/core-components/e2e/tests/utils.ts`'s
+// hand-maintained `seedWalletN` pool. Pick the slot at module scope
+// in each chain-touching test file; two parallel files must never
+// declare the same slot.
+
+import type { LocalAccount } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import {
+  ACCOUNT_5,
+  ACCOUNT_6,
+  ACCOUNT_7,
+  ACCOUNT_10,
+  ACCOUNT_11,
+  ACCOUNT_12,
+} from "../../src/config/accounts.js";
+
+const toAccount = (a: { privateKey: `0x${string}` }) => privateKeyToAccount(a.privateKey);
+
+/**
+ * Named seed wallets. Each chain-touching test describe imports
+ * exactly one. NEVER assign the same slot to two describes that can
+ * run in parallel — Vitest runs files in parallel by default, so two
+ * parallel files on the same EOA will race the chain nonce.
+ */
+export const SEED_WALLETS = {
+  /** `commit.test.ts` — `@p0 commit-time scenarios` describe. */
+  commit: toAccount(ACCOUNT_5),
+  /** `post-commit.test.ts` — `@p0 post-commit lifecycle scenarios` describe. */
+  postCommitP0: toAccount(ACCOUNT_6),
+  /** `post-commit.test.ts` — `@p1 post-commit lifecycle scenarios` describe. */
+  postCommitP1: toAccount(ACCOUNT_7),
+  /** Reserved for `validation-commit.test.ts` once it lands chain-touching tests. */
+  validationCommit: toAccount(ACCOUNT_10),
+  /** Spare slots for future chain-touching scenario files (D, E, F sections). */
+  spareA: toAccount(ACCOUNT_11),
+  spareB: toAccount(ACCOUNT_12),
+} as const satisfies Record<string, LocalAccount>;
+
+export type SeedWalletName = keyof typeof SEED_WALLETS;

--- a/typescript/packages/x402-e2e/test/scenarios/_seed-wallets.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_seed-wallets.ts
@@ -1,19 +1,30 @@
-// Per-describe seed wallets for the chain-touching scenario suite.
+// Per-FILE seed-wallet slots for the chain-touching scenario suite.
 //
 // Vitest runs test FILES in parallel by default. Each chain-touching
-// describe in each file is wired up against a freshly-generated random
-// buyer EOA that the slot below funds with native ETH for gas. Two
-// slots that run in parallel must never reuse the same account —
-// concurrent funding transactions on a shared EOA collide on tx nonce
-// and cascade into `NonceTooLow` / `BAD_META_TX_SIGNATURE` /
-// `OfferSoldOut` failures.
+// test FILE imports exactly one slot below. Two FILES that can run
+// concurrently MUST NOT share a slot — sharing causes:
+//
+//   1. Funding-tx nonce collisions on the slot account (since each
+//      describe's `beforeAll` funds a fresh random buyer EOA), and
+//   2. `OfferSoldOut` reverts inside `createOfferAndCommit`: parallel
+//      resource servers both sign FullOffer templates with the SAME
+//      seller and the protocol rejects the second submission because
+//      the predicted offerId has already been minted and bought.
+//
+// Each slot's account is therefore registered on-chain as a SEPARATE
+// Boson seller entity by `globalSetup` (see `test/setup/globalSetup.ts`).
+// The seller id is published via `process.env[SELLERS_ENV_KEY]` and
+// looked up at test time via `getSellerInfo(slot)`.
+//
+// Within one file, vitest serialises tests, so describes inside the
+// same file share the slot safely (post-commit.test.ts's `@p0` and
+// `@p1` both use `postCommit`).
 //
 // Mirrors `bosonprotocol/core-components/e2e/tests/utils.ts`'s
-// hand-maintained `seedWalletN` pool. Pick the slot at module scope
-// in each chain-touching test file; two parallel files must never
-// declare the same slot.
+// hand-maintained `seedWalletN` pool, but with each slot doubling as
+// both the buyer-funder and the registered seller.
 
-import type { LocalAccount } from "viem";
+import type { Address, Hex, LocalAccount } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 
 import {
@@ -25,26 +36,73 @@ import {
   ACCOUNT_12,
 } from "../../src/config/accounts.js";
 
-const toAccount = (a: { privateKey: `0x${string}` }) => privateKeyToAccount(a.privateKey);
+export interface SeedWalletSlot {
+  /** viem `LocalAccount` — buyer-funder and seller signer for the slot. */
+  account: LocalAccount;
+  /** Raw private key — passed to the in-process resource server's `sellerPk` arg. */
+  privateKey: Hex;
+}
+
+const toSlot = (a: { privateKey: `0x${string}` }): SeedWalletSlot => ({
+  account: privateKeyToAccount(a.privateKey),
+  privateKey: a.privateKey,
+});
 
 /**
- * Named seed wallets. Each chain-touching test describe imports
- * exactly one. NEVER assign the same slot to two describes that can
- * run in parallel — Vitest runs files in parallel by default, so two
- * parallel files on the same EOA will race the chain nonce.
+ * Named per-FILE slots. Each chain-touching test file imports exactly
+ * one. NEVER assign the same slot to two test files that can run in
+ * parallel — globalSetup registers a separate seller per slot, and
+ * sharing a slot defeats the parallel-safety guarantees.
  */
 export const SEED_WALLETS = {
-  /** `commit.test.ts` — `@p0 commit-time scenarios` describe. */
-  commit: toAccount(ACCOUNT_5),
-  /** `post-commit.test.ts` — `@p0 post-commit lifecycle scenarios` describe. */
-  postCommitP0: toAccount(ACCOUNT_6),
-  /** `post-commit.test.ts` — `@p1 post-commit lifecycle scenarios` describe. */
-  postCommitP1: toAccount(ACCOUNT_7),
+  /** `commit.test.ts` */
+  commit: toSlot(ACCOUNT_5),
+  /** `post-commit.test.ts` — both `@p0` and `@p1` describes share this file's slot. */
+  postCommit: toSlot(ACCOUNT_6),
   /** Reserved for `validation-commit.test.ts` once it lands chain-touching tests. */
-  validationCommit: toAccount(ACCOUNT_10),
-  /** Spare slots for future chain-touching scenario files (D, E, F sections). */
-  spareA: toAccount(ACCOUNT_11),
-  spareB: toAccount(ACCOUNT_12),
-} as const satisfies Record<string, LocalAccount>;
+  validationCommit: toSlot(ACCOUNT_7),
+  /** Spare slots for future chain-touching scenario files. */
+  spareA: toSlot(ACCOUNT_10),
+  spareB: toSlot(ACCOUNT_11),
+  spareC: toSlot(ACCOUNT_12),
+} as const;
 
 export type SeedWalletName = keyof typeof SEED_WALLETS;
+
+/**
+ * Env-var key under which `globalSetup` publishes the JSON map of
+ * `{ slotName → { id, address } }` for the seller entity registered
+ * against each slot. Tests look this up via `getSellerInfo(slot)`.
+ */
+export const SELLERS_ENV_KEY = "X402_E2E_SELLERS";
+
+export interface SeedWalletSellerInfo {
+  /** Boson seller entity id (decimal string). */
+  id: string;
+  /** Seller's assistant address — matches `SEED_WALLETS[slot].account.address`. */
+  address: Address;
+}
+
+type SellerInfoMap = Record<string, SeedWalletSellerInfo>;
+
+/**
+ * Read the seller info that `globalSetup` registered for `slot`.
+ * Throws when the env map is missing (globalSetup didn't run — likely
+ * `E2E_DOCKER=1` was off) or the slot has no entry.
+ */
+export function getSellerInfo(slot: SeedWalletName): SeedWalletSellerInfo {
+  const raw = process.env[SELLERS_ENV_KEY];
+  if (raw === undefined || raw.length === 0) {
+    throw new Error(
+      `[x402-e2e/seed-wallets] ${SELLERS_ENV_KEY} not set — did globalSetup run? (set E2E_DOCKER=1)`,
+    );
+  }
+  const all = JSON.parse(raw) as SellerInfoMap;
+  const info = all[slot];
+  if (info === undefined) {
+    throw new Error(
+      `[x402-e2e/seed-wallets] no seller registered for slot "${slot}" in ${SELLERS_ENV_KEY}`,
+    );
+  }
+  return info;
+}

--- a/typescript/packages/x402-e2e/test/scenarios/_seed-wallets.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_seed-wallets.ts
@@ -34,6 +34,7 @@ import {
   ACCOUNT_10,
   ACCOUNT_11,
   ACCOUNT_12,
+  ACCOUNT_13,
 } from "../../src/config/accounts.js";
 
 export interface SeedWalletSlot {
@@ -61,6 +62,8 @@ export const SEED_WALLETS = {
   postCommit: toSlot(ACCOUNT_6),
   /** Reserved for `validation-commit.test.ts` once it lands chain-touching tests. */
   validationCommit: toSlot(ACCOUNT_7),
+  /** `concurrent.test.ts` — funds the 20 parallel buyers and registers the slot's seller. */
+  concurrent: toSlot(ACCOUNT_13),
   /** Spare slots for future chain-touching scenario files. */
   spareA: toSlot(ACCOUNT_10),
   spareB: toSlot(ACCOUNT_11),

--- a/typescript/packages/x402-e2e/test/scenarios/_setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_setup.ts
@@ -14,7 +14,11 @@
 // `ASSET_ADDRESS`, etc. with the seeded state. The compose service
 // stays available for manual smoke testing.
 
-import { createResourceServerApp, readEnv } from "@bosonprotocol/x402-example-resource-server";
+import {
+  createResourceServerApp,
+  fetchProtocolConfig,
+  readEnv,
+} from "@bosonprotocol/x402-example-resource-server";
 import { createServer, type AddressInfo } from "node:net";
 import { type Hex } from "viem";
 import { privateKeyToAccount, type LocalAccount } from "viem/accounts";
@@ -64,6 +68,12 @@ export interface ScenarioContextArgs {
 export interface ScenarioContext {
   /** Public URL of the in-process resource server (`http://127.0.0.1:<port>`). */
   resourceServerUrl: string;
+  /** Facilitator HTTP service (compose-service URL). Used by scenarios that bypass the resource server. */
+  facilitatorUrl: string;
+  /** CAIP-2 network id (`eip155:31337` for the local stack). */
+  network: `eip155:${number}`;
+  /** Escrow address baked into requirements + EIP-712 domain. */
+  escrowAddress: `0x${string}`;
   seller: SellerActor;
   buyer: BuyerActor;
   resolver: ResolverActor;
@@ -126,10 +136,13 @@ export async function createScenarioContext(
   // to ingest a freshly-mined block; `@bosonprotocol/x402-server`'s
   // default `verifyExchange` retry budget (3 × 50 ms) gives up well
   // before that, surfacing as `STATE_VERIFY_EXCHANGE_NOT_FOUND` on
-  // every commit. `withPollUntilFound` extends the reader's wait
-  // budget without touching the server's defaults (production
-  // consumers want the fast path).
-  const exchangeReader = withPollUntilFound(createSubgraphExchangeReader());
+  // every commit. Plumbing `publicClient` into the reader gives it
+  // the chain head it needs to call `waitForGraphNodeIndexing(block)`
+  // on a miss — the canonical "indexer caught up" wait. The
+  // `withPollUntilFound` outer wrapper backs the indexer-wait path
+  // with a bounded retry so a transient subgraph hiccup doesn't
+  // collapse straight into `STATE_VERIFY_EXCHANGE_NOT_FOUND`.
+  const exchangeReader = withPollUntilFound(createSubgraphExchangeReader({ publicClient }));
   const asserter = createOnchainAsserter(exchangeReader);
 
   // Reserve a real port up front: `createResourceServerApp` builds the
@@ -155,7 +168,15 @@ export async function createScenarioContext(
     port,
   };
 
-  const { app } = createResourceServerApp(env, { exchangeReader });
+  // Tighten the in-process offer's `feeLimit` cap + `disputePeriodDurationInMS`
+  // floor against the live `ConfigHandlerFacet` values. The compose-service
+  // entrypoint does the same fetch in `src/bin/resource-server.ts`.
+  const protocolConfig = await fetchProtocolConfig({
+    publicClient,
+    escrowAddress: env.escrowAddress,
+  });
+
+  const { app } = createResourceServerApp(env, { exchangeReader, protocolConfig });
   const httpServer = app.listen(port);
   await new Promise<void>((resolve, reject) => {
     httpServer.once("listening", resolve);
@@ -168,6 +189,9 @@ export async function createScenarioContext(
 
   return {
     resourceServerUrl,
+    facilitatorUrl: env.facilitatorUrl,
+    network: env.network,
+    escrowAddress: env.escrowAddress,
     seller,
     buyer,
     resolver,

--- a/typescript/packages/x402-e2e/test/scenarios/_setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_setup.ts
@@ -20,7 +20,6 @@ import {
   readEnv,
 } from "@bosonprotocol/x402-example-resource-server";
 import { createServer, type AddressInfo } from "node:net";
-import { type Hex } from "viem";
 import { privateKeyToAccount, type LocalAccount } from "viem/accounts";
 
 /** `ResourceServerEnv` isn't re-exported from the example's barrel; derive it from `readEnv`'s return type. */
@@ -44,17 +43,25 @@ import {
 
 import { SUITE_STATE_ENV } from "../setup/globalSetup.js";
 
+import { SEED_WALLETS, getSellerInfo, type SeedWalletName } from "./_seed-wallets.js";
+
 const LOCALHOST_HTTP = "http://127.0.0.1";
 
 export interface ScenarioContextArgs {
   /**
-   * Override the seller private key. Defaults to `ROLE_ACCOUNTS.seller.privateKey`.
-   * Taken as a raw key (not a `LocalAccount`) so the same identity drives both
-   * the `SellerActor` and the in-process resource server's `sellerPk`.
+   * Per-file seed-wallet slot. The slot's account is the registered seller
+   * (its `sellerId` was published by `globalSetup`) and supplies the
+   * `sellerPk` the in-process resource server signs FullOffer templates
+   * with. Two chain-touching test files MUST NOT pick the same slot —
+   * see `_seed-wallets.ts`.
    */
-  sellerPk?: Hex;
-  /** Override the buyer `LocalAccount`. Defaults to `ROLE_ACCOUNTS.buyer`. */
-  buyerAccount?: LocalAccount;
+  slot: SeedWalletName;
+  /**
+   * Buyer `LocalAccount` — typically a fresh random EOA built via
+   * `createFundedBuyer({ funder: SEED_WALLETS[slot].account, … })` so each
+   * describe transacts from its own nonce space.
+   */
+  buyerAccount: LocalAccount;
   /** Override the resolver `LocalAccount`. Defaults to `ROLE_ACCOUNTS.resolver`. */
   resolverAccount?: LocalAccount;
   /** Override `ASSET_ADDRESS`. Defaults to the test ERC-20 (`testErc20`). */
@@ -116,18 +123,18 @@ async function allocateFreePort(): Promise<number> {
   return port;
 }
 
-export async function createScenarioContext(
-  args: ScenarioContextArgs = {},
-): Promise<ScenarioContext> {
-  const sellerPk = args.sellerPk ?? ROLE_ACCOUNTS.seller.privateKey;
-  const sellerAccount = privateKeyToAccount(sellerPk);
-  const buyerAccount = args.buyerAccount ?? privateKeyToAccount(ROLE_ACCOUNTS.buyer.privateKey);
+export async function createScenarioContext(args: ScenarioContextArgs): Promise<ScenarioContext> {
+  const slot = SEED_WALLETS[args.slot];
+  const sellerPk = slot.privateKey;
+  const sellerAccount = slot.account;
+  const buyerAccount = args.buyerAccount;
   const resolverAccount =
     args.resolverAccount ?? privateKeyToAccount(ROLE_ACCOUNTS.resolver.privateKey);
 
+  const sellerInfo = getSellerInfo(args.slot);
   const suite = {
-    sellerId: requireSuiteEnv(SUITE_STATE_ENV.sellerId),
-    sellerAddress: requireSuiteEnv(SUITE_STATE_ENV.sellerAddress) as `0x${string}`,
+    sellerId: sellerInfo.id,
+    sellerAddress: sellerInfo.address as `0x${string}`,
     disputeResolverId: requireSuiteEnv(SUITE_STATE_ENV.disputeResolverId),
   };
 

--- a/typescript/packages/x402-e2e/test/scenarios/_skeletons.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_skeletons.test.ts
@@ -10,17 +10,14 @@ import { describe, it } from "vitest";
 
 import { ENABLED } from "./_flags.js";
 
-describe.skipIf(!ENABLED)("@p0 post-commit lifecycle — PR 7", () => {
-  it.todo("B1 — redeem after deferred commit → ExchangeState.REDEEMED");
-  it.todo("B2 — completeExchange after redeem → ExchangeState.COMPLETED, escrow released");
-  it.todo("B3 — raiseDispute after redeem → DisputeState.RESOLVING");
-  it.todo("B4 — mutual resolveDispute (buyer % split, dual-sig) → DisputeState.RESOLVED");
-});
+// B1–B4, B6, B7 moved to `post-commit.test.ts` as runnable scenarios.
+// The remaining @p1 / @p2 items stay parked here as `it.todo` until
+// they're picked up — B5 needs dispute-resolver-deposit handling,
+// B8 needs SellerActor meta-tx signing, and B9 needs ResolverActor
+// wallet signing.
 
-describe.skipIf(!ENABLED)("@p1 post-commit lifecycle — PR 7", () => {
+describe.skipIf(!ENABLED)("@p1 post-commit lifecycle — follow-up", () => {
   it.todo("B5 — escalateDispute with deposit → DisputeState.ESCALATED");
-  it.todo("B6 — retractDispute by buyer → DisputeState.RETRACTED");
-  it.todo("B7 — cancelVoucher before redeem → ExchangeState.CANCELLED, escrow refunded - penalty");
 });
 
 describe.skipIf(!ENABLED)("@p2 post-commit lifecycle — PR 7", () => {

--- a/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
@@ -37,9 +37,9 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
 
   beforeAll(async () => {
     const publicClient = buildPublicClient();
-    const funder = buildWalletClient(SEED_WALLETS.commit);
+    const funder = buildWalletClient(SEED_WALLETS.commit.account);
     buyerAccount = await createFundedBuyer({ funder, publicClient });
-    ctx = await createScenarioContext({ buyerAccount });
+    ctx = await createScenarioContext({ slot: "commit", buyerAccount });
     await ensureBuyerCanPay({
       walletClient: buildWalletClient(buyerAccount),
       publicClient,

--- a/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
@@ -40,13 +40,18 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
     const funder = buildWalletClient(SEED_WALLETS.commit.account);
     buyerAccount = await createFundedBuyer({ funder, publicClient });
     ctx = await createScenarioContext({ slot: "commit", buyerAccount });
+    // Over-provision the buyer for the whole describe — A1 spends 1
+    // USDC, A2's atomic flow spends another, and the to-be-unskipped
+    // A3–A5 each commit one more. Funding the deficit ~10x up-front
+    // keeps each test from re-minting (and matches the post-commit
+    // describe's pattern).
     await ensureBuyerCanPay({
       walletClient: buildWalletClient(buyerAccount),
       publicClient,
       buyerAddress: buyerAccount.address,
       assetAddress: LOCAL_31337_0.contracts.testErc20,
       escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
-      amount: 1_000_000n,
+      amount: 10_000_000n,
     });
   });
 

--- a/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
@@ -15,32 +15,33 @@
 // in this PR and land in PR 7.
 
 import { ExchangeState } from "@bosonprotocol/x402-actions";
+import type { LocalAccount } from "viem";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { LOCAL_31337_0 } from "../../src/config/local-31337-0.js";
-import { ROLE_ACCOUNTS } from "../../src/config/accounts.js";
 import {
   buildPublicClient,
   buildWalletClient,
   createBuyerActor,
   readXPaymentResponse,
 } from "../../src/harness/index.js";
-import { privateKeyToAccount } from "viem/accounts";
 
-import { ensureBuyerCanPay } from "./_buyer-setup.js";
+import { createFundedBuyer, ensureBuyerCanPay } from "./_buyer-setup.js";
 import { ENABLED } from "./_flags.js";
+import { SEED_WALLETS } from "./_seed-wallets.js";
 import { createScenarioContext, type ScenarioContext } from "./_setup.js";
 
 describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
   let ctx: ScenarioContext;
+  let buyerAccount: LocalAccount;
 
   beforeAll(async () => {
-    ctx = await createScenarioContext();
-    const buyerAccount = privateKeyToAccount(ROLE_ACCOUNTS.buyer.privateKey);
-    const buyerWallet = buildWalletClient(buyerAccount);
     const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS.commit);
+    buyerAccount = await createFundedBuyer({ funder, publicClient });
+    ctx = await createScenarioContext({ buyerAccount });
     await ensureBuyerCanPay({
-      walletClient: buyerWallet,
+      walletClient: buildWalletClient(buyerAccount),
       publicClient,
       buyerAddress: buyerAccount.address,
       assetAddress: LOCAL_31337_0.contracts.testErc20,
@@ -92,9 +93,8 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
   it("A2 — atomic commit-and-redeem with `none` strategy", async () => {
     // A2 needs its own buyer with a non-default `Policy.redeemMode` so
     // the client picks `boson-createOfferCommitAndRedeem` instead of
-    // the deferred flow A1 used. Reuse the shared buyer's funded
-    // wallet (the allowance from `beforeAll` is still in place).
-    const buyerAccount = privateKeyToAccount(ROLE_ACCOUNTS.buyer.privateKey);
+    // the deferred flow A1 used. Reuse the describe-scoped funded
+    // buyer (the allowance from `beforeAll` is still in place).
     const atomicBuyer = createBuyerActor({
       account: buyerAccount,
       publicClient: ctx.buyer.publicClient,

--- a/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
@@ -22,6 +22,7 @@ import { ROLE_ACCOUNTS } from "../../src/config/accounts.js";
 import {
   buildPublicClient,
   buildWalletClient,
+  createBuyerActor,
   readXPaymentResponse,
 } from "../../src/harness/index.js";
 import { privateKeyToAccount } from "viem/accounts";
@@ -87,8 +88,43 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
   // Atomic commit-and-redeem (`boson-createOfferCommitAndRedeem`).
   // Same wire path as A1 but the client selects `commit-and-redeem`
   // via `Policy.redeemMode: "commit-and-redeem"` so the buyer ends
-  // up at `REDEEMED` in a single tx. Unblocked by Boson PR #1105.
-  it.todo("A2 — atomic commit-and-redeem with `none` strategy");
+  // up at `REDEEMED` in a single tx.
+  it("A2 — atomic commit-and-redeem with `none` strategy", async () => {
+    // A2 needs its own buyer with a non-default `Policy.redeemMode` so
+    // the client picks `boson-createOfferCommitAndRedeem` instead of
+    // the deferred flow A1 used. Reuse the shared buyer's funded
+    // wallet (the allowance from `beforeAll` is still in place).
+    const buyerAccount = privateKeyToAccount(ROLE_ACCOUNTS.buyer.privateKey);
+    const atomicBuyer = createBuyerActor({
+      account: buyerAccount,
+      publicClient: ctx.buyer.publicClient,
+      policy: { redeemMode: "commit-and-redeem" },
+    });
+
+    const res = await atomicBuyer.fetch(`${ctx.resourceServerUrl}/resource`);
+    expect(res.status, await res.clone().text()).toBe(200);
+
+    const body = (await res.json()) as {
+      ok?: boolean;
+      x402b?: { exchangeId?: string; txHash?: `0x${string}` };
+    };
+    expect(body.ok).toBe(true);
+    expect(typeof body.x402b?.exchangeId).toBe("string");
+
+    const decoded = readXPaymentResponse(res.headers);
+    expect(decoded?.exchangeId).toBe(body.x402b?.exchangeId);
+    expect(decoded?.txHash).toMatch(/^0x[0-9a-fA-F]+$/);
+
+    // Atomic flow → exchange should land directly in REDEEMED, not
+    // COMMITTED. Same seller / exchangeToken / price as A1.
+    const exchangeId = body.x402b!.exchangeId!;
+    await ctx.asserter.expect(exchangeId, {
+      state: ExchangeState.REDEEMED,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc20,
+      price: "1000000",
+    });
+  });
 
   // Token-auth strategies. The resource server already advertises
   // `["none","erc3009","permit","permit2"]`; PR6 follow-up implements

--- a/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
@@ -26,6 +26,7 @@ import {
   readXPaymentResponse,
 } from "../../src/harness/index.js";
 
+import { EXPECTED_PRICE, TX_HASH_REGEX } from "./_assertion-constants.js";
 import { createFundedBuyer, ensureBuyerCanPay } from "./_buyer-setup.js";
 import { ENABLED } from "./_flags.js";
 import { SEED_WALLETS } from "./_seed-wallets.js";
@@ -77,7 +78,7 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
     const decoded = readXPaymentResponse(res.headers);
     expect(decoded, "X-PAYMENT-RESPONSE header should decode to a JSON payload").not.toBeNull();
     expect(decoded?.exchangeId).toBe(body.x402b?.exchangeId);
-    expect(decoded?.txHash).toMatch(/^0x[0-9a-fA-F]+$/);
+    expect(decoded?.txHash).toMatch(TX_HASH_REGEX);
 
     // On-chain state — exchange should be `COMMITTED` with seller +
     // exchangeToken + price matching the requirements. The asserter
@@ -87,7 +88,7 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
       state: ExchangeState.COMMITTED,
       seller: ctx.seller.address,
       exchangeToken: LOCAL_31337_0.contracts.testErc20,
-      price: "1000000",
+      price: EXPECTED_PRICE,
     });
   });
 
@@ -118,7 +119,7 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
 
     const decoded = readXPaymentResponse(res.headers);
     expect(decoded?.exchangeId).toBe(body.x402b?.exchangeId);
-    expect(decoded?.txHash).toMatch(/^0x[0-9a-fA-F]+$/);
+    expect(decoded?.txHash).toMatch(TX_HASH_REGEX);
 
     // Atomic flow → exchange should land directly in REDEEMED, not
     // COMMITTED. Same seller / exchangeToken / price as A1.
@@ -127,7 +128,7 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
       state: ExchangeState.REDEEMED,
       seller: ctx.seller.address,
       exchangeToken: LOCAL_31337_0.contracts.testErc20,
-      price: "1000000",
+      price: EXPECTED_PRICE,
     });
   });
 

--- a/typescript/packages/x402-e2e/test/scenarios/concurrent.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/concurrent.test.ts
@@ -1,0 +1,158 @@
+// Concurrent access scenario — exercises the resource server +
+// facilitator pair under simultaneous, multi-buyer load. Every other
+// scenario file drives one buyer at a time (vitest serialises tests
+// within a file), so regressions in the relayer nonce manager,
+// session cache, or seller-side FullOffer signing under contention
+// only show up here.
+//
+// Layout: 20 distinct freshly-funded EOAs each call
+// `fetch(/resource)` against the same in-process resource server
+// concurrently, all configured with `policy.redeemMode = "commit-and-redeem"`
+// (atomic flow, same wire path as scenario A2). Every fetch is
+// kicked off via `Promise.all(...)` so each client launches before
+// any previous one has resolved.
+//
+// Gated behind `E2E_DOCKER=1`. Idempotent: each run mints 20 new
+// random accounts, so re-running against an already-up stack
+// (`E2E_DOCKER_KEEP_STACK=1`, see `test/setup/globalSetup.ts`) is
+// safe to repeat indefinitely.
+
+import { ExchangeState } from "@bosonprotocol/x402-actions";
+import type { LocalAccount } from "viem";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { LOCAL_31337_0 } from "../../src/config/local-31337-0.js";
+import {
+  buildPublicClient,
+  buildWalletClient,
+  createBuyerActor,
+  readXPaymentResponse,
+  type BuyerActor,
+} from "../../src/harness/index.js";
+
+import { createFundedBuyer, ensureBuyerCanPay } from "./_buyer-setup.js";
+import { ENABLED } from "./_flags.js";
+import { SEED_WALLETS } from "./_seed-wallets.js";
+import { createScenarioContext, type ScenarioContext } from "./_setup.js";
+
+const CONCURRENT_BUYERS = 20;
+const PER_COMMIT_AMOUNT = 1_000_000n;
+
+interface CommitResponseBody {
+  ok?: boolean;
+  x402b?: { exchangeId?: string; txHash?: `0x${string}` };
+}
+
+describe.skipIf(!ENABLED)("@p0 concurrent commit-and-redeem scenarios", () => {
+  let ctx: ScenarioContext;
+  let buyers: BuyerActor[];
+
+  beforeAll(async () => {
+    const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS.concurrent.account);
+
+    // Step 1 — fund 20 fresh EOAs sequentially. The funder has a
+    // single nonce stream, so parallel `sendTransaction` calls would
+    // race; the loop costs ~1 s total (well inside `hookTimeout`).
+    const buyerAccounts: LocalAccount[] = [];
+    for (let i = 0; i < CONCURRENT_BUYERS; i++) {
+      buyerAccounts.push(await createFundedBuyer({ funder, publicClient }));
+    }
+
+    // Step 2 — mint + approve in parallel. Each buyer signs from its
+    // own nonce stream, so 20 concurrent `mint` + `approve` pairs are
+    // safe and let the chain mine them back-to-back.
+    await Promise.all(
+      buyerAccounts.map((account) =>
+        ensureBuyerCanPay({
+          walletClient: buildWalletClient(account),
+          publicClient,
+          buyerAddress: account.address,
+          assetAddress: LOCAL_31337_0.contracts.testErc20,
+          escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+          amount: PER_COMMIT_AMOUNT,
+        }),
+      ),
+    );
+
+    // The describe only needs the context for `resourceServerUrl`,
+    // `seller`, `asserter`, and `teardown` — `ctx.buyer` is unused
+    // because the test drives its own 20-buyer fleet. The first
+    // buyer account is passed in to satisfy the required arg.
+    ctx = await createScenarioContext({
+      slot: "concurrent",
+      buyerAccount: buyerAccounts[0]!,
+    });
+
+    // Step 3 — assemble 20 BuyerActors that all share a single
+    // `publicClient` (viem connection reuse) and the single
+    // in-process resource server. Each actor signs from its own
+    // account, so concurrent meta-tx signing across the fleet is
+    // race-free.
+    buyers = buyerAccounts.map((account) =>
+      createBuyerActor({
+        account,
+        publicClient,
+        policy: { redeemMode: "commit-and-redeem" },
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await ctx?.teardown();
+  });
+
+  it(`E0 — ${CONCURRENT_BUYERS} concurrent buyers atomic commit-and-redeem`, async () => {
+    // Fire every fetch synchronously before awaiting any of them.
+    // `Promise.all` over `.map((b) => b.fetch(...))` starts each
+    // request in the same microtask, satisfying the "no waiting for
+    // the previous client" requirement; `t0` lets the run log
+    // confirm the burst behaviour at a glance.
+    const t0 = Date.now();
+    const responses = await Promise.all(
+      buyers.map((b) => b.fetch(`${ctx.resourceServerUrl}/resource`)),
+    );
+    console.log(
+      `[concurrent.test] ${CONCURRENT_BUYERS} fetches completed in ${Date.now() - t0} ms`,
+    );
+
+    for (const res of responses) {
+      expect(res.status, await res.clone().text()).toBe(200);
+    }
+
+    const bodies = (await Promise.all(responses.map((r) => r.json()))) as CommitResponseBody[];
+    const exchangeIds: string[] = [];
+    for (let i = 0; i < bodies.length; i++) {
+      const body = bodies[i]!;
+      expect(body.ok, `buyer ${i} body.ok`).toBe(true);
+      const exchangeId = body.x402b?.exchangeId;
+      expect(typeof exchangeId, `buyer ${i} exchangeId type`).toBe("string");
+      exchangeIds.push(exchangeId!);
+
+      const decoded = readXPaymentResponse(responses[i]!.headers);
+      expect(decoded, `buyer ${i} X-PAYMENT-RESPONSE`).not.toBeNull();
+      expect(decoded?.exchangeId).toBe(exchangeId);
+      expect(decoded?.txHash).toMatch(/^0x[0-9a-fA-F]+$/);
+    }
+
+    // Each request gets a freshly-signed FullOffer template (random
+    // meta-tx nonce → unique predicted offerId), so collisions
+    // would surface here as duplicate exchange ids.
+    expect(new Set(exchangeIds).size).toBe(CONCURRENT_BUYERS);
+
+    // On-chain state — all 20 should land in REDEEMED (atomic flow).
+    // The asserter's `withPollUntilFound` wrapper absorbs the
+    // subgraph indexer's 1–5 s lag; 20 parallel polls overlap so the
+    // wall-clock is dominated by the slowest, not the sum.
+    await Promise.all(
+      exchangeIds.map((id) =>
+        ctx.asserter.expect(id, {
+          state: ExchangeState.REDEEMED,
+          seller: ctx.seller.address,
+          exchangeToken: LOCAL_31337_0.contracts.testErc20,
+          price: PER_COMMIT_AMOUNT.toString(),
+        }),
+      ),
+    );
+  });
+});

--- a/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
@@ -32,6 +32,7 @@ import {
   performCancelVoucher,
 } from "../../src/harness/index.js";
 
+import { EXPECTED_PRICE, TX_HASH_REGEX } from "./_assertion-constants.js";
 import { createFundedBuyer, ensureBuyerCanPay } from "./_buyer-setup.js";
 import { ENABLED } from "./_flags.js";
 import { SEED_WALLETS } from "./_seed-wallets.js";
@@ -101,14 +102,14 @@ describe.skipIf(!ENABLED)("@p0 post-commit lifecycle scenarios", () => {
       escrowAddress: ctx.escrowAddress,
       network: ctx.network,
     });
-    expect(result.txHash).toMatch(/^0x[0-9a-fA-F]+$/);
+    expect(result.txHash).toMatch(TX_HASH_REGEX);
     expect(result.newExchangeState).toBe(ExchangeState.REDEEMED);
 
     await ctx.asserter.expect(exchangeId, {
       state: ExchangeState.REDEEMED,
       seller: ctx.seller.address,
       exchangeToken: LOCAL_31337_0.contracts.testErc20,
-      price: "1000000",
+      price: EXPECTED_PRICE,
     });
   });
 
@@ -136,7 +137,7 @@ describe.skipIf(!ENABLED)("@p0 post-commit lifecycle scenarios", () => {
       state: ExchangeState.COMPLETED,
       seller: ctx.seller.address,
       exchangeToken: LOCAL_31337_0.contracts.testErc20,
-      price: "1000000",
+      price: EXPECTED_PRICE,
     });
   });
 
@@ -166,7 +167,7 @@ describe.skipIf(!ENABLED)("@p0 post-commit lifecycle scenarios", () => {
       disputeState: DisputeState.RESOLVING,
       seller: ctx.seller.address,
       exchangeToken: LOCAL_31337_0.contracts.testErc20,
-      price: "1000000",
+      price: EXPECTED_PRICE,
     });
   });
 
@@ -221,7 +222,7 @@ describe.skipIf(!ENABLED)("@p0 post-commit lifecycle scenarios", () => {
       disputeState: DisputeState.RESOLVED,
       seller: ctx.seller.address,
       exchangeToken: LOCAL_31337_0.contracts.testErc20,
-      price: "1000000",
+      price: EXPECTED_PRICE,
     });
   });
 });
@@ -285,7 +286,7 @@ describe.skipIf(!ENABLED)("@p1 post-commit lifecycle scenarios", () => {
       disputeState: DisputeState.RETRACTED,
       seller: ctx.seller.address,
       exchangeToken: LOCAL_31337_0.contracts.testErc20,
-      price: "1000000",
+      price: EXPECTED_PRICE,
     });
   });
 
@@ -310,7 +311,7 @@ describe.skipIf(!ENABLED)("@p1 post-commit lifecycle scenarios", () => {
       state: ExchangeState.CANCELLED,
       seller: ctx.seller.address,
       exchangeToken: LOCAL_31337_0.contracts.testErc20,
-      price: "1000000",
+      price: EXPECTED_PRICE,
     });
   });
 });

--- a/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
@@ -69,12 +69,12 @@ describe.skipIf(!ENABLED)("@p0 post-commit lifecycle scenarios", () => {
 
   beforeAll(async () => {
     const publicClient = buildPublicClient();
-    const funder = buildWalletClient(SEED_WALLETS.postCommitP0);
+    const funder = buildWalletClient(SEED_WALLETS.postCommit.account);
     // Each test in this describe commits multiple fresh exchanges, so
     // give the random buyer enough native ETH to cover all the local
     // mint + approve + transfer fees.
     const buyerAccount = await createFundedBuyer({ funder, publicClient, fundEth: "2" });
-    ctx = await createScenarioContext({ buyerAccount });
+    ctx = await createScenarioContext({ slot: "postCommit", buyerAccount });
     // Over-provision the buyer's allowance by ~10x the per-commit cap
     // so successive commits inside the describe don't need re-approval.
     await ensureBuyerCanPay({
@@ -231,9 +231,12 @@ describe.skipIf(!ENABLED)("@p1 post-commit lifecycle scenarios", () => {
 
   beforeAll(async () => {
     const publicClient = buildPublicClient();
-    const funder = buildWalletClient(SEED_WALLETS.postCommitP1);
+    // @p0 and @p1 live in the same file and run sequentially, so they
+    // share the file's slot — `vitest` serialises within-file tests
+    // and the slot's seller / funder can handle both describes' load.
+    const funder = buildWalletClient(SEED_WALLETS.postCommit.account);
     const buyerAccount = await createFundedBuyer({ funder, publicClient, fundEth: "2" });
-    ctx = await createScenarioContext({ buyerAccount });
+    ctx = await createScenarioContext({ slot: "postCommit", buyerAccount });
     await ensureBuyerCanPay({
       walletClient: buildWalletClient(buyerAccount),
       publicClient,

--- a/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
@@ -25,17 +25,16 @@ import { ExchangeState, DisputeState } from "@bosonprotocol/x402-actions";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { LOCAL_31337_0 } from "../../src/config/local-31337-0.js";
-import { ROLE_ACCOUNTS } from "../../src/config/accounts.js";
 import {
   buildPublicClient,
   buildWalletClient,
   performBuyerPostCommitAction,
   performCancelVoucher,
 } from "../../src/harness/index.js";
-import { privateKeyToAccount } from "viem/accounts";
 
-import { ensureBuyerCanPay } from "./_buyer-setup.js";
+import { createFundedBuyer, ensureBuyerCanPay } from "./_buyer-setup.js";
 import { ENABLED } from "./_flags.js";
+import { SEED_WALLETS } from "./_seed-wallets.js";
 import { createScenarioContext, type ScenarioContext } from "./_setup.js";
 
 /**
@@ -69,15 +68,17 @@ describe.skipIf(!ENABLED)("@p0 post-commit lifecycle scenarios", () => {
   let ctx: ScenarioContext;
 
   beforeAll(async () => {
-    ctx = await createScenarioContext();
-    const buyerAccount = privateKeyToAccount(ROLE_ACCOUNTS.buyer.privateKey);
-    const buyerWallet = buildWalletClient(buyerAccount);
     const publicClient = buildPublicClient();
-    // The post-commit lifecycle file commits *multiple* fresh
-    // exchanges (one per test), so over-provision the buyer's
-    // allowance by ~10x the per-commit cap.
+    const funder = buildWalletClient(SEED_WALLETS.postCommitP0);
+    // Each test in this describe commits multiple fresh exchanges, so
+    // give the random buyer enough native ETH to cover all the local
+    // mint + approve + transfer fees.
+    const buyerAccount = await createFundedBuyer({ funder, publicClient, fundEth: "2" });
+    ctx = await createScenarioContext({ buyerAccount });
+    // Over-provision the buyer's allowance by ~10x the per-commit cap
+    // so successive commits inside the describe don't need re-approval.
     await ensureBuyerCanPay({
-      walletClient: buyerWallet,
+      walletClient: buildWalletClient(buyerAccount),
       publicClient,
       buyerAddress: buyerAccount.address,
       assetAddress: LOCAL_31337_0.contracts.testErc20,
@@ -229,12 +230,12 @@ describe.skipIf(!ENABLED)("@p1 post-commit lifecycle scenarios", () => {
   let ctx: ScenarioContext;
 
   beforeAll(async () => {
-    ctx = await createScenarioContext();
-    const buyerAccount = privateKeyToAccount(ROLE_ACCOUNTS.buyer.privateKey);
-    const buyerWallet = buildWalletClient(buyerAccount);
     const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS.postCommitP1);
+    const buyerAccount = await createFundedBuyer({ funder, publicClient, fundEth: "2" });
+    ctx = await createScenarioContext({ buyerAccount });
     await ensureBuyerCanPay({
-      walletClient: buyerWallet,
+      walletClient: buildWalletClient(buyerAccount),
       publicClient,
       buyerAddress: buyerAccount.address,
       assetAddress: LOCAL_31337_0.contracts.testErc20,

--- a/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
@@ -1,0 +1,312 @@
+// Post-commit lifecycle scenarios — section B of the e2e plan.
+//
+// Each test starts from a fresh committed exchange (driven through
+// the same `/resource` 402 retry A1 uses) and exercises one of the
+// post-commit transitions the protocol supports.
+//
+// Coverage in this file:
+//
+//   - B1  redeem after deferred commit                        @p0
+//   - B2  completeExchange after redeem                       @p0
+//   - B3  raiseDispute after redeem                           @p0
+//   - B4  mutual resolveDispute (50/50, dual-sig)             @p0
+//   - B6  retractDispute by buyer                             @p1
+//   - B7  cancelVoucher before redeem (via facilitator)       @p1
+//
+// Deferred to a follow-up PR:
+//   - B5 escalateDispute  — needs dispute-resolver-deposit handling
+//   - B8 revokeVoucher    — needs SellerActor meta-tx signing
+//   - B9 decideDispute    — needs ResolverActor wallet signing
+//
+// All scenarios gated behind `E2E_DOCKER=1` because they hit the live
+// local stack (Diamond, subgraph, facilitator).
+
+import { ExchangeState, DisputeState } from "@bosonprotocol/x402-actions";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { LOCAL_31337_0 } from "../../src/config/local-31337-0.js";
+import { ROLE_ACCOUNTS } from "../../src/config/accounts.js";
+import {
+  buildPublicClient,
+  buildWalletClient,
+  performBuyerPostCommitAction,
+  performCancelVoucher,
+} from "../../src/harness/index.js";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { ensureBuyerCanPay } from "./_buyer-setup.js";
+import { ENABLED } from "./_flags.js";
+import { createScenarioContext, type ScenarioContext } from "./_setup.js";
+
+/**
+ * Drive a fresh `/resource` 402 retry → commit and return the
+ * resulting `exchangeId`. The shared buyer's allowance is topped up
+ * once in `beforeAll`; every commit produces a brand-new on-chain
+ * offer (the seller's signed FullOffer carries a fresh meta-tx nonce
+ * each time), so successive commits don't race the `quantityAvailable: "1"`
+ * cap on a single offer.
+ */
+async function commitFreshExchange(ctx: ScenarioContext): Promise<string> {
+  const res = await ctx.buyer.fetch(`${ctx.resourceServerUrl}/resource`);
+  if (res.status !== 200) {
+    throw new Error(
+      `[post-commit.test] failed to commit a fresh exchange: HTTP ${res.status} ${await res.text()}`,
+    );
+  }
+  const body = (await res.json()) as {
+    x402b?: { exchangeId?: string };
+  };
+  const exchangeId = body.x402b?.exchangeId;
+  if (typeof exchangeId !== "string" || exchangeId.length === 0) {
+    throw new Error(
+      `[post-commit.test] commit response missing exchangeId: ${JSON.stringify(body)}`,
+    );
+  }
+  return exchangeId;
+}
+
+describe.skipIf(!ENABLED)("@p0 post-commit lifecycle scenarios", () => {
+  let ctx: ScenarioContext;
+
+  beforeAll(async () => {
+    ctx = await createScenarioContext();
+    const buyerAccount = privateKeyToAccount(ROLE_ACCOUNTS.buyer.privateKey);
+    const buyerWallet = buildWalletClient(buyerAccount);
+    const publicClient = buildPublicClient();
+    // The post-commit lifecycle file commits *multiple* fresh
+    // exchanges (one per test), so over-provision the buyer's
+    // allowance by ~10x the per-commit cap.
+    await ensureBuyerCanPay({
+      walletClient: buyerWallet,
+      publicClient,
+      buyerAddress: buyerAccount.address,
+      assetAddress: LOCAL_31337_0.contracts.testErc20,
+      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      amount: 10_000_000n,
+    });
+  });
+
+  afterAll(async () => {
+    await ctx?.teardown();
+  });
+
+  it("B1 — redeem after deferred commit → REDEEMED", async () => {
+    const exchangeId = await commitFreshExchange(ctx);
+    const result = await performBuyerPostCommitAction({
+      actionId: "boson-redeem",
+      buyer: ctx.buyer,
+      resourceServerUrl: ctx.resourceServerUrl,
+      exchangeId,
+      escrowAddress: ctx.escrowAddress,
+      network: ctx.network,
+    });
+    expect(result.txHash).toMatch(/^0x[0-9a-fA-F]+$/);
+    expect(result.newExchangeState).toBe(ExchangeState.REDEEMED);
+
+    await ctx.asserter.expect(exchangeId, {
+      state: ExchangeState.REDEEMED,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc20,
+      price: "1000000",
+    });
+  });
+
+  it("B2 — completeExchange after redeem → COMPLETED, escrow released", async () => {
+    const exchangeId = await commitFreshExchange(ctx);
+    await performBuyerPostCommitAction({
+      actionId: "boson-redeem",
+      buyer: ctx.buyer,
+      resourceServerUrl: ctx.resourceServerUrl,
+      exchangeId,
+      escrowAddress: ctx.escrowAddress,
+      network: ctx.network,
+    });
+    const completed = await performBuyerPostCommitAction({
+      actionId: "boson-completeExchange",
+      buyer: ctx.buyer,
+      resourceServerUrl: ctx.resourceServerUrl,
+      exchangeId,
+      escrowAddress: ctx.escrowAddress,
+      network: ctx.network,
+    });
+    expect(completed.newExchangeState).toBe(ExchangeState.COMPLETED);
+
+    await ctx.asserter.expect(exchangeId, {
+      state: ExchangeState.COMPLETED,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc20,
+      price: "1000000",
+    });
+  });
+
+  it("B3 — raiseDispute after redeem → DISPUTED + RESOLVING", async () => {
+    const exchangeId = await commitFreshExchange(ctx);
+    await performBuyerPostCommitAction({
+      actionId: "boson-redeem",
+      buyer: ctx.buyer,
+      resourceServerUrl: ctx.resourceServerUrl,
+      exchangeId,
+      escrowAddress: ctx.escrowAddress,
+      network: ctx.network,
+    });
+    const disputed = await performBuyerPostCommitAction({
+      actionId: "boson-raiseDispute",
+      buyer: ctx.buyer,
+      resourceServerUrl: ctx.resourceServerUrl,
+      exchangeId,
+      escrowAddress: ctx.escrowAddress,
+      network: ctx.network,
+    });
+    expect(disputed.newExchangeState).toBe(ExchangeState.DISPUTED);
+    expect(disputed.newDisputeState).toBe(DisputeState.RESOLVING);
+
+    await ctx.asserter.expect(exchangeId, {
+      state: ExchangeState.DISPUTED,
+      disputeState: DisputeState.RESOLVING,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc20,
+      price: "1000000",
+    });
+  });
+
+  it("B4 — mutual resolveDispute (50/50 dual-sig) → RESOLVED", async () => {
+    // Commit → redeem → raiseDispute brings us to the state where
+    // mutual resolveDispute is legal. From here the buyer needs the
+    // seller's signature over `Resolution(exchangeId, buyerPercentBasisPoints)`
+    // — produced by `SellerActor.signResolutionProposal` — as the
+    // `counterpartySig` argument to `client.signAction`.
+    const exchangeId = await commitFreshExchange(ctx);
+    await performBuyerPostCommitAction({
+      actionId: "boson-redeem",
+      buyer: ctx.buyer,
+      resourceServerUrl: ctx.resourceServerUrl,
+      exchangeId,
+      escrowAddress: ctx.escrowAddress,
+      network: ctx.network,
+    });
+    await performBuyerPostCommitAction({
+      actionId: "boson-raiseDispute",
+      buyer: ctx.buyer,
+      resourceServerUrl: ctx.resourceServerUrl,
+      exchangeId,
+      escrowAddress: ctx.escrowAddress,
+      network: ctx.network,
+    });
+
+    // 50/50 split. `buyerPercentBasisPoints` is the canonical wire
+    // unit (10000 = 100 %); the buyer's `signAction` accepts
+    // `buyerPercent` as a `BigNumberish` and forwards the same value
+    // to core-sdk's `signMetaTxResolveDispute`.
+    const buyerPercentBasisPoints = 5000n;
+    const sellerSig = await ctx.seller.signResolutionProposal({
+      exchangeId,
+      buyerPercentBasisPoints,
+    });
+
+    const resolved = await performBuyerPostCommitAction({
+      actionId: "boson-resolveDispute",
+      buyer: ctx.buyer,
+      resourceServerUrl: ctx.resourceServerUrl,
+      exchangeId,
+      escrowAddress: ctx.escrowAddress,
+      network: ctx.network,
+      buyerPercent: buyerPercentBasisPoints,
+      counterpartySig: { r: sellerSig.r, s: sellerSig.s, v: sellerSig.v },
+    });
+    expect(resolved.newDisputeState).toBe(DisputeState.RESOLVED);
+
+    await ctx.asserter.expect(exchangeId, {
+      state: ExchangeState.DISPUTED,
+      disputeState: DisputeState.RESOLVED,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc20,
+      price: "1000000",
+    });
+  });
+});
+
+describe.skipIf(!ENABLED)("@p1 post-commit lifecycle scenarios", () => {
+  let ctx: ScenarioContext;
+
+  beforeAll(async () => {
+    ctx = await createScenarioContext();
+    const buyerAccount = privateKeyToAccount(ROLE_ACCOUNTS.buyer.privateKey);
+    const buyerWallet = buildWalletClient(buyerAccount);
+    const publicClient = buildPublicClient();
+    await ensureBuyerCanPay({
+      walletClient: buyerWallet,
+      publicClient,
+      buyerAddress: buyerAccount.address,
+      assetAddress: LOCAL_31337_0.contracts.testErc20,
+      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      amount: 10_000_000n,
+    });
+  });
+
+  afterAll(async () => {
+    await ctx?.teardown();
+  });
+
+  it("B6 — retractDispute by buyer → RETRACTED (seller wins)", async () => {
+    const exchangeId = await commitFreshExchange(ctx);
+    await performBuyerPostCommitAction({
+      actionId: "boson-redeem",
+      buyer: ctx.buyer,
+      resourceServerUrl: ctx.resourceServerUrl,
+      exchangeId,
+      escrowAddress: ctx.escrowAddress,
+      network: ctx.network,
+    });
+    await performBuyerPostCommitAction({
+      actionId: "boson-raiseDispute",
+      buyer: ctx.buyer,
+      resourceServerUrl: ctx.resourceServerUrl,
+      exchangeId,
+      escrowAddress: ctx.escrowAddress,
+      network: ctx.network,
+    });
+
+    const retracted = await performBuyerPostCommitAction({
+      actionId: "boson-retractDispute",
+      buyer: ctx.buyer,
+      resourceServerUrl: ctx.resourceServerUrl,
+      exchangeId,
+      escrowAddress: ctx.escrowAddress,
+      network: ctx.network,
+    });
+    expect(retracted.newDisputeState).toBe(DisputeState.RETRACTED);
+
+    await ctx.asserter.expect(exchangeId, {
+      state: ExchangeState.DISPUTED,
+      disputeState: DisputeState.RETRACTED,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc20,
+      price: "1000000",
+    });
+  });
+
+  it("B7 — cancelVoucher before redeem → CANCELLED (via facilitator)", async () => {
+    // `cancelVoucher` is buyer-initiated but the example resource
+    // server doesn't mount a `/x402B/cancel` route (it's outside the
+    // happy-path "buy a resource" flow). The facilitator's generic
+    // `POST /perform-action` route still accepts it, so the harness
+    // submits there directly.
+    const exchangeId = await commitFreshExchange(ctx);
+
+    const cancelled = await performCancelVoucher({
+      buyer: ctx.buyer,
+      facilitatorUrl: ctx.facilitatorUrl,
+      exchangeId,
+      escrowAddress: ctx.escrowAddress,
+      network: ctx.network,
+    });
+    expect(cancelled.newExchangeState).toBe(ExchangeState.CANCELLED);
+
+    await ctx.asserter.expect(exchangeId, {
+      state: ExchangeState.CANCELLED,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc20,
+      price: "1000000",
+    });
+  });
+});

--- a/typescript/packages/x402-e2e/test/setup/globalSetup.ts
+++ b/typescript/packages/x402-e2e/test/setup/globalSetup.ts
@@ -170,14 +170,20 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
       `[x402-e2e/globalSetup] suite ready — sellers=${JSON.stringify(sellersBySlot)}, disputeResolverId=${disputeResolverId}`,
     );
   } catch (setupErr) {
-    console.error("[x402-e2e/globalSetup] post-start setup failed, tearing down stack…");
-    try {
-      await stopStack();
-    } catch (teardownErr) {
+    if (KEEP_STACK) {
       console.error(
-        "[x402-e2e/globalSetup] stopStack() failed during teardown after setup error — original setup error will be rethrown:",
-        teardownErr,
+        "[x402-e2e/globalSetup] post-start setup failed; E2E_DOCKER_KEEP_STACK=1 — leaving stack up for debugging.",
       );
+    } else {
+      console.error("[x402-e2e/globalSetup] post-start setup failed, tearing down stack…");
+      try {
+        await stopStack();
+      } catch (teardownErr) {
+        console.error(
+          "[x402-e2e/globalSetup] stopStack() failed during teardown after setup error — original setup error will be rethrown:",
+          teardownErr,
+        );
+      }
     }
     throw setupErr;
   }

--- a/typescript/packages/x402-e2e/test/setup/globalSetup.ts
+++ b/typescript/packages/x402-e2e/test/setup/globalSetup.ts
@@ -133,10 +133,10 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   console.log("[x402-e2e/globalSetup] starting stack…");
   await startStack({ waitForReady: true });
 
-  console.log("[x402-e2e/globalSetup] switching Hardhat to 50 ms interval mining…");
-  await enableIntervalMining();
-
   try {
+    console.log("[x402-e2e/globalSetup] switching Hardhat to 50 ms interval mining…");
+    await enableIntervalMining();
+
     const publicClient = buildPublicClient();
     const sellersBySlot: Record<string, SeedWalletSellerInfo> = {};
     let disputeResolverId: string | undefined;

--- a/typescript/packages/x402-e2e/test/setup/globalSetup.ts
+++ b/typescript/packages/x402-e2e/test/setup/globalSetup.ts
@@ -52,6 +52,24 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     };
   }
 
+  // Defensive `down -v` before `up`: a previous run aborted before its
+  // teardown (Ctrl+C, vitest crash, OS shutdown) leaves containers up
+  // but with stale in-process state — most notably the facilitator's
+  // viem `nonceManager`, which caches the relayer's next-nonce in
+  // memory. Once the chain is redeployed (deploy.done re-runs on
+  // volume reset), the chain expects nonce 0 while the lingering
+  // facilitator process still thinks it's at N+1 → "Nonce too high"
+  // on every meta-tx submit. Tearing the stack down here guarantees
+  // every test run starts from genesis: fresh containers, fresh
+  // in-memory state, fresh chain. The cost is a few extra seconds at
+  // suite startup; the win is determinism.
+  console.log("[x402-e2e/globalSetup] resetting any leftover stack…");
+  try {
+    await stopStack();
+  } catch (e) {
+    console.warn("[x402-e2e/globalSetup] stopStack() before startStack failed — continuing:", e);
+  }
+
   console.log("[x402-e2e/globalSetup] starting stack…");
   await startStack({ waitForReady: true });
 

--- a/typescript/packages/x402-e2e/test/setup/globalSetup.ts
+++ b/typescript/packages/x402-e2e/test/setup/globalSetup.ts
@@ -7,20 +7,19 @@
 //   1. `startStack({ waitForReady: true })` — bring up the canonical
 //      Boson stack + x402B services and block until the contracts +
 //      subgraph `deploy.done` markers exist.
-//   2. `seedSuite({ createSeller: buildCreateSellerCallback(...) })` —
-//      register the seller entity tied to `ROLE_ACCOUNTS.seller`.
-//      Idempotent: re-runs are no-ops because the subgraph already
-//      reports an existing seller for that assistant.
-//   3. Export the seeded state (seller id, dispute resolver id) via
-//      `process.env` so each test file's `beforeAll` can read it
-//      without re-querying the subgraph.
-//
-// Test files MUST also call `describe.skipIf(!process.env.E2E_DOCKER)`
-// or equivalent so they skip cleanly when the gate is off.
+//   2. Register one Boson seller entity per slot in `SEED_WALLETS`.
+//      Each chain-touching test FILE picks a slot — sharing a seller
+//      across parallel files causes `OfferSoldOut` races on FullOffer
+//      signature reuse, so we provision a distinct seller for every
+//      slot the suite knows about. `seedSuite` is idempotent so
+//      re-running on an existing chain state is a no-op.
+//   3. Export per-slot seller info (`{id, address}`) as a JSON map
+//      via `process.env[SELLERS_ENV_KEY]`, plus the protocol-global
+//      dispute resolver id, so each test file's `beforeAll` can read
+//      its slot's seller without re-querying the subgraph.
 
-import { privateKeyToAccount } from "viem/accounts";
+import type { Address } from "viem";
 
-import { ROLE_ACCOUNTS } from "../../src/config/accounts.js";
 import {
   buildCreateSellerCallback,
   buildPublicClient,
@@ -29,10 +28,17 @@ import {
 } from "../../src/harness/index.js";
 import { startStack, stopStack } from "../../src/stack/index.js";
 
+import {
+  SEED_WALLETS,
+  SELLERS_ENV_KEY,
+  type SeedWalletSellerInfo,
+} from "../scenarios/_seed-wallets.js";
+
 /** Env-var keys the scenario tests read from `process.env`. */
 export const SUITE_STATE_ENV = {
-  sellerId: "X402_E2E_SELLER_ID",
-  sellerAddress: "X402_E2E_SELLER_ADDRESS",
+  /** JSON map `{ slotName → { id, address } }` — populated by this setup. */
+  sellers: SELLERS_ENV_KEY,
+  /** Protocol-global dispute resolver id (shared across all sellers). */
   disputeResolverId: "X402_E2E_DISPUTE_RESOLVER_ID",
 } as const;
 
@@ -50,22 +56,37 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   await startStack({ waitForReady: true });
 
   try {
-    const sellerAccount = privateKeyToAccount(ROLE_ACCOUNTS.seller.privateKey);
     const publicClient = buildPublicClient();
-    const walletClient = buildWalletClient(sellerAccount);
+    const sellersBySlot: Record<string, SeedWalletSellerInfo> = {};
+    let disputeResolverId: string | undefined;
 
-    console.log(`[x402-e2e/globalSetup] seeding seller ${sellerAccount.address}…`);
-    const suite = await seedSuite({
-      sellerAddress: sellerAccount.address,
-      createSeller: buildCreateSellerCallback({ walletClient, publicClient }),
-    });
+    for (const [slotName, slot] of Object.entries(SEED_WALLETS)) {
+      const walletClient = buildWalletClient(slot.account);
+      console.log(
+        `[x402-e2e/globalSetup] seeding seller for slot "${slotName}" (${slot.account.address})…`,
+      );
+      const suite = await seedSuite({
+        sellerAddress: slot.account.address,
+        createSeller: buildCreateSellerCallback({ walletClient, publicClient }),
+      });
+      sellersBySlot[slotName] = {
+        id: suite.seller.id,
+        address: suite.seller.assistant as Address,
+      };
+      // The dispute resolver is a protocol-global entity (`id: 1` on the
+      // local stack); every slot's `seedSuite` returns the same value.
+      disputeResolverId = suite.disputeResolverId;
+    }
 
-    process.env[SUITE_STATE_ENV.sellerId] = suite.seller.id;
-    process.env[SUITE_STATE_ENV.sellerAddress] = suite.seller.assistant;
-    process.env[SUITE_STATE_ENV.disputeResolverId] = suite.disputeResolverId;
+    if (disputeResolverId === undefined) {
+      throw new Error("[x402-e2e/globalSetup] no slots registered — SEED_WALLETS is empty?");
+    }
+
+    process.env[SUITE_STATE_ENV.sellers] = JSON.stringify(sellersBySlot);
+    process.env[SUITE_STATE_ENV.disputeResolverId] = disputeResolverId;
 
     console.log(
-      `[x402-e2e/globalSetup] suite ready — sellerId=${suite.seller.id}, disputeResolverId=${suite.disputeResolverId}`,
+      `[x402-e2e/globalSetup] suite ready — sellers=${JSON.stringify(sellersBySlot)}, disputeResolverId=${disputeResolverId}`,
     );
   } catch (setupErr) {
     console.error("[x402-e2e/globalSetup] post-start setup failed, tearing down stack…");

--- a/typescript/packages/x402-e2e/test/setup/globalSetup.ts
+++ b/typescript/packages/x402-e2e/test/setup/globalSetup.ts
@@ -7,19 +7,37 @@
 //   1. `startStack({ waitForReady: true })` — bring up the canonical
 //      Boson stack + x402B services and block until the contracts +
 //      subgraph `deploy.done` markers exist.
-//   2. Register one Boson seller entity per slot in `SEED_WALLETS`.
+//   2. Switch the chain from default automine to a 50 ms mining
+//      interval (see `enableIntervalMining` below). Concurrent
+//      meta-tx submissions only queue in the mempool when automine
+//      is off — under automine Hardhat rejects everything that isn't
+//      the next-next nonce.
+//   3. Register one Boson seller entity per slot in `SEED_WALLETS`.
 //      Each chain-touching test FILE picks a slot — sharing a seller
 //      across parallel files causes `OfferSoldOut` races on FullOffer
 //      signature reuse, so we provision a distinct seller for every
 //      slot the suite knows about. `seedSuite` is idempotent so
 //      re-running on an existing chain state is a no-op.
-//   3. Export per-slot seller info (`{id, address}`) as a JSON map
+//   4. Export per-slot seller info (`{id, address}`) as a JSON map
 //      via `process.env[SELLERS_ENV_KEY]`, plus the protocol-global
 //      dispute resolver id, so each test file's `beforeAll` can read
 //      its slot's seller without re-querying the subgraph.
+//
+// Standalone-run escape hatch — `E2E_DOCKER_KEEP_STACK=1`:
+//   When set alongside `E2E_DOCKER=1`, the setup skips BOTH the
+//   defensive pre-start `stopStack()` AND the post-suite teardown.
+//   `startStack({ waitForReady: true })` is still called (`docker
+//   compose up -d --wait` is idempotent and returns ~instantly when
+//   every container is already healthy) and seller seeding still
+//   runs (`seedSuite` is itself idempotent). The caller's contract:
+//   "the stack I brought up matches the facilitator's view of the
+//   chain — don't touch it." Use this when iterating on a single
+//   scenario file against a stack you launched manually via
+//   `pnpm stack:up`.
 
 import type { Address } from "viem";
 
+import { LOCAL_31337_0 } from "../../src/config/local-31337-0.js";
 import {
   buildCreateSellerCallback,
   buildPublicClient,
@@ -43,6 +61,40 @@ export const SUITE_STATE_ENV = {
 } as const;
 
 const ENABLED = process.env.E2E_DOCKER === "1";
+const KEEP_STACK = process.env.E2E_DOCKER_KEEP_STACK === "1";
+
+/**
+ * Switch the local Hardhat chain from automine to a 50 ms mining
+ * interval. Concurrent meta-tx submissions through the facilitator
+ * (e.g. `concurrent.test.ts`'s 20 parallel buyers) only queue in the
+ * mempool when automine is OFF — under default automine Hardhat
+ * rejects every tx whose nonce isn't already-next with
+ * `"transactions can't be queued when automining"`. The 50 ms cadence
+ * keeps the sequential seeding phase fast (~1.5 s for the ~30 txs
+ * across all `SEED_WALLETS` slots) while letting a burst of 20+
+ * concurrent commits land in one or two blocks.
+ *
+ * Idempotent: re-invoking on an already-interval-mining chain just
+ * resets the timer. Called every globalSetup invocation so the
+ * KEEP_STACK fast-path doesn't have to remember the prior setting.
+ */
+async function enableIntervalMining(): Promise<void> {
+  const rpc = LOCAL_31337_0.urls.jsonRpc;
+  const post = async (method: string, params: unknown[]): Promise<unknown> => {
+    const res = await fetch(rpc, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+    const body = (await res.json()) as { result?: unknown; error?: { message: string } };
+    if (body.error !== undefined) {
+      throw new Error(`[x402-e2e/globalSetup] ${method} failed: ${body.error.message}`);
+    }
+    return body.result;
+  };
+  await post("evm_setAutomine", [false]);
+  await post("evm_setIntervalMining", [50]);
+}
 
 export default async function globalSetup(): Promise<() => Promise<void>> {
   if (!ENABLED) {
@@ -52,26 +104,37 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     };
   }
 
-  // Defensive `down -v` before `up`: a previous run aborted before its
-  // teardown (Ctrl+C, vitest crash, OS shutdown) leaves containers up
-  // but with stale in-process state — most notably the facilitator's
-  // viem `nonceManager`, which caches the relayer's next-nonce in
-  // memory. Once the chain is redeployed (deploy.done re-runs on
-  // volume reset), the chain expects nonce 0 while the lingering
-  // facilitator process still thinks it's at N+1 → "Nonce too high"
-  // on every meta-tx submit. Tearing the stack down here guarantees
-  // every test run starts from genesis: fresh containers, fresh
-  // in-memory state, fresh chain. The cost is a few extra seconds at
-  // suite startup; the win is determinism.
-  console.log("[x402-e2e/globalSetup] resetting any leftover stack…");
-  try {
-    await stopStack();
-  } catch (e) {
-    console.warn("[x402-e2e/globalSetup] stopStack() before startStack failed — continuing:", e);
+  if (KEEP_STACK) {
+    // Caller asserts they brought the stack up themselves (via
+    // `pnpm stack:up` or a previous KEEP_STACK run) and want it left
+    // running afterwards. Skip the defensive `stopStack()` — tearing
+    // down would defeat the whole purpose of the flag.
+    console.log("[x402-e2e/globalSetup] E2E_DOCKER_KEEP_STACK=1 — using existing stack as-is…");
+  } else {
+    // Defensive `down -v` before `up`: a previous run aborted before its
+    // teardown (Ctrl+C, vitest crash, OS shutdown) leaves containers up
+    // but with stale in-process state — most notably the facilitator's
+    // viem `nonceManager`, which caches the relayer's next-nonce in
+    // memory. Once the chain is redeployed (deploy.done re-runs on
+    // volume reset), the chain expects nonce 0 while the lingering
+    // facilitator process still thinks it's at N+1 → "Nonce too high"
+    // on every meta-tx submit. Tearing the stack down here guarantees
+    // every test run starts from genesis: fresh containers, fresh
+    // in-memory state, fresh chain. The cost is a few extra seconds at
+    // suite startup; the win is determinism.
+    console.log("[x402-e2e/globalSetup] resetting any leftover stack…");
+    try {
+      await stopStack();
+    } catch (e) {
+      console.warn("[x402-e2e/globalSetup] stopStack() before startStack failed — continuing:", e);
+    }
   }
 
   console.log("[x402-e2e/globalSetup] starting stack…");
   await startStack({ waitForReady: true });
+
+  console.log("[x402-e2e/globalSetup] switching Hardhat to 50 ms interval mining…");
+  await enableIntervalMining();
 
   try {
     const publicClient = buildPublicClient();
@@ -120,6 +183,12 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   }
 
   return async () => {
+    if (KEEP_STACK) {
+      console.log(
+        "[x402-e2e/globalSetup] E2E_DOCKER_KEEP_STACK=1 — preserving stack; run `pnpm stack:down` manually when done.",
+      );
+      return;
+    }
     console.log("[x402-e2e/globalSetup] tearing down stack…");
     await stopStack();
   };

--- a/typescript/packages/x402-e2e/vitest.config.ts
+++ b/typescript/packages/x402-e2e/vitest.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from "vitest/config";
 
+// Debug fallback: set `E2E_SEQUENTIAL=1` to disable cross-file
+// parallelism. The suite is designed to be parallel-safe via the
+// per-describe seed-wallet pool (see `test/scenarios/_seed-wallets.ts`);
+// this knob exists only as an escape hatch when debugging suspected
+// chain-state interactions across files.
+const SEQUENTIAL = process.env.E2E_SEQUENTIAL === "1";
+
 export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
@@ -15,5 +22,6 @@ export default defineConfig({
     // wiring — flipping the gate runs the suite end-to-end without any
     // config change.
     globalSetup: ["./test/setup/globalSetup.ts"],
+    ...(SEQUENTIAL ? { fileParallelism: false } : {}),
   },
 });

--- a/typescript/packages/x402-e2e/vitest.config.ts
+++ b/typescript/packages/x402-e2e/vitest.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from "vitest/config";
 
 // Debug fallback: set `E2E_SEQUENTIAL=1` to disable cross-file
-// parallelism. The suite is designed to be parallel-safe via the
-// per-describe seed-wallet pool (see `test/scenarios/_seed-wallets.ts`);
+// parallelism. The suite is designed to be parallel-safe via
+// per-file seed-wallet slots (see `test/scenarios/_seed-wallets.ts`);
 // this knob exists only as an escape hatch when debugging suspected
 // chain-state interactions across files.
 const SEQUENTIAL = process.env.E2E_SEQUENTIAL === "1";


### PR DESCRIPTION
## Summary

Picks up the e2e suite where #74 left off (A1 only). Adds the @p0/@p1 buyer-driven post-commit lifecycle scenarios and applies the two robustness cleanups carried over from PR6.

**New scenarios** in [`typescript/packages/x402-e2e/test/scenarios/`](typescript/packages/x402-e2e/test/scenarios/):

- [`commit.test.ts`](typescript/packages/x402-e2e/test/scenarios/commit.test.ts) — promotes **A2** (atomic commit-and-redeem via `Policy.redeemMode: \"commit-and-redeem\"`) from `it.todo` to runnable.
- New [`post-commit.test.ts`](typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts):
  - **B1** redeem after deferred commit → `REDEEMED`
  - **B2** completeExchange after redeem → `COMPLETED`
  - **B3** raiseDispute after redeem → `DISPUTED` + `RESOLVING`
  - **B4** mutual resolveDispute (50/50 dual-sig) → `RESOLVED`
  - **B6** retractDispute by buyer → `RETRACTED`
  - **B7** cancelVoucher before redeem → `CANCELLED` (driven via the facilitator since server-express doesn't mount a `/cancel` route)

Each post-commit test starts from a fresh commit driven through the same 402 retry A1 uses, then drives the transition under test.

**Harness extensions:**

- [`SellerActor.signResolutionProposal`](typescript/packages/x402-e2e/src/harness/seller-actor.ts) — produces the `counterpartySig` the buyer needs for mutual resolveDispute. Routes through `coreSdk.signDisputeResolutionProposal` so the EIP-712 typed-data stays in lock-step with the deployed protocol.
- New [`post-commit-http.ts`](typescript/packages/x402-e2e/src/harness/post-commit-http.ts) — `performBuyerPostCommitAction` wraps `buyer.client.signAction(...)` + POST to `/x402B/{redeem,complete,dispute/{raise,resolve,retract,escalate}}`.
- New [`facilitator-perform-action.ts`](typescript/packages/x402-e2e/src/harness/facilitator-perform-action.ts) — `performCancelVoucher` reaches the facilitator's `POST /perform-action` directly.
- [`BuyerActor`](typescript/packages/x402-e2e/src/harness/buyer-actor.ts) now accepts an optional `policy` override (needed by A2).

**PR6 cleanups** (the two robustness items the A1 PR called out as follow-ups):

- [`exchange-reader.ts`](typescript/packages/x402-e2e/src/harness/exchange-reader.ts) now accepts a viem `PublicClient`; on a `null` `getExchangeById` it fetches the chain head and calls `coreSdk.waitForGraphNodeIndexing(blockNumber)` before forwarding `null` — the canonical \"indexer caught up\" wait, replacing reliance on the outer poll loop alone.
- New [`examples/resource-server/src/protocol-config.ts`](examples/resource-server/src/protocol-config.ts) — `fetchProtocolConfig` reads `ConfigHandlerFacet.getMaxTotalOfferFeePercentage()` + `getMinDisputePeriod()`. [`offer.ts`](examples/resource-server/src/offer.ts) tightens `feeLimit = price * maxFeeBps / 10000` and floors `disputePeriodDurationInMS` against the on-chain minimum. Backwards-compatible: `protocolConfig` is an optional arg, so the example's existing unit tests still pass without changes.

## Out of scope (deferred to follow-up PRs)

- A3–A5 (per-strategy `erc3009` / `permit` / `permit2` token-auth)
- B5 escalateDispute (DR-deposit handling)
- B8 revokeVoucher (SellerActor meta-tx signing)
- B9 decideDispute (ResolverActor wallet signing)
- C/D/E scenarios (validation negatives, nextActions assertions, multi-party)

## Test plan

- [ ] `pnpm build` — workspace builds clean
- [ ] `pnpm test` — offline unit tests pass; scenario tests skip cleanly without `E2E_DOCKER=1`
- [ ] `pnpm lint` + `pnpm format:check` — clean
- [ ] `E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test` — all enabled scenarios green end-to-end against the local Boson stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request session IDs with a shared session header export.
  * Action-aware meta-transaction typed-data and signer recovery.
  * Protocol-driven offer parameters with on-chain config fetch and session-scoped payment-requirements cache.
  * New e2e harnesses: seeded seed-wallet slots, funded-buyer helper, buyer/facilitator post-commit helpers, facilitator voucher actions, seller resolution signing, and safe-stringify utility.
  * Client token-auth deadline utility; improved Docker multi-stage build caching.

* **Bug Fixes**
  * Relayer nonce management to prevent concurrent nonce races.

* **Tests**
  * Expanded e2e scenarios, additional accounts, concurrency/load tests, and optional sequential debug mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->