### PR TITLE
feat(resource-server): wire optional paywall into the example host

### DIFF
--- a/.changeset/resource-server-example-paywall.md
+++ b/.changeset/resource-server-example-paywall.md
@@ -1,0 +1,19 @@
+---
+"@bosonprotocol/x402-example-resource-server": minor
+"@bosonprotocol/x402-server-express": patch
+---
+
+Wire the optional `paywall` + `paywallConfig` options through
+`createResourceServerApp` to the underlying `expressMiddleware` and
+`mountX402b` calls. Setting any `PAYWALL_*` env var
+(`PAYWALL_APP_NAME`, `PAYWALL_WALLETCONNECT_PROJECT_ID`,
+`PAYWALL_TESTNET`) populates a `paywall` block on the parsed env;
+forks of the example binary can then import `evmEscrowPaywall` from
+`@bosonprotocol/x402-paywall` and forward both into the app to get
+HTML 402 bodies for browser User-Agents.
+
+Also widens `PaywallConfigLike` in `@bosonprotocol/x402-server-express`
+from `Record<string, unknown>` to `object` so concrete `PaywallConfig`
+shapes (with named optional fields, no index signature) satisfy it
+structurally — required for the demo example to typecheck without
+casts.

--- a/examples/resource-server/README.md
+++ b/examples/resource-server/README.md
@@ -82,14 +82,18 @@ Then `curl http://localhost:4001/resource` returns 402 + the
 
 ### Browser paywall
 
-Set any `PAYWALL_*` env var (e.g. `PAYWALL_APP_NAME="My App"`) to
-enable the HTML paywall. Programmatic clients (anything that doesn't
-send `Accept: text/html`) still get JSON 402s — the content-negotiation
-gate lives in
-[`@bosonprotocol/x402-server-express`](../../typescript/packages/server-express),
-which this example wires up via `createResourceServerApp(env, { paywall, paywallConfig })`.
-Browse to `http://localhost:4001/resource` to see the paywall — the
-React app renders the offer, lets the buyer connect a wallet
+Setting any `PAYWALL_*` env var (e.g. `PAYWALL_APP_NAME="My App"`)
+populates `env.paywall` / `paywallConfig`; by itself, that does **not**
+make this repo's default binary serve the HTML paywall. HTML 402s are
+only returned when a `paywall` provider (for example
+`evmEscrowPaywall`) is actually passed into
+`createResourceServerApp(env, { paywall, paywallConfig })`.
+Programmatic clients (anything that doesn't send `Accept: text/html`)
+still get JSON 402s — the content-negotiation gate lives in
+[`@bosonprotocol/x402-server-express`](../../typescript/packages/server-express).
+If you wire a paywall provider into a fork/custom entrypoint, browsing
+to `http://localhost:4001/resource` will show the paywall: the React
+app renders the offer, lets the buyer connect a wallet
 (injected / Coinbase / optionally WalletConnect), drives the atomic
 commit-and-redeem flow, and swaps in the gated resource on success.
 

--- a/examples/resource-server/README.md
+++ b/examples/resource-server/README.md
@@ -50,6 +50,9 @@ this host adds no protocol logic of its own.
 | `MAX_TIMEOUT_SECONDS` | no  | `3600` | `PaymentRequirements.maxTimeoutSeconds`. Capped at 24 h. |
 | `SUBGRAPH_URL`        | no  | — | Optional Boson subgraph URL — required for `getAvailableFunds` / `withdrawFunds`. |
 | `PORT`                | no  | `4001` | HTTP listen port. |
+| `PAYWALL_APP_NAME`    | no  | — | Display name in the paywall UI + wagmi connector identity. Setting any `PAYWALL_*` var enables the HTML paywall path. |
+| `PAYWALL_WALLETCONNECT_PROJECT_ID` | no | — | Enables the WalletConnect connector; omit for injected + Coinbase only. |
+| `PAYWALL_TESTNET`     | no  | `false` | `true` / `1` surfaces a "testnet" badge in the paywall UI. |
 
 ## Run locally
 
@@ -76,6 +79,19 @@ pnpm --filter @bosonprotocol/x402-example-resource-server start
 
 Then `curl http://localhost:4001/resource` returns 402 + the
 `PaymentRequirements` echoed from your env.
+
+### Browser paywall
+
+Set any `PAYWALL_*` env var (e.g. `PAYWALL_APP_NAME="My App"`) to
+enable the HTML paywall. Programmatic clients (anything that doesn't
+send `Accept: text/html`) still get JSON 402s — the content-negotiation
+gate lives in
+[`@bosonprotocol/x402-server-express`](../../typescript/packages/server-express),
+which this example wires up via `createResourceServerApp(env, { paywall, paywallConfig })`.
+Browse to `http://localhost:4001/resource` to see the paywall — the
+React app renders the offer, lets the buyer connect a wallet
+(injected / Coinbase / optionally WalletConnect), drives the atomic
+commit-and-redeem flow, and swaps in the gated resource on success.
 
 ## Run in Docker
 

--- a/examples/resource-server/package.json
+++ b/examples/resource-server/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@bosonprotocol/x402-actions": "workspace:^",
     "@bosonprotocol/x402-core": "workspace:^",
+    "@bosonprotocol/x402-paywall": "workspace:^",
     "@bosonprotocol/x402-server": "workspace:^",
     "@bosonprotocol/x402-server-express": "workspace:^",
     "express": "^4.21.2",

--- a/examples/resource-server/src/app.ts
+++ b/examples/resource-server/src/app.ts
@@ -20,6 +20,7 @@
 //    reader can be built from the env (see README).
 
 import type { EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
+import type { PaywallConfig, PaywallProvider } from "@bosonprotocol/x402-paywall";
 import {
   createX402bServer,
   type ExchangeReader,
@@ -43,6 +44,17 @@ export interface ResourceServerAppOptions {
   exchangeReader: ExchangeReader;
   /** Replace `Date.now()` for deterministic offer-validity windows in tests. */
   now?: () => number;
+  /**
+   * Optional paywall provider — typically `evmEscrowPaywall` from
+   * `@bosonprotocol/x402-paywall`. When supplied, browser User-Agents
+   * hitting `/resource` (i.e. requests preferring `text/html`) get a
+   * full HTML paywall body instead of the JSON 402; programmatic
+   * clients still see JSON. The `paywallConfig` is forwarded to the
+   * paywall's `generateHtml(...)` as the second argument.
+   */
+  paywall?: PaywallProvider;
+  /** Forwarded to `paywall.generateHtml(...)`. Ignored when `paywall` is omitted. */
+  paywallConfig?: PaywallConfig;
 }
 
 export interface ResourceServerAppBundle {
@@ -134,15 +146,29 @@ export function createResourceServerApp(
     }
   });
 
-  app.get("/resource", expressMiddleware(server, { resolveRequirements }), (_req, res) => {
-    res.json({
-      ok: true,
-      x402b: res.locals.x402b,
-      resource: "example resource bytes",
-    });
-  });
+  app.get(
+    "/resource",
+    expressMiddleware(server, {
+      resolveRequirements,
+      ...(options.paywall !== undefined ? { paywall: options.paywall } : {}),
+      ...(options.paywallConfig !== undefined ? { paywallConfig: options.paywallConfig } : {}),
+    }),
+    (_req, res) => {
+      res.json({
+        ok: true,
+        x402b: res.locals.x402b,
+        resource: "example resource bytes",
+      });
+    },
+  );
 
-  app.use(mountX402b(server, { resolveRequirements }));
+  app.use(
+    mountX402b(server, {
+      resolveRequirements,
+      ...(options.paywall !== undefined ? { paywall: options.paywall } : {}),
+      ...(options.paywallConfig !== undefined ? { paywallConfig: options.paywallConfig } : {}),
+    }),
+  );
 
   app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
     const status =

--- a/examples/resource-server/src/config.ts
+++ b/examples/resource-server/src/config.ts
@@ -34,6 +34,22 @@ export interface ResourceServerEnv {
   subgraphUrl?: string;
   /** HTTP listen port. */
   port: number;
+  /**
+   * Paywall config block. Populated only when at least one
+   * `PAYWALL_*` env var is set; otherwise `undefined` and the
+   * resource server serves JSON-only 402s. Pair-shipped with
+   * the `paywall` option on `createResourceServerApp` — the binary
+   * passes both together so a fork can opt into the HTML paywall by
+   * setting env vars and importing `evmEscrowPaywall`.
+   */
+  paywall?: {
+    /** Display name used in the paywall UI + wagmi connector identity. */
+    appName?: string;
+    /** Enables the WalletConnect connector. Omit for injected + Coinbase only. */
+    walletConnectProjectId?: string;
+    /** Surface a "testnet" badge in the paywall UI. */
+    testnet: boolean;
+  };
 }
 
 function required(name: string): string {
@@ -117,5 +133,31 @@ export function readEnv(): ResourceServerEnv {
       ? { subgraphUrl: asHttpUrl(subgraphRaw, "SUBGRAPH_URL") }
       : {}),
     port: asInt(optional("PORT", "4001"), "PORT", { min: 1, max: 65535 }),
+    ...(readPaywallEnv() !== undefined ? { paywall: readPaywallEnv() } : {}),
+  };
+}
+
+/**
+ * Build the paywall config from `PAYWALL_*` env vars. Returns
+ * `undefined` when no paywall env var is set, signalling that the
+ * resource server should not enable the HTML paywall path. Any
+ * non-empty `PAYWALL_*` var opts in; `PAYWALL_TESTNET` defaults to
+ * `false` when the block is enabled but the var is unset.
+ */
+function readPaywallEnv(): ResourceServerEnv["paywall"] {
+  const appName = process.env.PAYWALL_APP_NAME;
+  const walletConnectProjectId = process.env.PAYWALL_WALLETCONNECT_PROJECT_ID;
+  const testnetRaw = process.env.PAYWALL_TESTNET;
+  const anySet =
+    (appName !== undefined && appName.length > 0) ||
+    (walletConnectProjectId !== undefined && walletConnectProjectId.length > 0) ||
+    (testnetRaw !== undefined && testnetRaw.length > 0);
+  if (!anySet) return undefined;
+  return {
+    ...(appName !== undefined && appName.length > 0 ? { appName } : {}),
+    ...(walletConnectProjectId !== undefined && walletConnectProjectId.length > 0
+      ? { walletConnectProjectId }
+      : {}),
+    testnet: testnetRaw === "true" || testnetRaw === "1",
   };
 }

--- a/examples/resource-server/src/config.ts
+++ b/examples/resource-server/src/config.ts
@@ -113,6 +113,7 @@ function asHttpUrl(value: string, name: string): string {
 export function readEnv(): ResourceServerEnv {
   const chainId = asInt(optional("CHAIN_ID", "31337"), "CHAIN_ID", { min: 1 });
   const subgraphRaw = process.env.SUBGRAPH_URL;
+  const paywall = readPaywallEnv();
   return {
     publicUrl: asHttpUrl(required("RESOURCE_SERVER_URL"), "RESOURCE_SERVER_URL"),
     rpcNode: asHttpUrl(required("RPC_NODE"), "RPC_NODE"),
@@ -133,7 +134,7 @@ export function readEnv(): ResourceServerEnv {
       ? { subgraphUrl: asHttpUrl(subgraphRaw, "SUBGRAPH_URL") }
       : {}),
     port: asInt(optional("PORT", "4001"), "PORT", { min: 1, max: 65535 }),
-    ...(readPaywallEnv() !== undefined ? { paywall: readPaywallEnv() } : {}),
+    ...(paywall !== undefined ? { paywall } : {}),
   };
 }
 

--- a/examples/resource-server/src/index.ts
+++ b/examples/resource-server/src/index.ts
@@ -23,8 +23,17 @@ if (isMain) {
 // Reference assembly for forks — once `exchangeReader` is wired in,
 // replace the throw above with:
 //
+//   import { evmEscrowPaywall } from "@bosonprotocol/x402-paywall";
+//
 //   const env = readEnv();
-//   const { app, seller } = createResourceServerApp(env, { exchangeReader });
+//   const { app, seller } = createResourceServerApp(env, {
+//     exchangeReader,
+//     // Opt-in HTML paywall for browser User-Agents; programmatic
+//     // clients keep seeing JSON 402s.
+//     ...(env.paywall !== undefined
+//       ? { paywall: evmEscrowPaywall, paywallConfig: env.paywall }
+//       : {}),
+//   });
 //   app.listen(env.port, () => {
 //     console.log(
 //       `[resource-server] listening on :${env.port} (chain ${env.chainId}, seller ${seller.address}, asset ${env.assetAddress})`,

--- a/examples/resource-server/test/resource-server.test.ts
+++ b/examples/resource-server/test/resource-server.test.ts
@@ -290,4 +290,68 @@ describe("resource-server example app", () => {
     expect(settle.body.exchangeId).toBe("42");
     expect(settle.body.txHash).toBe("0xabc");
   });
+
+  // Paywall integration — verifies that the `paywall` / `paywallConfig`
+  // options flow from `createResourceServerApp` through to
+  // `expressMiddleware` and `mountX402b`. Uses a tiny stub
+  // `PaywallProvider`; the real `evmEscrowPaywall` is exercised
+  // end-to-end through the middleware in `@bosonprotocol/x402-server-express`'s
+  // own test suite, so reusing the 4.7 MB bundle here would just
+  // duplicate that work (and choke supertest on the response size).
+  it("GET /resource with Accept: text/html and no paywall configured still returns JSON (no regression)", async () => {
+    const { app } = createResourceServerApp(buildEnv(), { exchangeReader: NULL_READER });
+    const res = await supertest(app).get("/resource").set("Accept", "text/html");
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.body.x402Version).toBe(2);
+  });
+
+  it("GET /resource with Accept: text/html + paywall configured returns HTML 402 (wiring through expressMiddleware)", async () => {
+    const stubPaywall = {
+      supports: vi.fn().mockReturnValue(true),
+      generateHtml: vi
+        .fn()
+        .mockReturnValue('<!DOCTYPE html><html><body data-from="stub">x</body></html>'),
+    };
+
+    const { app } = createResourceServerApp(buildEnv(), {
+      exchangeReader: NULL_READER,
+      paywall: stubPaywall,
+      paywallConfig: { appName: "Demo", testnet: true },
+    });
+
+    const res = await supertest(app).get("/resource").set("Accept", "text/html");
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/text\/html/);
+    expect(res.text).toContain('data-from="stub"');
+    expect(stubPaywall.generateHtml).toHaveBeenCalledTimes(1);
+    // The example forwards `paywallConfig` straight through.
+    expect(stubPaywall.generateHtml).toHaveBeenCalledWith(
+      expect.objectContaining({ requirements: expect.objectContaining({ scheme: "escrow" }) }),
+      { appName: "Demo", testnet: true },
+    );
+  });
+
+  it("POST /x402B/commit with Accept: text/html + paywall configured returns HTML 402 (wiring through mountX402b)", async () => {
+    const stubPaywall = {
+      supports: vi.fn().mockReturnValue(true),
+      generateHtml: vi
+        .fn()
+        .mockReturnValue('<!DOCTYPE html><html><body data-from="commit-stub">y</body></html>'),
+    };
+
+    const { app } = createResourceServerApp(buildEnv(), {
+      exchangeReader: NULL_READER,
+      paywall: stubPaywall,
+    });
+
+    const res = await supertest(app).post("/x402B/commit").set("Accept", "text/html").send();
+
+    expect(res.status).toBe(402);
+    expect(res.headers["content-type"]).toMatch(/text\/html/);
+    expect(res.text).toContain('data-from="commit-stub"');
+    expect(stubPaywall.generateHtml).toHaveBeenCalledTimes(1);
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@bosonprotocol/x402-core':
         specifier: workspace:^
         version: link:../../typescript/packages/core
+      '@bosonprotocol/x402-paywall':
+        specifier: workspace:^
+        version: link:../../typescript/packages/paywall
       '@bosonprotocol/x402-server':
         specifier: workspace:^
         version: link:../../typescript/packages/server

--- a/typescript/packages/server-express/src/internal/x402-challenge.ts
+++ b/typescript/packages/server-express/src/internal/x402-challenge.ts
@@ -34,9 +34,11 @@ export interface PaywallProviderLike {
 
 /**
  * Opaque pass-through config forwarded to `PaywallProvider.generateHtml`.
- * The adapter doesn't introspect it.
+ * The adapter doesn't introspect it — `object` is intentionally broad so
+ * any concrete `PaywallConfig` shape (with named optional fields, no
+ * index signature) satisfies it structurally.
  */
-export type PaywallConfigLike = Record<string, unknown>;
+export type PaywallConfigLike = object;
 
 export interface ChallengeOptions {
   paywall?: PaywallProviderLike;


### PR DESCRIPTION
## Summary

- `createResourceServerApp` now accepts optional `paywall` (`PaywallProvider`) and `paywallConfig`, forwarded to the underlying `expressMiddleware` and `mountX402b` calls.
- New env vars (`PAYWALL_APP_NAME`, `PAYWALL_WALLETCONNECT_PROJECT_ID`, `PAYWALL_TESTNET`) populate a `paywall` block on the parsed env; setting any of them opts in.
- `src/index.ts`'s reference assembly comment now shows how a fork wires in `evmEscrowPaywall` alongside the `exchangeReader`.
- Two new tests verify the wiring through both `expressMiddleware` (`GET /resource`) and `mountX402b` (`POST /x402B/commit`) using a stub `PaywallProvider`. End-to-end coverage against the real `evmEscrowPaywall` lives one PR up in `@bosonprotocol/x402-server-express`'s own suite.

## Why this completes the staged rollout

This is the fourth and final PR in the browser-paywall sequence:

1. #77 \`@bosonprotocol/x402-client-browser\` — viem WalletClient / EIP-1193 → Signer adapters
2. #78 \`@bosonprotocol/x402-paywall\` — React+wagmi paywall bundle + \`generateHtml\` server entry
3. #79 \`@bosonprotocol/x402-server-express\` — \`paywall:\` option + Accept content negotiation
4. **#80 (this PR)** — example host wiring; fork \`src/index.ts\`, set \`PAYWALL_*\` env vars, browse to \`/resource\` and see the paywall

## Drive-by fix

Widens \`PaywallConfigLike\` in \`@bosonprotocol/x402-server-express\` from \`Record<string, unknown>\` to \`object\` so concrete \`PaywallConfig\` shapes (with named optional fields, no index signature) satisfy it structurally. Required for this example to typecheck without casts; the structural-typing intent of \`PaywallProviderLike\` was already documented in #79.

## Notes

- Depends on #79 (\`server-express\` paywall option); base is set accordingly. Auto-rebases to \`main\` once #77 → #78 → #79 merge.
- The binary still refuses to start without an \`ExchangeReader\` (unchanged) — the paywall integration is for the programmatic / fork path, plus the test surface.

## Test plan

- [x] \`pnpm --filter @bosonprotocol/x402-example-resource-server build\` — clean
- [x] \`pnpm --filter @bosonprotocol/x402-example-resource-server test\` — 14/14 (11 existing + 3 new)
- [x] Repo-wide \`pnpm build\` — 16/16 successful
- [x] Repo-wide \`pnpm test\` — 32/32 successful
- [x] Repo-wide \`pnpm lint\` — 16/16 successful
- [x] Repo-wide \`pnpm format:check\` — clean
- [ ] Manual browser smoke test — needs a forked binary with \`ExchangeReader\` wired in and a live facilitator; deferred to your local environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)