### PR TITLE
feat(server-express): add paywall + paywallConfig options

### DIFF
--- a/.changeset/resource-server-example-paywall.md
+++ b/.changeset/resource-server-example-paywall.md
@@ -1,0 +1,19 @@
+---
+"@bosonprotocol/x402-example-resource-server": minor
+"@bosonprotocol/x402-server-express": patch
+---
+
+Wire the optional `paywall` + `paywallConfig` options through
+`createResourceServerApp` to the underlying `expressMiddleware` and
+`mountX402b` calls. Setting any `PAYWALL_*` env var
+(`PAYWALL_APP_NAME`, `PAYWALL_WALLETCONNECT_PROJECT_ID`,
+`PAYWALL_TESTNET`) populates a `paywall` block on the parsed env;
+forks of the example binary can then import `evmEscrowPaywall` from
+`@bosonprotocol/x402-paywall` and forward both into the app to get
+HTML 402 bodies for browser User-Agents.
+
+Also widens `PaywallConfigLike` in `@bosonprotocol/x402-server-express`
+from `Record<string, unknown>` to `object` so concrete `PaywallConfig`
+shapes (with named optional fields, no index signature) satisfy it
+structurally — required for the demo example to typecheck without
+casts.

--- a/.changeset/server-express-paywall-option.md
+++ b/.changeset/server-express-paywall-option.md
@@ -9,3 +9,11 @@ document via `paywall.generateHtml(...)` instead of the canonical JSON
 body — pairing naturally with `@bosonprotocol/x402-paywall`'s
 `evmEscrowPaywall`. Non-browser clients always get JSON, and the
 paywall path never fires on the settle phase (X-PAYMENT present).
+
+The 402 challenge response now sets `Cache-Control: no-store` and
+`Vary: Accept` on both branches so an intermediary cache cannot store
+the per-request body or cross-serve HTML to a JSON client. A new
+`currentUrl?: string | ((req) => string)` option on both adapters lets
+deployments behind a TLS-terminating proxy pin the canonical retry URL
+embedded in the paywall HTML — useful when `app.set('trust proxy', ...)`
+alone isn't sufficient.

--- a/.changeset/server-express-paywall-option.md
+++ b/.changeset/server-express-paywall-option.md
@@ -1,0 +1,11 @@
+---
+"@bosonprotocol/x402-server-express": minor
+---
+
+Add optional `paywall` + `paywallConfig` to `ExpressMiddlewareOptions`
+and `MountX402bOptions`. When supplied and the request's `Accept`
+header prefers `text/html`, the 402 challenge is rendered as an HTML
+document via `paywall.generateHtml(...)` instead of the canonical JSON
+body — pairing naturally with `@bosonprotocol/x402-paywall`'s
+`evmEscrowPaywall`. Non-browser clients always get JSON, and the
+paywall path never fires on the settle phase (X-PAYMENT present).

--- a/examples/resource-server/README.md
+++ b/examples/resource-server/README.md
@@ -82,14 +82,18 @@ Then `curl http://localhost:4001/resource` returns 402 + the
 
 ### Browser paywall
 
-Set any `PAYWALL_*` env var (e.g. `PAYWALL_APP_NAME="My App"`) to
-enable the HTML paywall. Programmatic clients (anything that doesn't
-send `Accept: text/html`) still get JSON 402s — the content-negotiation
-gate lives in
-[`@bosonprotocol/x402-server-express`](../../typescript/packages/server-express),
-which this example wires up via `createResourceServerApp(env, { paywall, paywallConfig })`.
-Browse to `http://localhost:4001/resource` to see the paywall — the
-React app renders the offer, lets the buyer connect a wallet
+Setting any `PAYWALL_*` env var (e.g. `PAYWALL_APP_NAME="My App"`)
+populates `env.paywall` / `paywallConfig`; by itself, that does **not**
+make this repo's default binary serve the HTML paywall. HTML 402s are
+only returned when a `paywall` provider (for example
+`evmEscrowPaywall`) is actually passed into
+`createResourceServerApp(env, { paywall, paywallConfig })`.
+Programmatic clients (anything that doesn't send `Accept: text/html`)
+still get JSON 402s — the content-negotiation gate lives in
+[`@bosonprotocol/x402-server-express`](../../typescript/packages/server-express).
+If you wire a paywall provider into a fork/custom entrypoint, browsing
+to `http://localhost:4001/resource` will show the paywall: the React
+app renders the offer, lets the buyer connect a wallet
 (injected / Coinbase / optionally WalletConnect), drives the atomic
 commit-and-redeem flow, and swaps in the gated resource on success.
 

--- a/examples/resource-server/README.md
+++ b/examples/resource-server/README.md
@@ -50,6 +50,9 @@ this host adds no protocol logic of its own.
 | `MAX_TIMEOUT_SECONDS` | no  | `3600` | `PaymentRequirements.maxTimeoutSeconds`. Capped at 24 h. |
 | `SUBGRAPH_URL`        | no  | — | Optional Boson subgraph URL — required for `getAvailableFunds` / `withdrawFunds`. |
 | `PORT`                | no  | `4001` | HTTP listen port. |
+| `PAYWALL_APP_NAME`    | no  | — | Display name in the paywall UI + wagmi connector identity. Setting any `PAYWALL_*` var enables the HTML paywall path. |
+| `PAYWALL_WALLETCONNECT_PROJECT_ID` | no | — | Enables the WalletConnect connector; omit for injected + Coinbase only. |
+| `PAYWALL_TESTNET`     | no  | `false` | `true` / `1` surfaces a "testnet" badge in the paywall UI. |
 
 ## Run locally
 
@@ -76,6 +79,19 @@ pnpm --filter @bosonprotocol/x402-example-resource-server start
 
 Then `curl http://localhost:4001/resource` returns 402 + the
 `PaymentRequirements` echoed from your env.
+
+### Browser paywall
+
+Set any `PAYWALL_*` env var (e.g. `PAYWALL_APP_NAME="My App"`) to
+enable the HTML paywall. Programmatic clients (anything that doesn't
+send `Accept: text/html`) still get JSON 402s — the content-negotiation
+gate lives in
+[`@bosonprotocol/x402-server-express`](../../typescript/packages/server-express),
+which this example wires up via `createResourceServerApp(env, { paywall, paywallConfig })`.
+Browse to `http://localhost:4001/resource` to see the paywall — the
+React app renders the offer, lets the buyer connect a wallet
+(injected / Coinbase / optionally WalletConnect), drives the atomic
+commit-and-redeem flow, and swaps in the gated resource on success.
 
 ## Run in Docker
 

--- a/examples/resource-server/package.json
+++ b/examples/resource-server/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@bosonprotocol/x402-actions": "workspace:^",
     "@bosonprotocol/x402-core": "workspace:^",
+    "@bosonprotocol/x402-paywall": "workspace:^",
     "@bosonprotocol/x402-server": "workspace:^",
     "@bosonprotocol/x402-server-express": "workspace:^",
     "express": "^4.21.2",

--- a/examples/resource-server/src/app.ts
+++ b/examples/resource-server/src/app.ts
@@ -20,6 +20,7 @@
 //    reader can be built from the env (see README).
 
 import type { EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
+import type { PaywallConfig, PaywallProvider } from "@bosonprotocol/x402-paywall";
 import {
   createX402bServer,
   type ExchangeReader,
@@ -43,6 +44,17 @@ export interface ResourceServerAppOptions {
   exchangeReader: ExchangeReader;
   /** Replace `Date.now()` for deterministic offer-validity windows in tests. */
   now?: () => number;
+  /**
+   * Optional paywall provider — typically `evmEscrowPaywall` from
+   * `@bosonprotocol/x402-paywall`. When supplied, browser User-Agents
+   * hitting `/resource` (i.e. requests preferring `text/html`) get a
+   * full HTML paywall body instead of the JSON 402; programmatic
+   * clients still see JSON. The `paywallConfig` is forwarded to the
+   * paywall's `generateHtml(...)` as the second argument.
+   */
+  paywall?: PaywallProvider;
+  /** Forwarded to `paywall.generateHtml(...)`. Ignored when `paywall` is omitted. */
+  paywallConfig?: PaywallConfig;
 }
 
 export interface ResourceServerAppBundle {
@@ -134,15 +146,29 @@ export function createResourceServerApp(
     }
   });
 
-  app.get("/resource", expressMiddleware(server, { resolveRequirements }), (_req, res) => {
-    res.json({
-      ok: true,
-      x402b: res.locals.x402b,
-      resource: "example resource bytes",
-    });
-  });
+  app.get(
+    "/resource",
+    expressMiddleware(server, {
+      resolveRequirements,
+      ...(options.paywall !== undefined ? { paywall: options.paywall } : {}),
+      ...(options.paywallConfig !== undefined ? { paywallConfig: options.paywallConfig } : {}),
+    }),
+    (_req, res) => {
+      res.json({
+        ok: true,
+        x402b: res.locals.x402b,
+        resource: "example resource bytes",
+      });
+    },
+  );
 
-  app.use(mountX402b(server, { resolveRequirements }));
+  app.use(
+    mountX402b(server, {
+      resolveRequirements,
+      ...(options.paywall !== undefined ? { paywall: options.paywall } : {}),
+      ...(options.paywallConfig !== undefined ? { paywallConfig: options.paywallConfig } : {}),
+    }),
+  );
 
   app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
     const status =

--- a/examples/resource-server/src/app.ts
+++ b/examples/resource-server/src/app.ts
@@ -146,12 +146,22 @@ export function createResourceServerApp(
     }
   });
 
+  // `paywallConfig` is only forwarded alongside `paywall`: the adapters
+  // ignore `paywallConfig` when no provider is set, and surfacing the
+  // pairing here keeps the example from modelling an ambiguous config.
+  const paywallOptions =
+    options.paywall !== undefined
+      ? {
+          paywall: options.paywall,
+          ...(options.paywallConfig !== undefined ? { paywallConfig: options.paywallConfig } : {}),
+        }
+      : {};
+
   app.get(
     "/resource",
     expressMiddleware(server, {
       resolveRequirements,
-      ...(options.paywall !== undefined ? { paywall: options.paywall } : {}),
-      ...(options.paywallConfig !== undefined ? { paywallConfig: options.paywallConfig } : {}),
+      ...paywallOptions,
     }),
     (_req, res) => {
       res.json({
@@ -165,8 +175,7 @@ export function createResourceServerApp(
   app.use(
     mountX402b(server, {
       resolveRequirements,
-      ...(options.paywall !== undefined ? { paywall: options.paywall } : {}),
-      ...(options.paywallConfig !== undefined ? { paywallConfig: options.paywallConfig } : {}),
+      ...paywallOptions,
     }),
   );
 

--- a/examples/resource-server/src/config.ts
+++ b/examples/resource-server/src/config.ts
@@ -34,6 +34,22 @@ export interface ResourceServerEnv {
   subgraphUrl?: string;
   /** HTTP listen port. */
   port: number;
+  /**
+   * Paywall config block. Populated only when at least one
+   * `PAYWALL_*` env var is set; otherwise `undefined` and the
+   * resource server serves JSON-only 402s. Pair-shipped with
+   * the `paywall` option on `createResourceServerApp` — the binary
+   * passes both together so a fork can opt into the HTML paywall by
+   * setting env vars and importing `evmEscrowPaywall`.
+   */
+  paywall?: {
+    /** Display name used in the paywall UI + wagmi connector identity. */
+    appName?: string;
+    /** Enables the WalletConnect connector. Omit for injected + Coinbase only. */
+    walletConnectProjectId?: string;
+    /** Surface a "testnet" badge in the paywall UI. */
+    testnet: boolean;
+  };
 }
 
 function required(name: string): string {
@@ -117,5 +133,31 @@ export function readEnv(): ResourceServerEnv {
       ? { subgraphUrl: asHttpUrl(subgraphRaw, "SUBGRAPH_URL") }
       : {}),
     port: asInt(optional("PORT", "4001"), "PORT", { min: 1, max: 65535 }),
+    ...(readPaywallEnv() !== undefined ? { paywall: readPaywallEnv() } : {}),
+  };
+}
+
+/**
+ * Build the paywall config from `PAYWALL_*` env vars. Returns
+ * `undefined` when no paywall env var is set, signalling that the
+ * resource server should not enable the HTML paywall path. Any
+ * non-empty `PAYWALL_*` var opts in; `PAYWALL_TESTNET` defaults to
+ * `false` when the block is enabled but the var is unset.
+ */
+function readPaywallEnv(): ResourceServerEnv["paywall"] {
+  const appName = process.env.PAYWALL_APP_NAME;
+  const walletConnectProjectId = process.env.PAYWALL_WALLETCONNECT_PROJECT_ID;
+  const testnetRaw = process.env.PAYWALL_TESTNET;
+  const anySet =
+    (appName !== undefined && appName.length > 0) ||
+    (walletConnectProjectId !== undefined && walletConnectProjectId.length > 0) ||
+    (testnetRaw !== undefined && testnetRaw.length > 0);
+  if (!anySet) return undefined;
+  return {
+    ...(appName !== undefined && appName.length > 0 ? { appName } : {}),
+    ...(walletConnectProjectId !== undefined && walletConnectProjectId.length > 0
+      ? { walletConnectProjectId }
+      : {}),
+    testnet: testnetRaw === "true" || testnetRaw === "1",
   };
 }

--- a/examples/resource-server/src/config.ts
+++ b/examples/resource-server/src/config.ts
@@ -113,6 +113,7 @@ function asHttpUrl(value: string, name: string): string {
 export function readEnv(): ResourceServerEnv {
   const chainId = asInt(optional("CHAIN_ID", "31337"), "CHAIN_ID", { min: 1 });
   const subgraphRaw = process.env.SUBGRAPH_URL;
+  const paywall = readPaywallEnv();
   return {
     publicUrl: asHttpUrl(required("RESOURCE_SERVER_URL"), "RESOURCE_SERVER_URL"),
     rpcNode: asHttpUrl(required("RPC_NODE"), "RPC_NODE"),
@@ -133,7 +134,7 @@ export function readEnv(): ResourceServerEnv {
       ? { subgraphUrl: asHttpUrl(subgraphRaw, "SUBGRAPH_URL") }
       : {}),
     port: asInt(optional("PORT", "4001"), "PORT", { min: 1, max: 65535 }),
-    ...(readPaywallEnv() !== undefined ? { paywall: readPaywallEnv() } : {}),
+    ...(paywall !== undefined ? { paywall } : {}),
   };
 }
 

--- a/examples/resource-server/src/index.ts
+++ b/examples/resource-server/src/index.ts
@@ -23,8 +23,17 @@ if (isMain) {
 // Reference assembly for forks — once `exchangeReader` is wired in,
 // replace the throw above with:
 //
+//   import { evmEscrowPaywall } from "@bosonprotocol/x402-paywall";
+//
 //   const env = readEnv();
-//   const { app, seller } = createResourceServerApp(env, { exchangeReader });
+//   const { app, seller } = createResourceServerApp(env, {
+//     exchangeReader,
+//     // Opt-in HTML paywall for browser User-Agents; programmatic
+//     // clients keep seeing JSON 402s.
+//     ...(env.paywall !== undefined
+//       ? { paywall: evmEscrowPaywall, paywallConfig: env.paywall }
+//       : {}),
+//   });
 //   app.listen(env.port, () => {
 //     console.log(
 //       `[resource-server] listening on :${env.port} (chain ${env.chainId}, seller ${seller.address}, asset ${env.assetAddress})`,

--- a/examples/resource-server/test/resource-server.test.ts
+++ b/examples/resource-server/test/resource-server.test.ts
@@ -290,4 +290,68 @@ describe("resource-server example app", () => {
     expect(settle.body.exchangeId).toBe("42");
     expect(settle.body.txHash).toBe("0xabc");
   });
+
+  // Paywall integration — verifies that the `paywall` / `paywallConfig`
+  // options flow from `createResourceServerApp` through to
+  // `expressMiddleware` and `mountX402b`. Uses a tiny stub
+  // `PaywallProvider`; the real `evmEscrowPaywall` is exercised
+  // end-to-end through the middleware in `@bosonprotocol/x402-server-express`'s
+  // own test suite, so reusing the 4.7 MB bundle here would just
+  // duplicate that work (and choke supertest on the response size).
+  it("GET /resource with Accept: text/html and no paywall configured still returns JSON (no regression)", async () => {
+    const { app } = createResourceServerApp(buildEnv(), { exchangeReader: NULL_READER });
+    const res = await supertest(app).get("/resource").set("Accept", "text/html");
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.body.x402Version).toBe(2);
+  });
+
+  it("GET /resource with Accept: text/html + paywall configured returns HTML 402 (wiring through expressMiddleware)", async () => {
+    const stubPaywall = {
+      supports: vi.fn().mockReturnValue(true),
+      generateHtml: vi
+        .fn()
+        .mockReturnValue('<!DOCTYPE html><html><body data-from="stub">x</body></html>'),
+    };
+
+    const { app } = createResourceServerApp(buildEnv(), {
+      exchangeReader: NULL_READER,
+      paywall: stubPaywall,
+      paywallConfig: { appName: "Demo", testnet: true },
+    });
+
+    const res = await supertest(app).get("/resource").set("Accept", "text/html");
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/text\/html/);
+    expect(res.text).toContain('data-from="stub"');
+    expect(stubPaywall.generateHtml).toHaveBeenCalledTimes(1);
+    // The example forwards `paywallConfig` straight through.
+    expect(stubPaywall.generateHtml).toHaveBeenCalledWith(
+      expect.objectContaining({ requirements: expect.objectContaining({ scheme: "escrow" }) }),
+      { appName: "Demo", testnet: true },
+    );
+  });
+
+  it("POST /x402B/commit with Accept: text/html + paywall configured returns HTML 402 (wiring through mountX402b)", async () => {
+    const stubPaywall = {
+      supports: vi.fn().mockReturnValue(true),
+      generateHtml: vi
+        .fn()
+        .mockReturnValue('<!DOCTYPE html><html><body data-from="commit-stub">y</body></html>'),
+    };
+
+    const { app } = createResourceServerApp(buildEnv(), {
+      exchangeReader: NULL_READER,
+      paywall: stubPaywall,
+    });
+
+    const res = await supertest(app).post("/x402B/commit").set("Accept", "text/html").send();
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/text\/html/);
+    expect(res.text).toContain('data-from="commit-stub"');
+    expect(stubPaywall.generateHtml).toHaveBeenCalledTimes(1);
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@bosonprotocol/x402-core':
         specifier: workspace:^
         version: link:../../typescript/packages/core
+      '@bosonprotocol/x402-paywall':
+        specifier: workspace:^
+        version: link:../../typescript/packages/paywall
       '@bosonprotocol/x402-server':
         specifier: workspace:^
         version: link:../../typescript/packages/server

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,10 +433,10 @@ importers:
         version: 19.2.6(react@19.2.6)
       viem:
         specifier: ^2.39.3
-        version: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       wagmi:
         specifier: ^2.14.0
-        version: 2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        version: 2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: ^20.17.10
@@ -521,6 +521,9 @@ importers:
       '@bosonprotocol/x402-evm':
         specifier: workspace:^
         version: link:../evm
+      '@bosonprotocol/x402-paywall':
+        specifier: workspace:^
+        version: link:../paywall
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -4988,16 +4991,16 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
-  '@base-org/account@2.4.0(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@base-org/account@2.4.0(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@coinbase/cdp-sdk': 1.49.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.6.9(typescript@5.9.3)(zod@4.4.3)
       preact: 10.24.2
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zustand: 5.0.3(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
     transitivePeerDependencies:
       - '@types/react'
@@ -5227,15 +5230,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.6.9(typescript@5.9.3)(zod@4.4.3)
       preact: 10.24.2
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zustand: 5.0.3(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
     transitivePeerDependencies:
       - '@types/react'
@@ -5771,11 +5774,11 @@ snapshots:
       '@ethersproject/properties': 5.8.0
       '@ethersproject/strings': 5.8.0
 
-  '@gemini-wallet/core@0.3.2(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@gemini-wallet/core@0.3.2(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
     dependencies:
       '@metamask/rpc-errors': 7.0.2
       eventemitter3: 5.0.1
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6098,24 +6101,24 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-common@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-common@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-controllers@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       valtio: 1.13.2(@types/react@19.2.15)(react@19.2.6)
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6144,12 +6147,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-pay@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-pay@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@4.4.3)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@19.2.15)(react@19.2.6)
     transitivePeerDependencies:
@@ -6184,12 +6187,12 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@3.25.76)':
+  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@4.4.3)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@4.4.3)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
     transitivePeerDependencies:
@@ -6221,10 +6224,10 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-ui@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-ui@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -6256,16 +6259,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@3.25.76)':
+  '@reown/appkit-utils@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@4.4.3)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@reown/appkit-polyfills': 1.7.8
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       valtio: 1.13.2(@types/react@19.2.15)(react@19.2.6)
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6305,21 +6308,21 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reown/appkit@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-pay': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-pay': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@3.25.76)
+      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@4.4.3)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@4.4.3)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.21.0
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.15)(react@19.2.6)
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6423,9 +6426,9 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
-  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       events: 3.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -6433,10 +6436,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -7176,19 +7179,19 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
-  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
+  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)))(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@base-org/account': 2.4.0(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@gemini-wallet/core': 0.3.2(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@base-org/account': 2.4.0(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@gemini-wallet/core': 0.3.2(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       '@metamask/sdk': 0.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      porto: 0.2.35(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3))
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -7229,11 +7232,11 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/core@2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@wagmi/core@2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
     optionalDependencies:
       '@tanstack/query-core': 5.100.11
@@ -7244,7 +7247,7 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -7258,7 +7261,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -7288,7 +7291,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/core@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -7302,7 +7305,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -7336,18 +7339,18 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@reown/appkit': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/types': 2.21.1
-      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7470,16 +7473,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/sign-client@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@walletconnect/core': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/core': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7506,16 +7509,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7604,7 +7607,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/universal-provider@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/universal-provider@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -7613,9 +7616,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -7644,7 +7647,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -7653,9 +7656,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -7684,7 +7687,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/utils@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -7702,7 +7705,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -7728,7 +7731,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -7746,7 +7749,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -7800,10 +7803,10 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
-  abitype@1.0.8(typescript@5.9.3)(zod@3.25.76):
+  abitype@1.0.8(typescript@5.9.3)(zod@4.4.3):
     optionalDependencies:
       typescript: 5.9.3
-      zod: 3.25.76
+      zod: 4.4.3
 
   abitype@1.2.3(typescript@5.9.3)(zod@3.22.4):
     optionalDependencies:
@@ -9231,28 +9234,28 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
+  ox@0.6.7(typescript@5.9.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.4.3)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.9(typescript@5.9.3)(zod@3.25.76):
+  ox@0.6.9(typescript@5.9.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.4.3)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -9371,21 +9374,21 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3)):
     dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       hono: 4.12.21
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.17(typescript@5.9.3)(zod@4.4.3)
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zod: 4.4.3
       zustand: 5.0.13(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
     optionalDependencies:
       '@tanstack/react-query': 5.100.11(react@19.2.6)
       react: 19.2.6
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -10001,15 +10004,15 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.0.8(typescript@5.9.3)(zod@4.4.3)
       isows: 1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.6.7(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.6.7(typescript@5.9.3)(zod@4.4.3)
       ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
@@ -10199,14 +10202,14 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  wagmi@2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
+  wagmi@2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3):
     dependencies:
       '@tanstack/react-query': 5.100.11(react@19.2.6)
-      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)))(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@2.19.5(@tanstack/query-core@5.100.11)(@tanstack/react-query@5.100.11(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.11)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       react: 19.2.6
       use-sync-external-store: 1.4.0(react@19.2.6)
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/typescript/packages/server-express/package.json
+++ b/typescript/packages/server-express/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@bosonprotocol/x402-actions": "workspace:^",
     "@bosonprotocol/x402-evm": "workspace:^",
+    "@bosonprotocol/x402-paywall": "workspace:^",
     "@types/express": "^4.17.21",
     "@types/node": "^20.17.10",
     "@types/supertest": "^6.0.2",

--- a/typescript/packages/server-express/src/internal/x402-challenge.ts
+++ b/typescript/packages/server-express/src/internal/x402-challenge.ts
@@ -47,9 +47,10 @@ export interface ChallengeOptions {
    * browser will POST the X-PAYMENT retry to). Use this when deployed
    * behind a TLS-terminating proxy where `req.protocol` /
    * `req.get('host')` may not reflect the public origin. If omitted,
-   * falls back to `${req.protocol}://${req.get('host')}${req.originalUrl}`,
-   * which honors `X-Forwarded-Proto` / `X-Forwarded-Host` only when
-   * `app.set('trust proxy', ...)` is configured on the Express app.
+   * falls back to `${req.protocol}://${req.get('host')}${req.originalUrl}`.
+   * With `app.set('trust proxy', ...)`, `req.protocol` may honor
+   * `X-Forwarded-Proto`, but `req.get('host')` reads the `Host` header
+   * and does not consult `X-Forwarded-Host`.
    */
   currentUrl?: string | ((req: Request) => string);
 }

--- a/typescript/packages/server-express/src/internal/x402-challenge.ts
+++ b/typescript/packages/server-express/src/internal/x402-challenge.ts
@@ -1,21 +1,88 @@
-// Shared helper for the canonical x402 challenge response (status 402,
-// body `{ x402Version: 2, accepts: [requirements] }`).
+// Shared helper for the x402 challenge response.
 //
-// Both `expressMiddleware` and `mountX402b`'s commit routes need to
-// emit the same shape when an incoming request is missing `X-PAYMENT`;
-// keeping the format in one place means the two adapter entry points
-// can't drift.
+// Two output formats, chosen by content negotiation:
+//
+//  - `application/json` (the default, and the only output when no
+//    paywall is configured) — `{ x402Version, accepts: [requirements] }`,
+//    the canonical x402 wire contract clients pattern-match on.
+//  - `text/html` — a full HTML document produced by a
+//    `PaywallProvider.generateHtml(...)`, served when the request's
+//    `Accept` header prefers HTML *and* the caller configured a paywall.
+//
+// Both `expressMiddleware` and `mountX402b`'s commit routes funnel
+// missing-`X-PAYMENT` requests through this helper so the negotiation
+// rules can't drift between the two adapter entry points.
 
 import type { EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
-import type { Response } from "express";
+import type { Request, Response } from "express";
 
 export const X402_VERSION = 2 as const;
 
 /**
- * Write the canonical x402 challenge response to `res`. The body matches
- * what `@x402/core` clients expect: `{ x402Version, accepts: [...] }`
- * with a single entry carrying the resolved `EscrowPaymentRequirements`.
+ * Structural subset of `@bosonprotocol/x402-paywall`'s `PaywallProvider`
+ * that this adapter exercises. Defined locally so this package doesn't
+ * need to take `@bosonprotocol/x402-paywall` as a runtime / type dep —
+ * any object satisfying this shape works.
  */
-export function respondWithChallenge(res: Response, requirements: EscrowPaymentRequirements): void {
+export interface PaywallProviderLike {
+  supports(requirements: { scheme?: string }): boolean;
+  generateHtml(
+    payload: { requirements: EscrowPaymentRequirements; currentUrl?: string },
+    config?: PaywallConfigLike,
+  ): string;
+}
+
+/**
+ * Opaque pass-through config forwarded to `PaywallProvider.generateHtml`.
+ * The adapter doesn't introspect it.
+ */
+export type PaywallConfigLike = Record<string, unknown>;
+
+export interface ChallengeOptions {
+  paywall?: PaywallProviderLike;
+  paywallConfig?: PaywallConfigLike;
+}
+
+/**
+ * Write the x402 challenge response to `res`.
+ *
+ * If `opts.paywall` is supplied, the request's `Accept` header prefers
+ * HTML, and `paywall.supports(requirements)` returns `true`, the
+ * response body is the paywall's `generateHtml(...)` output (status 402,
+ * `Content-Type: text/html`). Otherwise the canonical JSON body is
+ * emitted.
+ */
+export function respondWithChallenge(
+  req: Request,
+  res: Response,
+  requirements: EscrowPaymentRequirements,
+  opts: ChallengeOptions = {},
+): void {
+  if (opts.paywall && wantsHtml(req) && opts.paywall.supports(requirements)) {
+    const html = opts.paywall.generateHtml(
+      { requirements, currentUrl: buildCurrentUrl(req) },
+      opts.paywallConfig,
+    );
+    res.status(402).type("html").send(html);
+    return;
+  }
   res.status(402).json({ x402Version: X402_VERSION, accepts: [requirements] });
+}
+
+/**
+ * `req.accepts(['html', 'json'])` returns whichever the client prefers
+ * (per the standard `Accept` header q-value ordering). When the header
+ * is missing entirely `accepts` returns the first listed entry — which
+ * we don't want as a paywall trigger, so we also gate on `req.headers.accept`
+ * being a non-empty string.
+ */
+function wantsHtml(req: Request): boolean {
+  const acceptHeader = req.headers.accept;
+  if (typeof acceptHeader !== "string" || acceptHeader.length === 0) return false;
+  return req.accepts(["html", "json"]) === "html";
+}
+
+function buildCurrentUrl(req: Request): string {
+  const host = req.get("host") ?? "";
+  return `${req.protocol}://${host}${req.originalUrl}`;
 }

--- a/typescript/packages/server-express/src/internal/x402-challenge.ts
+++ b/typescript/packages/server-express/src/internal/x402-challenge.ts
@@ -47,12 +47,17 @@ export interface ChallengeOptions {
    * Optional override for the canonical URL embedded in the paywall
    * HTML response as `window.x402b.currentUrl` (the URL the buyer's
    * browser will POST the X-PAYMENT retry to). Use this when deployed
-   * behind a TLS-terminating proxy where `req.protocol` /
-   * `req.get('host')` may not reflect the public origin. If omitted,
-   * falls back to `${req.protocol}://${req.get('host')}${req.originalUrl}`.
-   * With `app.set('trust proxy', ...)`, `req.protocol` may honor
-   * `X-Forwarded-Proto`, but `req.get('host')` reads the `Host` header
-   * and does not consult `X-Forwarded-Host`.
+   * behind a TLS-terminating proxy where the auto-derivation below
+   * cannot reflect the public origin. When omitted, the URL is built
+   * from `req.protocol`, the first non-empty value of `X-Forwarded-Host`
+   * / `Host`, and `req.originalUrl`; if neither host header is present
+   * (e.g. a malformed HTTP/1.0 request) the helper falls back to a
+   * relative URL (`req.originalUrl`) so the paywall form still posts
+   * back to the same origin the buyer is on. With
+   * `app.set('trust proxy', ...)`, `req.protocol` honors
+   * `X-Forwarded-Proto`; `req.get('host')` does not consult
+   * `X-Forwarded-Host`, which is why this helper prefers the forwarded
+   * header explicitly.
    */
   currentUrl?: string | ((req: Request) => string);
 }
@@ -118,6 +123,18 @@ function resolveCurrentUrl(
 ): string {
   if (typeof override === "string") return override;
   if (typeof override === "function") return override(req);
-  const host = req.get("host") ?? "";
+  // Prefer `X-Forwarded-Host` over the raw `Host` header: when the app
+  // is fronted by a reverse proxy and `app.set('trust proxy', ...)` is
+  // enabled, the public origin lives in the forwarded header while
+  // `req.get('host')` still reflects the internal hop. Outside a trusted
+  // proxy the worst case is the buyer's browser posting back to a host
+  // they themselves controlled, which is bounded — they can already
+  // choose not to pay. If neither header is present (e.g. a malformed
+  // HTTP/1.0 request with no `Host`), emit a relative URL so the paywall
+  // form still posts back to the buyer's current origin instead of
+  // producing an invalid `http:///path`.
+  const forwardedHost = req.get("x-forwarded-host")?.split(",")[0]?.trim();
+  const host = forwardedHost || req.get("host");
+  if (!host) return req.originalUrl;
   return `${req.protocol}://${host}${req.originalUrl}`;
 }

--- a/typescript/packages/server-express/src/internal/x402-challenge.ts
+++ b/typescript/packages/server-express/src/internal/x402-challenge.ts
@@ -76,7 +76,7 @@ export function respondWithChallenge(
   opts: ChallengeOptions = {},
 ): void {
   res.setHeader("Cache-Control", "no-store");
-  res.setHeader("Vary", "Accept");
+  res.vary("Accept");
 
   if (opts.paywall && wantsHtml(req) && opts.paywall.supports(requirements)) {
     const html = opts.paywall.generateHtml(

--- a/typescript/packages/server-express/src/internal/x402-challenge.ts
+++ b/typescript/packages/server-express/src/internal/x402-challenge.ts
@@ -114,7 +114,14 @@ function wantsHtml(req: Request): boolean {
 
   if (!explicitlyAcceptsHtml) return false;
 
-  return req.accepts(["html", "json"]) === "html";
+  // Confirm HTML is preferred over JSON per the Accept q-values. Match
+  // against full media types here rather than Express's `html`/`json`
+  // short aliases, because the short `html` alias only resolves to
+  // `text/html` — an XHTML-only client (`Accept: application/xhtml+xml`)
+  // would otherwise fall through to JSON despite the explicit check
+  // above listing it as HTML-capable.
+  const preferred = req.accepts(["text/html", "application/xhtml+xml", "application/json"]);
+  return preferred === "text/html" || preferred === "application/xhtml+xml";
 }
 
 function resolveCurrentUrl(

--- a/typescript/packages/server-express/src/internal/x402-challenge.ts
+++ b/typescript/packages/server-express/src/internal/x402-challenge.ts
@@ -69,15 +69,13 @@ export function respondWithChallenge(
   res.status(402).json({ x402Version: X402_VERSION, accepts: [requirements] });
 }
 
-/**
- * `req.accepts(['html', 'json'])` returns whichever the client prefers
- * (per the standard `Accept` header q-value ordering). However, generic
- * headers such as `*/*` can make both HTML and JSON acceptable, and
- * Express will typically select the first listed type. To keep JSON as
- * the canonical default for non-browser clients, only treat the request
- * as HTML-capable when the raw `Accept` header explicitly includes
- * `text/html` or `application/xhtml+xml`.
- */
+// `req.accepts(['html', 'json'])` returns whichever the client prefers
+// (per the standard `Accept` header q-value ordering). However, generic
+// wildcard Accept values can make both HTML and JSON acceptable, and
+// Express will typically select the first listed type. To keep JSON as
+// the canonical default for non-browser clients, only treat the request
+// as HTML-capable when the raw `Accept` header explicitly includes
+// `text/html` or `application/xhtml+xml`.
 function wantsHtml(req: Request): boolean {
   const acceptHeader = req.headers.accept;
   if (typeof acceptHeader !== "string" || acceptHeader.length === 0) return false;

--- a/typescript/packages/server-express/src/internal/x402-challenge.ts
+++ b/typescript/packages/server-express/src/internal/x402-challenge.ts
@@ -71,14 +71,24 @@ export function respondWithChallenge(
 
 /**
  * `req.accepts(['html', 'json'])` returns whichever the client prefers
- * (per the standard `Accept` header q-value ordering). When the header
- * is missing entirely `accepts` returns the first listed entry — which
- * we don't want as a paywall trigger, so we also gate on `req.headers.accept`
- * being a non-empty string.
+ * (per the standard `Accept` header q-value ordering). However, generic
+ * headers such as `*/*` can make both HTML and JSON acceptable, and
+ * Express will typically select the first listed type. To keep JSON as
+ * the canonical default for non-browser clients, only treat the request
+ * as HTML-capable when the raw `Accept` header explicitly includes
+ * `text/html` or `application/xhtml+xml`.
  */
 function wantsHtml(req: Request): boolean {
   const acceptHeader = req.headers.accept;
   if (typeof acceptHeader !== "string" || acceptHeader.length === 0) return false;
+
+  const explicitlyAcceptsHtml = acceptHeader
+    .split(",")
+    .map((value) => value.split(";")[0]?.trim().toLowerCase())
+    .some((value) => value === "text/html" || value === "application/xhtml+xml");
+
+  if (!explicitlyAcceptsHtml) return false;
+
   return req.accepts(["html", "json"]) === "html";
 }
 

--- a/typescript/packages/server-express/src/internal/x402-challenge.ts
+++ b/typescript/packages/server-express/src/internal/x402-challenge.ts
@@ -34,9 +34,11 @@ export interface PaywallProviderLike {
 
 /**
  * Opaque pass-through config forwarded to `PaywallProvider.generateHtml`.
- * The adapter doesn't introspect it.
+ * The adapter doesn't introspect it — `object` is intentionally broad so
+ * any concrete `PaywallConfig` shape (with named optional fields, no
+ * index signature) satisfies it structurally.
  */
-export type PaywallConfigLike = Record<string, unknown>;
+export type PaywallConfigLike = object;
 
 export interface ChallengeOptions {
   paywall?: PaywallProviderLike;

--- a/typescript/packages/server-express/src/internal/x402-challenge.ts
+++ b/typescript/packages/server-express/src/internal/x402-challenge.ts
@@ -41,6 +41,17 @@ export type PaywallConfigLike = Record<string, unknown>;
 export interface ChallengeOptions {
   paywall?: PaywallProviderLike;
   paywallConfig?: PaywallConfigLike;
+  /**
+   * Optional override for the canonical URL embedded in the paywall
+   * HTML response as `window.x402b.currentUrl` (the URL the buyer's
+   * browser will POST the X-PAYMENT retry to). Use this when deployed
+   * behind a TLS-terminating proxy where `req.protocol` /
+   * `req.get('host')` may not reflect the public origin. If omitted,
+   * falls back to `${req.protocol}://${req.get('host')}${req.originalUrl}`,
+   * which honors `X-Forwarded-Proto` / `X-Forwarded-Host` only when
+   * `app.set('trust proxy', ...)` is configured on the Express app.
+   */
+  currentUrl?: string | ((req: Request) => string);
 }
 
 /**
@@ -51,6 +62,11 @@ export interface ChallengeOptions {
  * response body is the paywall's `generateHtml(...)` output (status 402,
  * `Content-Type: text/html`). Otherwise the canonical JSON body is
  * emitted.
+ *
+ * Both branches set `Cache-Control: no-store` and `Vary: Accept`:
+ * the 402 body is per-buyer / per-request state (signed offer, single-use
+ * token-auth nonces, injected `window.x402b` payload), so an intermediary
+ * must never cache it or cross-serve HTML to a JSON client.
  */
 export function respondWithChallenge(
   req: Request,
@@ -58,9 +74,12 @@ export function respondWithChallenge(
   requirements: EscrowPaymentRequirements,
   opts: ChallengeOptions = {},
 ): void {
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("Vary", "Accept");
+
   if (opts.paywall && wantsHtml(req) && opts.paywall.supports(requirements)) {
     const html = opts.paywall.generateHtml(
-      { requirements, currentUrl: buildCurrentUrl(req) },
+      { requirements, currentUrl: resolveCurrentUrl(req, opts.currentUrl) },
       opts.paywallConfig,
     );
     res.status(402).type("html").send(html);
@@ -90,7 +109,12 @@ function wantsHtml(req: Request): boolean {
   return req.accepts(["html", "json"]) === "html";
 }
 
-function buildCurrentUrl(req: Request): string {
+function resolveCurrentUrl(
+  req: Request,
+  override: string | ((req: Request) => string) | undefined,
+): string {
+  if (typeof override === "string") return override;
+  if (typeof override === "function") return override(req);
   const host = req.get("host") ?? "";
   return `${req.protocol}://${host}${req.originalUrl}`;
 }

--- a/typescript/packages/server-express/src/middleware.ts
+++ b/typescript/packages/server-express/src/middleware.ts
@@ -52,10 +52,27 @@ export interface ExpressMiddlewareOptions {
    * instead of the canonical JSON body. Non-browser clients always get
    * JSON. Structurally compatible with
    * `@bosonprotocol/x402-paywall`'s `evmEscrowPaywall`.
+   *
+   * When deployed behind a TLS-terminating proxy, call
+   * `app.set('trust proxy', ...)` on the Express app so the paywall's
+   * `currentUrl` is built with the original `https://` scheme and
+   * forwarded host (the browser's retry URL is embedded in
+   * `window.x402b.currentUrl` — an `http://` value loaded from an HTTPS
+   * page hits mixed-content blocking). Alternatively, use `currentUrl`
+   * below to pass an explicit value.
    */
   paywall?: PaywallProviderLike;
   /** Forwarded to `paywall.generateHtml(...)` as the second argument when the paywall path fires. */
   paywallConfig?: PaywallConfigLike;
+  /**
+   * Optional override for the canonical URL embedded in the paywall
+   * HTML response. Either a literal string or a `(req) => string`
+   * resolver. Use this when `trust proxy` isn't sufficient — e.g. when
+   * the public origin differs from `X-Forwarded-Host`, or when you want
+   * the retry URL pinned to a fixed checkout endpoint. Only consulted
+   * on the paywall (HTML) branch.
+   */
+  currentUrl?: string | ((req: Request) => string);
 }
 
 export interface X402bResLocals {
@@ -94,6 +111,7 @@ export function expressMiddleware(
         respondWithChallenge(req, res, requirements, {
           paywall: opts.paywall,
           paywallConfig: opts.paywallConfig,
+          currentUrl: opts.currentUrl,
         });
       } catch (e) {
         next(e);

--- a/typescript/packages/server-express/src/middleware.ts
+++ b/typescript/packages/server-express/src/middleware.ts
@@ -18,7 +18,11 @@ import {
 } from "@bosonprotocol/x402-server";
 import type { NextFunction, Request, RequestHandler, Response } from "express";
 
-import { respondWithChallenge } from "./internal/x402-challenge.js";
+import {
+  respondWithChallenge,
+  type PaywallConfigLike,
+  type PaywallProviderLike,
+} from "./internal/x402-challenge.js";
 
 export interface ExpressMiddlewareOptions {
   /**
@@ -41,6 +45,17 @@ export interface ExpressMiddlewareOptions {
    * point so the buyer redeems in the same transaction.
    */
   flow?: "commit" | "commit-and-redeem";
+  /**
+   * Optional paywall provider. When supplied and the request's `Accept`
+   * header prefers `text/html` (a browser User-Agent), the 402 challenge
+   * is rendered as an HTML document via `paywall.generateHtml(...)`
+   * instead of the canonical JSON body. Non-browser clients always get
+   * JSON. Structurally compatible with
+   * `@bosonprotocol/x402-paywall`'s `evmEscrowPaywall`.
+   */
+  paywall?: PaywallProviderLike;
+  /** Forwarded to `paywall.generateHtml(...)` as the second argument when the paywall path fires. */
+  paywallConfig?: PaywallConfigLike;
 }
 
 export interface X402bResLocals {
@@ -76,7 +91,10 @@ export function expressMiddleware(
     if (header === undefined || header.length === 0) {
       try {
         const requirements = await opts.resolveRequirements(req, "challenge");
-        respondWithChallenge(res, requirements);
+        respondWithChallenge(req, res, requirements, {
+          paywall: opts.paywall,
+          paywallConfig: opts.paywallConfig,
+        });
       } catch (e) {
         next(e);
       }

--- a/typescript/packages/server-express/src/mount.ts
+++ b/typescript/packages/server-express/src/mount.ts
@@ -20,7 +20,11 @@ import {
 import { Router, type Request, type RequestHandler, type Response } from "express";
 import type { Hex } from "viem";
 
-import { respondWithChallenge } from "./internal/x402-challenge.js";
+import {
+  respondWithChallenge,
+  type PaywallConfigLike,
+  type PaywallProviderLike,
+} from "./internal/x402-challenge.js";
 
 /** Shared error code for malformed `POST /x402B/*` bodies. */
 export const INVALID_REQUEST_BODY = "INVALID_REQUEST_BODY" as const;
@@ -36,6 +40,16 @@ export interface MountX402bOptions {
   ) => Promise<EscrowPaymentRequirements> | EscrowPaymentRequirements;
   /** Optional mount path. Defaults to both `/x402B` and legacy `/x402b`. */
   basePath?: string;
+  /**
+   * Optional paywall provider. When supplied and the request's `Accept`
+   * header prefers `text/html`, the commit-route 402 challenge is
+   * rendered as an HTML document via `paywall.generateHtml(...)` instead
+   * of the canonical JSON body. Same semantics as
+   * `ExpressMiddlewareOptions.paywall`.
+   */
+  paywall?: PaywallProviderLike;
+  /** Forwarded to `paywall.generateHtml(...)` when the paywall path fires. */
+  paywallConfig?: PaywallConfigLike;
 }
 
 /**
@@ -79,7 +93,10 @@ function commitRoute(
       // useful for non-Express integrators, but not the x402 wire
       // contract clients branch on.
       if (header === undefined || header.length === 0) {
-        respondWithChallenge(res, requirements);
+        respondWithChallenge(req, res, requirements, {
+          paywall: opts.paywall,
+          paywallConfig: opts.paywallConfig,
+        });
         return;
       }
 

--- a/typescript/packages/server-express/src/mount.ts
+++ b/typescript/packages/server-express/src/mount.ts
@@ -46,10 +46,22 @@ export interface MountX402bOptions {
    * rendered as an HTML document via `paywall.generateHtml(...)` instead
    * of the canonical JSON body. Same semantics as
    * `ExpressMiddlewareOptions.paywall`.
+   *
+   * When deployed behind a TLS-terminating proxy, call
+   * `app.set('trust proxy', ...)` on the Express app so the paywall's
+   * `currentUrl` is built with the original `https://` scheme and
+   * forwarded host. Alternatively, use `currentUrl` below to pass an
+   * explicit value.
    */
   paywall?: PaywallProviderLike;
   /** Forwarded to `paywall.generateHtml(...)` when the paywall path fires. */
   paywallConfig?: PaywallConfigLike;
+  /**
+   * Optional override for the canonical URL embedded in the paywall
+   * HTML response. Either a literal string or a `(req) => string`
+   * resolver. Same semantics as `ExpressMiddlewareOptions.currentUrl`.
+   */
+  currentUrl?: string | ((req: Request) => string);
 }
 
 /**
@@ -96,6 +108,7 @@ function commitRoute(
         respondWithChallenge(req, res, requirements, {
           paywall: opts.paywall,
           paywallConfig: opts.paywallConfig,
+          currentUrl: opts.currentUrl,
         });
         return;
       }

--- a/typescript/packages/server-express/test/paywall.test.ts
+++ b/typescript/packages/server-express/test/paywall.test.ts
@@ -103,7 +103,7 @@ describe("expressMiddleware — paywall content negotiation", () => {
     expect(paywall.generateHtml).not.toHaveBeenCalled();
   });
 
-  it("serves JSON when no Accept header is sent (e.g. a default fetch() with no headers)", async () => {
+  it("serves JSON when the Accept header is empty (explicitly cleared by the client)", async () => {
     const paywall = makePaywall();
 
     const app = express();
@@ -121,6 +121,32 @@ describe("expressMiddleware — paywall content negotiation", () => {
 
     expect(res.status).toBe(402);
     expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(paywall.generateHtml).not.toHaveBeenCalled();
+  });
+
+  it("serves JSON when Accept is */* (e.g. a default browser fetch() with no headers)", async () => {
+    // Browsers send `Accept: */*` for `fetch()` without an explicit
+    // headers option. Generic API clients (curl, etc.) do the same.
+    // Such requests must default to the canonical JSON wire contract,
+    // not the paywall HTML — only requests that explicitly accept
+    // `text/html` (or `application/xhtml+xml`) opt into the paywall.
+    const paywall = makePaywall();
+
+    const app = express();
+    app.get(
+      "/datafeed",
+      expressMiddleware(emptyServer, {
+        resolveRequirements: () => REQUIREMENTS,
+        paywall,
+      }),
+      (_req, res) => res.json({ kpi: 42 }),
+    );
+
+    const res = await supertest(app).get("/datafeed").set("Accept", "*/*");
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.body.x402Version).toBe(2);
     expect(paywall.generateHtml).not.toHaveBeenCalled();
   });
 

--- a/typescript/packages/server-express/test/paywall.test.ts
+++ b/typescript/packages/server-express/test/paywall.test.ts
@@ -186,6 +186,121 @@ describe("expressMiddleware — paywall content negotiation", () => {
     expect(res.body.x402Version).toBe(2);
   });
 
+  it("stamps Cache-Control: no-store and Vary: Accept on the JSON branch", async () => {
+    // The 402 body carries per-request signature state (offer.sellerSig,
+    // single-use token-auth nonces) — an intermediary cache MUST NOT
+    // store it or cross-serve HTML to a JSON client.
+    const app = express();
+    app.get(
+      "/datafeed",
+      expressMiddleware(emptyServer, { resolveRequirements: () => REQUIREMENTS }),
+      (_req, res) => res.json({ kpi: 42 }),
+    );
+
+    const res = await supertest(app).get("/datafeed").set("Accept", "application/json");
+
+    expect(res.status).toBe(402);
+    expect(res.headers["cache-control"]).toBe("no-store");
+    expect(res.headers["vary"]).toMatch(/Accept/i);
+  });
+
+  it("stamps Cache-Control: no-store and Vary: Accept on the HTML branch", async () => {
+    const paywall = makePaywall();
+
+    const app = express();
+    app.get(
+      "/datafeed",
+      expressMiddleware(emptyServer, {
+        resolveRequirements: () => REQUIREMENTS,
+        paywall,
+      }),
+      (_req, res) => res.json({ kpi: 42 }),
+    );
+
+    const res = await supertest(app).get("/datafeed").set("Accept", "text/html");
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/text\/html/);
+    expect(res.headers["cache-control"]).toBe("no-store");
+    expect(res.headers["vary"]).toMatch(/Accept/i);
+  });
+
+  it("uses an explicit currentUrl override verbatim when provided as a string", async () => {
+    const paywall = makePaywall();
+
+    const app = express();
+    app.get(
+      "/datafeed",
+      expressMiddleware(emptyServer, {
+        resolveRequirements: () => REQUIREMENTS,
+        paywall,
+        currentUrl: "https://seller.example/checkout/abc",
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    await supertest(app).get("/datafeed").set("Accept", "text/html");
+
+    const callArg = paywall.generateHtml.mock.calls[0]?.[0] as { currentUrl?: string };
+    expect(callArg.currentUrl).toBe("https://seller.example/checkout/abc");
+  });
+
+  it("uses an explicit currentUrl override when provided as a (req) => string resolver", async () => {
+    const paywall = makePaywall();
+
+    const app = express();
+    app.get(
+      "/checkout/:id",
+      expressMiddleware(emptyServer, {
+        resolveRequirements: () => REQUIREMENTS,
+        paywall,
+        currentUrl: (req) => `https://seller.example/checkout/${req.params.id}`,
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    await supertest(app).get("/checkout/abc123").set("Accept", "text/html");
+
+    const callArg = paywall.generateHtml.mock.calls[0]?.[0] as { currentUrl?: string };
+    expect(callArg.currentUrl).toBe("https://seller.example/checkout/abc123");
+  });
+
+  it("honors X-Forwarded-Proto when app.set('trust proxy') is configured", async () => {
+    // Behind a TLS-terminating proxy, `req.protocol` returns the raw
+    // socket scheme unless `trust proxy` is set — in which case Express
+    // honors `X-Forwarded-Proto`. The reviewer's concern (#79) was that
+    // an integrator without `trust proxy` would inject `http://...` as
+    // the retry URL even when the browser loaded the page over HTTPS;
+    // pin the contract.
+    //
+    // Note: `req.get('host')` returns the raw `Host` header (not
+    // `X-Forwarded-Host`), so real reverse-proxy deployments typically
+    // configure their proxy to preserve the original `Host` (nginx:
+    // `proxy_set_header Host $host`) — mirrored here by overriding
+    // `Host` in supertest.
+    const paywall = makePaywall();
+
+    const app = express();
+    app.set("trust proxy", true);
+    app.get(
+      "/datafeed",
+      expressMiddleware(emptyServer, {
+        resolveRequirements: () => REQUIREMENTS,
+        paywall,
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    await supertest(app)
+      .get("/datafeed")
+      .set("Accept", "text/html")
+      .set("Host", "seller.example")
+      .set("X-Forwarded-Proto", "https");
+
+    const callArg = paywall.generateHtml.mock.calls[0]?.[0] as { currentUrl?: string };
+    expect(callArg.currentUrl).toBe("https://seller.example/datafeed");
+  });
+
   it("forwards a checkout-style currentUrl built from req.protocol + host + originalUrl", async () => {
     const paywall = makePaywall();
 

--- a/typescript/packages/server-express/test/paywall.test.ts
+++ b/typescript/packages/server-express/test/paywall.test.ts
@@ -1,0 +1,293 @@
+// Tests for the `paywall` integration in `expressMiddleware` and
+// `mountX402b`. Focus is the content-negotiation contract — the same
+// 402 challenge surface that already serves JSON now serves HTML when
+// the request prefers `text/html` and the caller has supplied a
+// `PaywallProvider`. JSON behaviour must be unchanged for every other
+// case (no paywall, JSON Accept header, missing Accept, unsupported
+// scheme).
+//
+// We drive the middleware with a stubbed `X402bServer` — the real
+// commit handler isn't exercised here, just the challenge path that
+// fires when `X-PAYMENT` is missing.
+
+import type { X402bServer } from "@bosonprotocol/x402-server";
+import express from "express";
+import supertest from "supertest";
+import { describe, expect, it, vi, type Mock } from "vitest";
+
+import { expressMiddleware, mountX402b } from "../src/index.js";
+import type { PaywallProviderLike } from "../src/internal/x402-challenge.js";
+
+const REQUIREMENTS = {
+  scheme: "escrow" as const,
+  network: "eip155:8453",
+  asset: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+  amount: "1000000",
+  escrowAddress: "0xdddddddddddddddddddddddddddddddddddddddd",
+  recipientId: "did:boson:seller:1",
+  maxTimeoutSeconds: 300,
+  offer: {
+    fullOffer: {},
+    sellerSig: "0xdead",
+    creator: "0x1111111111111111111111111111111111111111",
+  },
+  tokenAuthStrategies: ["erc3009" as const],
+  actions: { next: [{ id: "boson-createOfferAndCommit", channels: ["server" as const] }] },
+};
+
+function makePaywall(opts?: { supports?: boolean; html?: string }): PaywallProviderLike & {
+  supports: Mock;
+  generateHtml: Mock;
+} {
+  return {
+    supports: vi.fn().mockReturnValue(opts?.supports ?? true),
+    generateHtml: vi
+      .fn()
+      .mockReturnValue(opts?.html ?? "<!DOCTYPE html><html><body>paywall</body></html>"),
+  };
+}
+
+// Empty handlers — we only exercise the challenge path (missing X-PAYMENT),
+// which short-circuits before any handler runs.
+const emptyServer = { handlers: {} } as unknown as X402bServer;
+
+describe("expressMiddleware — paywall content negotiation", () => {
+  it("serves HTML when Accept prefers text/html and paywall.supports() is true", async () => {
+    const paywall = makePaywall({ html: "<!DOCTYPE html><html><body>hi</body></html>" });
+
+    const app = express();
+    app.get(
+      "/datafeed",
+      expressMiddleware(emptyServer, {
+        resolveRequirements: () => REQUIREMENTS,
+        paywall,
+        paywallConfig: { appName: "Test" },
+      }),
+      (_req, res) => res.json({ kpi: 42 }),
+    );
+
+    const res = await supertest(app).get("/datafeed").set("Accept", "text/html");
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/text\/html/);
+    expect(res.text).toContain("<!DOCTYPE html>");
+    expect(paywall.generateHtml).toHaveBeenCalledTimes(1);
+    expect(paywall.generateHtml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requirements: REQUIREMENTS,
+        currentUrl: expect.stringContaining("/datafeed"),
+      }),
+      { appName: "Test" },
+    );
+  });
+
+  it("serves JSON when Accept prefers application/json (browser API client)", async () => {
+    const paywall = makePaywall();
+
+    const app = express();
+    app.get(
+      "/datafeed",
+      expressMiddleware(emptyServer, {
+        resolveRequirements: () => REQUIREMENTS,
+        paywall,
+      }),
+      (_req, res) => res.json({ kpi: 42 }),
+    );
+
+    const res = await supertest(app).get("/datafeed").set("Accept", "application/json");
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.body.x402Version).toBe(2);
+    expect(res.body.accepts[0].scheme).toBe("escrow");
+    expect(paywall.generateHtml).not.toHaveBeenCalled();
+  });
+
+  it("serves JSON when no Accept header is sent (e.g. a default fetch() with no headers)", async () => {
+    const paywall = makePaywall();
+
+    const app = express();
+    app.get(
+      "/datafeed",
+      expressMiddleware(emptyServer, {
+        resolveRequirements: () => REQUIREMENTS,
+        paywall,
+      }),
+      (_req, res) => res.json({ kpi: 42 }),
+    );
+
+    // supertest forces an Accept header by default; explicitly clear it.
+    const res = await supertest(app).get("/datafeed").set("Accept", "");
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(paywall.generateHtml).not.toHaveBeenCalled();
+  });
+
+  it("serves JSON when paywall.supports() returns false (scheme not supported)", async () => {
+    const paywall = makePaywall({ supports: false });
+
+    const app = express();
+    app.get(
+      "/datafeed",
+      expressMiddleware(emptyServer, {
+        resolveRequirements: () => REQUIREMENTS,
+        paywall,
+      }),
+      (_req, res) => res.json({ kpi: 42 }),
+    );
+
+    const res = await supertest(app).get("/datafeed").set("Accept", "text/html");
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(paywall.supports).toHaveBeenCalledWith(REQUIREMENTS);
+    expect(paywall.generateHtml).not.toHaveBeenCalled();
+  });
+
+  it("serves JSON when no paywall is configured (no regression to existing behaviour)", async () => {
+    const app = express();
+    app.get(
+      "/datafeed",
+      expressMiddleware(emptyServer, { resolveRequirements: () => REQUIREMENTS }),
+      (_req, res) => res.json({ kpi: 42 }),
+    );
+
+    const res = await supertest(app).get("/datafeed").set("Accept", "text/html");
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.body.x402Version).toBe(2);
+  });
+
+  it("forwards a checkout-style currentUrl built from req.protocol + host + originalUrl", async () => {
+    const paywall = makePaywall();
+
+    const app = express();
+    app.get(
+      "/checkout/abc123",
+      expressMiddleware(emptyServer, {
+        resolveRequirements: () => REQUIREMENTS,
+        paywall,
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    await supertest(app).get("/checkout/abc123?coupon=10").set("Accept", "text/html");
+
+    const callArg = paywall.generateHtml.mock.calls[0]?.[0] as {
+      currentUrl?: string;
+    };
+    expect(callArg.currentUrl).toContain("/checkout/abc123?coupon=10");
+    // Includes scheme + host so the React app can fetch against an absolute URL.
+    expect(callArg.currentUrl).toMatch(/^https?:\/\/[^/]+\//);
+  });
+
+  it("does not invoke the paywall on a successful settle path (X-PAYMENT present)", async () => {
+    // When X-PAYMENT is supplied the middleware goes through the
+    // handler — even if that handler errors out, the paywall must not
+    // see the request. (The handler stub here lets us verify exactly
+    // that without wiring a full commit flow.)
+    const paywall = makePaywall();
+    const stubServer = {
+      handlers: {
+        commit: vi.fn(async () => ({
+          ok: false as const,
+          status: 400 as const,
+          body: { code: "STUBBED", reason: "intentional" },
+        })),
+      },
+    } as unknown as X402bServer;
+
+    const app = express();
+    app.get(
+      "/datafeed",
+      expressMiddleware(stubServer, {
+        resolveRequirements: () => REQUIREMENTS,
+        paywall,
+      }),
+      (_req, res) => res.json({ kpi: 42 }),
+    );
+
+    const res = await supertest(app)
+      .get("/datafeed")
+      .set("Accept", "text/html")
+      .set("X-PAYMENT", "anything-goes-base64");
+
+    expect(res.status).toBe(400);
+    expect(paywall.generateHtml).not.toHaveBeenCalled();
+  });
+});
+
+describe("mountX402b — paywall content negotiation on commit routes", () => {
+  it("POST /x402B/commit without X-PAYMENT serves HTML when Accept prefers text/html", async () => {
+    const paywall = makePaywall({
+      html: '<!DOCTYPE html><html><body data-test="commit-route">x</body></html>',
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use(
+      mountX402b(emptyServer, {
+        resolveRequirements: () => REQUIREMENTS,
+        paywall,
+      }),
+    );
+
+    const res = await supertest(app).post("/x402B/commit").set("Accept", "text/html").send();
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/text\/html/);
+    expect(res.text).toContain('data-test="commit-route"');
+  });
+
+  it("POST /x402B/commit without X-PAYMENT still defaults to JSON when no paywall is configured", async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(mountX402b(emptyServer, { resolveRequirements: () => REQUIREMENTS }));
+
+    const res = await supertest(app).post("/x402B/commit").set("Accept", "text/html").send();
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.body.accepts[0].scheme).toBe("escrow");
+  });
+});
+
+describe("integration: real evmEscrowPaywall from @bosonprotocol/x402-paywall", () => {
+  // Smoke-test against the actual workspace paywall so a structural
+  // drift between this adapter's `PaywallProviderLike` and the
+  // upstream `PaywallProvider` is caught at CI time. Imports are deferred
+  // to inside the test so this file still type-checks if the paywall
+  // hasn't been built yet (workspace ordering safety net).
+  it(
+    "expressMiddleware accepts evmEscrowPaywall and produces a full HTML 402 body",
+    // The dynamic import resolves a ~4.7 MB CJS bundle (the inlined
+    // React app template). Default 5 s vitest timeout is tight when
+    // turbo runs multiple test workers in parallel; bump generously.
+    { timeout: 30_000 },
+    async () => {
+      const { evmEscrowPaywall } = await import("@bosonprotocol/x402-paywall");
+
+      const app = express();
+      app.get(
+        "/datafeed",
+        expressMiddleware(emptyServer, {
+          resolveRequirements: () => REQUIREMENTS,
+          paywall: evmEscrowPaywall,
+          paywallConfig: { appName: "Integration Demo" },
+        }),
+        (_req, res) => res.json({ kpi: 42 }),
+      );
+
+      const res = await supertest(app).get("/datafeed").set("Accept", "text/html");
+
+      expect(res.status).toBe(402);
+      expect(res.headers["content-type"]).toMatch(/text\/html/);
+      expect(res.text).toContain("<!DOCTYPE html>");
+      expect(res.text).toContain("window.x402b");
+      // The PaywallConfig field should round-trip into the injected state.
+      expect(res.text).toContain("Integration Demo");
+    },
+  );
+});

--- a/typescript/packages/server-express/test/paywall.test.ts
+++ b/typescript/packages/server-express/test/paywall.test.ts
@@ -81,6 +81,31 @@ describe("expressMiddleware — paywall content negotiation", () => {
     );
   });
 
+  it("serves HTML when Accept prefers application/xhtml+xml", async () => {
+    // `wantsHtml` explicitly lists `application/xhtml+xml` alongside
+    // `text/html`. Lock in that branch so a future regression in the
+    // hand-rolled Accept parser doesn't silently downgrade XHTML clients
+    // to the JSON 402.
+    const paywall = makePaywall({ html: "<!DOCTYPE html><html><body>xhtml</body></html>" });
+
+    const app = express();
+    app.get(
+      "/datafeed",
+      expressMiddleware(emptyServer, {
+        resolveRequirements: () => REQUIREMENTS,
+        paywall,
+      }),
+      (_req, res) => res.json({ kpi: 42 }),
+    );
+
+    const res = await supertest(app).get("/datafeed").set("Accept", "application/xhtml+xml");
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/text\/html/);
+    expect(res.text).toContain("<!DOCTYPE html>");
+    expect(paywall.generateHtml).toHaveBeenCalledTimes(1);
+  });
+
   it("serves JSON when Accept prefers application/json (browser API client)", async () => {
     const paywall = makePaywall();
 


### PR DESCRIPTION
## Summary

- Adds optional `paywall` (a `PaywallProvider`) and `paywallConfig` to `ExpressMiddlewareOptions` and `MountX402bOptions`.
- When supplied and the request's `Accept` header prefers `text/html`, the 402 challenge is rendered as an HTML document via `paywall.generateHtml(...)` (with `currentUrl` built from `${protocol}://${host}${originalUrl}`) instead of the canonical JSON body.
- All other cases (JSON Accept, missing Accept, `paywall.supports()` returns false, no paywall configured, settle-phase requests) keep the existing JSON challenge unchanged — no regression.

## Implementation notes

- A local structural `PaywallProviderLike` interface in `src/internal/x402-challenge.ts` keeps `@bosonprotocol/x402-paywall` an **optional** integration. Consumers wanting HTML 402s install the paywall package separately; this adapter never imports it at runtime.
- Both `expressMiddleware` and `mountX402b`'s commit routes funnel through the same shared `respondWithChallenge` helper, so the content-negotiation rules can't drift between the two entry points.
- A devDep on `@bosonprotocol/x402-paywall` powers one CI-level smoke test that exercises the real `evmEscrowPaywall` through the middleware — catches structural drift between `PaywallProviderLike` here and the upstream `PaywallProvider` shape.

## Notes

- Depends on #78 (`@bosonprotocol/x402-paywall`); base is set accordingly. GitHub will auto-rebase to `main` once #78 (and its own base #77) merges.
- The integration test's vitest timeout is bumped to 30 s because dynamically importing the paywall pulls the 4.7 MB CJS bundle and can run slow under parallel turbo workers.

## Test plan

- [x] \`pnpm --filter @bosonprotocol/x402-server-express build\` — clean
- [x] \`pnpm --filter @bosonprotocol/x402-server-express test\` — 32/32 (22 existing + 10 new)
- [x] Repo-wide \`pnpm build\` — 16/16 successful
- [x] Repo-wide \`pnpm test\` — 32/32 successful
- [x] Repo-wide \`pnpm lint\` — 16/16 successful
- [x] Repo-wide \`pnpm format:check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)