### PR TITLE
feat(x402-e2e): concurrent commit-and-redeem scenario (20 parallel buyers)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,15 @@ JSON schemas under `src/**/schemas/` into `dist/schemas/`.
 Tests use **vitest**. The package-level `test` script passes
 `--passWithNoTests` for empty packages, so they don't fail CI.
 
+The `x402-e2e` suite gates on `E2E_DOCKER=1` (drives a real docker
+stack via `pnpm stack:up` / `stack:down`). When iterating on a
+single scenario file against a stack you launched manually, set
+`E2E_DOCKER_KEEP_STACK=1` alongside it — `globalSetup` then skips
+both the defensive pre-start `stopStack()` and the post-suite
+teardown, leaving the stack running so the next invocation reuses
+it (seeders are idempotent; the suite mints fresh buyer EOAs each
+run).
+
 ### CI
 
 GitHub Actions matrix on the currently-supported LTS Node versions.

--- a/examples/resource-server/src/app.ts
+++ b/examples/resource-server/src/app.ts
@@ -177,6 +177,7 @@ export function createResourceServerApp(
           env,
           sellerAddress: seller.address,
           now: now(),
+          sessionId,
           ...(protocolConfig !== undefined ? { protocolConfig } : {}),
         }),
       },

--- a/examples/resource-server/src/offer.ts
+++ b/examples/resource-server/src/offer.ts
@@ -25,6 +25,17 @@ export interface BuildOfferArgs {
   /** Wall-clock time to anchor offer validity windows. Injectable for tests. */
   now?: number;
   /**
+   * Per-request session id — folded into `metadataUri` / `metadataHash`
+   * so concurrent buyers (each with a distinct session id) never
+   * produce byte-identical `UnsignedFullOffer` structs. Without this
+   * salt, two requests hitting the server within the same millisecond
+   * share `validFromDateInMS` and every other field, the seller signs
+   * the same offer twice, and the second commit reverts `OfferSoldOut`
+   * on the single-quantity template. Defaults to `"no-session"` for
+   * callers that don't track sessions.
+   */
+  sessionId?: string;
+  /**
    * On-chain `ConfigHandlerFacet` slice — when supplied, the builder
    * tightens `feeLimit` and floors `disputePeriodDurationInMS` against
    * the actual on-chain values instead of using the conservative
@@ -87,11 +98,21 @@ export interface BuildOfferArgs {
  *
  * ## Customising for your catalogue
  *
- * The demo uses deliberately short windows (offer 1 h, redemption 1 h,
- * dispute 1 d, resolution 1 w) so e2e runs finish quickly. Real
- * catalogues should widen all four to whatever fits the product. The
- * only hard constraints are the validation rules in
- * `IBosonOfferHandler` and core-sdk's `CreateOfferArgs`:
+ * The defaults below are deliberately wide — offer + redemption open
+ * 1 day in the past and run 30 days into the future. Two reasons:
+ *
+ * 1. **Local-stack chain-time drift tolerance.** Hardhat under
+ *    interval mining advances `block.timestamp` 1 s per block, so at
+ *    a 50 ms interval chain time runs ~20× wall-clock. A 1-hour
+ *    validity window expires in ~3 min of wall-clock; a 30-day
+ *    window survives any realistic suite run.
+ * 2. **Drop-in for varied catalogue lifetimes.** Real catalogues
+ *    pick whatever fits the product; "30 days" is a sane upper
+ *    default that won't surprise demos.
+ *
+ * Forks can narrow these to fit their flow — the only hard
+ * constraints are the validation rules in `IBosonOfferHandler` and
+ * core-sdk's `CreateOfferArgs`:
  *
  * - `validFromDateInMS < validUntilDateInMS`, and `validUntilDateInMS`
  *   must be in the future at submission time.
@@ -103,12 +124,15 @@ export function buildUnsignedOffer({
   env,
   sellerAddress,
   now,
+  sessionId,
   protocolConfig,
 }: BuildOfferArgs): UnsignedFullOffer {
   const t = now ?? Date.now();
+  const salt = sessionId ?? "no-session";
   const oneHour = 60 * 60 * 1000;
   const oneDay = 24 * oneHour;
   const oneWeek = 7 * oneDay;
+  const thirtyDays = 30 * oneDay;
 
   // `disputePeriodDurationInMS`: prefer the demo's 1-week target but
   // floor it against the protocol's `getMinDisputePeriod()` when the
@@ -140,17 +164,17 @@ export function buildUnsignedOffer({
     agentId: "0",
     buyerCancelPenalty: "0",
     quantityAvailable: "1",
-    validFromDateInMS: String(t),
-    validUntilDateInMS: String(t + oneHour),
-    voucherRedeemableFromDateInMS: String(t),
-    voucherRedeemableUntilDateInMS: String(t + oneHour),
+    validFromDateInMS: String(t - oneDay),
+    validUntilDateInMS: String(t + thirtyDays),
+    voucherRedeemableFromDateInMS: String(t - oneDay),
+    voucherRedeemableUntilDateInMS: String(t + thirtyDays),
     disputePeriodDurationInMS: String(disputePeriodDurationInMS),
     voucherValidDurationInMS: "0",
     resolutionPeriodDurationInMS: String(oneWeek),
     exchangeToken: env.assetAddress,
     disputeResolverId: env.disputeResolverId,
-    metadataUri: "ipfs://x402b-example",
-    metadataHash: "x402b-example",
+    metadataUri: `ipfs://x402b-example/${salt}`,
+    metadataHash: `x402b-example-${salt}`,
     collectionIndex: "0",
     feeLimit,
     offerCreator: sellerAddress,

--- a/typescript/packages/x402-e2e/test/scenarios/_seed-wallets.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_seed-wallets.ts
@@ -34,6 +34,7 @@ import {
   ACCOUNT_10,
   ACCOUNT_11,
   ACCOUNT_12,
+  ACCOUNT_13,
 } from "../../src/config/accounts.js";
 
 export interface SeedWalletSlot {
@@ -61,6 +62,8 @@ export const SEED_WALLETS = {
   postCommit: toSlot(ACCOUNT_6),
   /** Reserved for `validation-commit.test.ts` once it lands chain-touching tests. */
   validationCommit: toSlot(ACCOUNT_7),
+  /** `concurrent.test.ts` — funds the 20 parallel buyers and registers the slot's seller. */
+  concurrent: toSlot(ACCOUNT_13),
   /** Spare slots for future chain-touching scenario files. */
   spareA: toSlot(ACCOUNT_10),
   spareB: toSlot(ACCOUNT_11),

--- a/typescript/packages/x402-e2e/test/scenarios/concurrent.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/concurrent.test.ts
@@ -1,0 +1,158 @@
+// Concurrent access scenario — exercises the resource server +
+// facilitator pair under simultaneous, multi-buyer load. Every other
+// scenario file drives one buyer at a time (vitest serialises tests
+// within a file), so regressions in the relayer nonce manager,
+// session cache, or seller-side FullOffer signing under contention
+// only show up here.
+//
+// Layout: 20 distinct freshly-funded EOAs each call
+// `fetch(/resource)` against the same in-process resource server
+// concurrently, all configured with `policy.redeemMode = "commit-and-redeem"`
+// (atomic flow, same wire path as scenario A2). Every fetch is
+// kicked off via `Promise.all(...)` so each client launches before
+// any previous one has resolved.
+//
+// Gated behind `E2E_DOCKER=1`. Idempotent: each run mints 20 new
+// random accounts, so re-running against an already-up stack
+// (`E2E_DOCKER_KEEP_STACK=1`, see `test/setup/globalSetup.ts`) is
+// safe to repeat indefinitely.
+
+import { ExchangeState } from "@bosonprotocol/x402-actions";
+import type { LocalAccount } from "viem";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { LOCAL_31337_0 } from "../../src/config/local-31337-0.js";
+import {
+  buildPublicClient,
+  buildWalletClient,
+  createBuyerActor,
+  readXPaymentResponse,
+  type BuyerActor,
+} from "../../src/harness/index.js";
+
+import { createFundedBuyer, ensureBuyerCanPay } from "./_buyer-setup.js";
+import { ENABLED } from "./_flags.js";
+import { SEED_WALLETS } from "./_seed-wallets.js";
+import { createScenarioContext, type ScenarioContext } from "./_setup.js";
+
+const CONCURRENT_BUYERS = 20;
+const PER_COMMIT_AMOUNT = 1_000_000n;
+
+interface CommitResponseBody {
+  ok?: boolean;
+  x402b?: { exchangeId?: string; txHash?: `0x${string}` };
+}
+
+describe.skipIf(!ENABLED)("@p0 concurrent commit-and-redeem scenarios", () => {
+  let ctx: ScenarioContext;
+  let buyers: BuyerActor[];
+
+  beforeAll(async () => {
+    const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS.concurrent.account);
+
+    // Step 1 — fund 20 fresh EOAs sequentially. The funder has a
+    // single nonce stream, so parallel `sendTransaction` calls would
+    // race; the loop costs ~1 s total (well inside `hookTimeout`).
+    const buyerAccounts: LocalAccount[] = [];
+    for (let i = 0; i < CONCURRENT_BUYERS; i++) {
+      buyerAccounts.push(await createFundedBuyer({ funder, publicClient }));
+    }
+
+    // Step 2 — mint + approve in parallel. Each buyer signs from its
+    // own nonce stream, so 20 concurrent `mint` + `approve` pairs are
+    // safe and let the chain mine them back-to-back.
+    await Promise.all(
+      buyerAccounts.map((account) =>
+        ensureBuyerCanPay({
+          walletClient: buildWalletClient(account),
+          publicClient,
+          buyerAddress: account.address,
+          assetAddress: LOCAL_31337_0.contracts.testErc20,
+          escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+          amount: PER_COMMIT_AMOUNT,
+        }),
+      ),
+    );
+
+    // The describe only needs the context for `resourceServerUrl`,
+    // `seller`, `asserter`, and `teardown` — `ctx.buyer` is unused
+    // because the test drives its own 20-buyer fleet. The first
+    // buyer account is passed in to satisfy the required arg.
+    ctx = await createScenarioContext({
+      slot: "concurrent",
+      buyerAccount: buyerAccounts[0]!,
+    });
+
+    // Step 3 — assemble 20 BuyerActors that all share a single
+    // `publicClient` (viem connection reuse) and the single
+    // in-process resource server. Each actor signs from its own
+    // account, so concurrent meta-tx signing across the fleet is
+    // race-free.
+    buyers = buyerAccounts.map((account) =>
+      createBuyerActor({
+        account,
+        publicClient,
+        policy: { redeemMode: "commit-and-redeem" },
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await ctx?.teardown();
+  });
+
+  it(`E0 — ${CONCURRENT_BUYERS} concurrent buyers atomic commit-and-redeem`, async () => {
+    // Fire every fetch synchronously before awaiting any of them.
+    // `Promise.all` over `.map((b) => b.fetch(...))` starts each
+    // request in the same microtask, satisfying the "no waiting for
+    // the previous client" requirement; `t0` lets the run log
+    // confirm the burst behaviour at a glance.
+    const t0 = Date.now();
+    const responses = await Promise.all(
+      buyers.map((b) => b.fetch(`${ctx.resourceServerUrl}/resource`)),
+    );
+    console.log(
+      `[concurrent.test] ${CONCURRENT_BUYERS} fetches completed in ${Date.now() - t0} ms`,
+    );
+
+    for (const res of responses) {
+      expect(res.status, await res.clone().text()).toBe(200);
+    }
+
+    const bodies = (await Promise.all(responses.map((r) => r.json()))) as CommitResponseBody[];
+    const exchangeIds: string[] = [];
+    for (let i = 0; i < bodies.length; i++) {
+      const body = bodies[i]!;
+      expect(body.ok, `buyer ${i} body.ok`).toBe(true);
+      const exchangeId = body.x402b?.exchangeId;
+      expect(typeof exchangeId, `buyer ${i} exchangeId type`).toBe("string");
+      exchangeIds.push(exchangeId!);
+
+      const decoded = readXPaymentResponse(responses[i]!.headers);
+      expect(decoded, `buyer ${i} X-PAYMENT-RESPONSE`).not.toBeNull();
+      expect(decoded?.exchangeId).toBe(exchangeId);
+      expect(decoded?.txHash).toMatch(/^0x[0-9a-fA-F]+$/);
+    }
+
+    // Each request gets a freshly-signed FullOffer template (random
+    // meta-tx nonce → unique predicted offerId), so collisions
+    // would surface here as duplicate exchange ids.
+    expect(new Set(exchangeIds).size).toBe(CONCURRENT_BUYERS);
+
+    // On-chain state — all 20 should land in REDEEMED (atomic flow).
+    // The asserter's `withPollUntilFound` wrapper absorbs the
+    // subgraph indexer's 1–5 s lag; 20 parallel polls overlap so the
+    // wall-clock is dominated by the slowest, not the sum.
+    await Promise.all(
+      exchangeIds.map((id) =>
+        ctx.asserter.expect(id, {
+          state: ExchangeState.REDEEMED,
+          seller: ctx.seller.address,
+          exchangeToken: LOCAL_31337_0.contracts.testErc20,
+          price: PER_COMMIT_AMOUNT.toString(),
+        }),
+      ),
+    );
+  });
+});

--- a/typescript/packages/x402-e2e/test/setup/globalSetup.ts
+++ b/typescript/packages/x402-e2e/test/setup/globalSetup.ts
@@ -170,14 +170,20 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
       `[x402-e2e/globalSetup] suite ready — sellers=${JSON.stringify(sellersBySlot)}, disputeResolverId=${disputeResolverId}`,
     );
   } catch (setupErr) {
-    console.error("[x402-e2e/globalSetup] post-start setup failed, tearing down stack…");
-    try {
-      await stopStack();
-    } catch (teardownErr) {
+    if (KEEP_STACK) {
       console.error(
-        "[x402-e2e/globalSetup] stopStack() failed during teardown after setup error — original setup error will be rethrown:",
-        teardownErr,
+        "[x402-e2e/globalSetup] post-start setup failed; E2E_DOCKER_KEEP_STACK=1 — leaving stack up for debugging.",
       );
+    } else {
+      console.error("[x402-e2e/globalSetup] post-start setup failed, tearing down stack…");
+      try {
+        await stopStack();
+      } catch (teardownErr) {
+        console.error(
+          "[x402-e2e/globalSetup] stopStack() failed during teardown after setup error — original setup error will be rethrown:",
+          teardownErr,
+        );
+      }
     }
     throw setupErr;
   }

--- a/typescript/packages/x402-e2e/test/setup/globalSetup.ts
+++ b/typescript/packages/x402-e2e/test/setup/globalSetup.ts
@@ -7,19 +7,37 @@
 //   1. `startStack({ waitForReady: true })` — bring up the canonical
 //      Boson stack + x402B services and block until the contracts +
 //      subgraph `deploy.done` markers exist.
-//   2. Register one Boson seller entity per slot in `SEED_WALLETS`.
+//   2. Switch the chain from default automine to a 50 ms mining
+//      interval (see `enableIntervalMining` below). Concurrent
+//      meta-tx submissions only queue in the mempool when automine
+//      is off — under automine Hardhat rejects everything that isn't
+//      the next-next nonce.
+//   3. Register one Boson seller entity per slot in `SEED_WALLETS`.
 //      Each chain-touching test FILE picks a slot — sharing a seller
 //      across parallel files causes `OfferSoldOut` races on FullOffer
 //      signature reuse, so we provision a distinct seller for every
 //      slot the suite knows about. `seedSuite` is idempotent so
 //      re-running on an existing chain state is a no-op.
-//   3. Export per-slot seller info (`{id, address}`) as a JSON map
+//   4. Export per-slot seller info (`{id, address}`) as a JSON map
 //      via `process.env[SELLERS_ENV_KEY]`, plus the protocol-global
 //      dispute resolver id, so each test file's `beforeAll` can read
 //      its slot's seller without re-querying the subgraph.
+//
+// Standalone-run escape hatch — `E2E_DOCKER_KEEP_STACK=1`:
+//   When set alongside `E2E_DOCKER=1`, the setup skips BOTH the
+//   defensive pre-start `stopStack()` AND the post-suite teardown.
+//   `startStack({ waitForReady: true })` is still called (`docker
+//   compose up -d --wait` is idempotent and returns ~instantly when
+//   every container is already healthy) and seller seeding still
+//   runs (`seedSuite` is itself idempotent). The caller's contract:
+//   "the stack I brought up matches the facilitator's view of the
+//   chain — don't touch it." Use this when iterating on a single
+//   scenario file against a stack you launched manually via
+//   `pnpm stack:up`.
 
 import type { Address } from "viem";
 
+import { LOCAL_31337_0 } from "../../src/config/local-31337-0.js";
 import {
   buildCreateSellerCallback,
   buildPublicClient,
@@ -43,6 +61,40 @@ export const SUITE_STATE_ENV = {
 } as const;
 
 const ENABLED = process.env.E2E_DOCKER === "1";
+const KEEP_STACK = process.env.E2E_DOCKER_KEEP_STACK === "1";
+
+/**
+ * Switch the local Hardhat chain from automine to a 50 ms mining
+ * interval. Concurrent meta-tx submissions through the facilitator
+ * (e.g. `concurrent.test.ts`'s 20 parallel buyers) only queue in the
+ * mempool when automine is OFF — under default automine Hardhat
+ * rejects every tx whose nonce isn't already-next with
+ * `"transactions can't be queued when automining"`. The 50 ms cadence
+ * keeps the sequential seeding phase fast (~1.5 s for the ~30 txs
+ * across all `SEED_WALLETS` slots) while letting a burst of 20+
+ * concurrent commits land in one or two blocks.
+ *
+ * Idempotent: re-invoking on an already-interval-mining chain just
+ * resets the timer. Called every globalSetup invocation so the
+ * KEEP_STACK fast-path doesn't have to remember the prior setting.
+ */
+async function enableIntervalMining(): Promise<void> {
+  const rpc = LOCAL_31337_0.urls.jsonRpc;
+  const post = async (method: string, params: unknown[]): Promise<unknown> => {
+    const res = await fetch(rpc, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+    const body = (await res.json()) as { result?: unknown; error?: { message: string } };
+    if (body.error !== undefined) {
+      throw new Error(`[x402-e2e/globalSetup] ${method} failed: ${body.error.message}`);
+    }
+    return body.result;
+  };
+  await post("evm_setAutomine", [false]);
+  await post("evm_setIntervalMining", [50]);
+}
 
 export default async function globalSetup(): Promise<() => Promise<void>> {
   if (!ENABLED) {
@@ -52,26 +104,37 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     };
   }
 
-  // Defensive `down -v` before `up`: a previous run aborted before its
-  // teardown (Ctrl+C, vitest crash, OS shutdown) leaves containers up
-  // but with stale in-process state — most notably the facilitator's
-  // viem `nonceManager`, which caches the relayer's next-nonce in
-  // memory. Once the chain is redeployed (deploy.done re-runs on
-  // volume reset), the chain expects nonce 0 while the lingering
-  // facilitator process still thinks it's at N+1 → "Nonce too high"
-  // on every meta-tx submit. Tearing the stack down here guarantees
-  // every test run starts from genesis: fresh containers, fresh
-  // in-memory state, fresh chain. The cost is a few extra seconds at
-  // suite startup; the win is determinism.
-  console.log("[x402-e2e/globalSetup] resetting any leftover stack…");
-  try {
-    await stopStack();
-  } catch (e) {
-    console.warn("[x402-e2e/globalSetup] stopStack() before startStack failed — continuing:", e);
+  if (KEEP_STACK) {
+    // Caller asserts they brought the stack up themselves (via
+    // `pnpm stack:up` or a previous KEEP_STACK run) and want it left
+    // running afterwards. Skip the defensive `stopStack()` — tearing
+    // down would defeat the whole purpose of the flag.
+    console.log("[x402-e2e/globalSetup] E2E_DOCKER_KEEP_STACK=1 — using existing stack as-is…");
+  } else {
+    // Defensive `down -v` before `up`: a previous run aborted before its
+    // teardown (Ctrl+C, vitest crash, OS shutdown) leaves containers up
+    // but with stale in-process state — most notably the facilitator's
+    // viem `nonceManager`, which caches the relayer's next-nonce in
+    // memory. Once the chain is redeployed (deploy.done re-runs on
+    // volume reset), the chain expects nonce 0 while the lingering
+    // facilitator process still thinks it's at N+1 → "Nonce too high"
+    // on every meta-tx submit. Tearing the stack down here guarantees
+    // every test run starts from genesis: fresh containers, fresh
+    // in-memory state, fresh chain. The cost is a few extra seconds at
+    // suite startup; the win is determinism.
+    console.log("[x402-e2e/globalSetup] resetting any leftover stack…");
+    try {
+      await stopStack();
+    } catch (e) {
+      console.warn("[x402-e2e/globalSetup] stopStack() before startStack failed — continuing:", e);
+    }
   }
 
   console.log("[x402-e2e/globalSetup] starting stack…");
   await startStack({ waitForReady: true });
+
+  console.log("[x402-e2e/globalSetup] switching Hardhat to 50 ms interval mining…");
+  await enableIntervalMining();
 
   try {
     const publicClient = buildPublicClient();
@@ -120,6 +183,12 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   }
 
   return async () => {
+    if (KEEP_STACK) {
+      console.log(
+        "[x402-e2e/globalSetup] E2E_DOCKER_KEEP_STACK=1 — preserving stack; run `pnpm stack:down` manually when done.",
+      );
+      return;
+    }
     console.log("[x402-e2e/globalSetup] tearing down stack…");
     await stopStack();
   };


### PR DESCRIPTION
## Summary

- New `@p0` scenario file `concurrent.test.ts` — 20 fresh EOAs fire `fetch(/resource)` concurrently against an in-process resource server, each going through atomic commit-and-redeem (the A2 wire path). Surfaces concurrency regressions the existing single-buyer scenarios can't catch (relayer `nonceManager`, offer-template signing under contention, subgraph indexer under load).
- `E2E_DOCKER_KEEP_STACK=1` escape hatch on `globalSetup` — preserves a stack the maintainer brought up via `pnpm stack:up` so individual scenario files can be re-run repeatedly without paying the full cold-start cost.

## Upstream tweaks bundled with the test

Three concurrency limits had to be addressed for the test to land green. Each is documented inline:

- **`example-resource-server` offer salting** — `buildUnsignedOffer` now folds the per-request `sessionId` into `metadataUri` / `metadataHash`. Without it, two concurrent requests within the same millisecond produce byte-identical `UnsignedFullOffer` structs and the second commit reverts `OfferSoldOut()` on the single-quantity template.
- **`example-resource-server` widened validity windows** — offer + voucher windows go from 1 h to 30 d (with 1 d backdate). Hardhat's `block.timestamp` advances 1 s per block; at 50 ms interval mining chain time runs ~20× wall-clock, so the prior 1 h window expired in ~3 min of suite wall-clock.
- **`x402-e2e/globalSetup` interval mining** — switches Hardhat from automine to 50 ms interval mining right after `[stack] ready`. Default automine rejects concurrent meta-tx submissions from a single relayer with `"transactions can't be queued when automining"`; interval mining lets them queue and mine in batches.

## Run modes

```bash
# Mode 1 — full suite (existing convention, the test runs alongside everything else):
E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test

# Mode 2 — repeatable against a stack you launched manually:
pnpm --filter @bosonprotocol/x402-e2e stack:up
E2E_DOCKER=1 E2E_DOCKER_KEEP_STACK=1 \
  pnpm --filter @bosonprotocol/x402-e2e exec vitest run test/scenarios/concurrent.test.ts
# (re-run as many times as you want — fresh EOAs each run)
pnpm --filter @bosonprotocol/x402-e2e stack:down
```

## Test plan

- [x] `pnpm -r build` — every workspace package builds clean
- [x] `pnpm -r lint` — zero warnings
- [x] `pnpm format:check` — clean
- [x] `pnpm --filter @bosonprotocol/x402-example-resource-server test` — 11/11 unit tests pass (cache + offer building still green after the `sessionId` plumbing)
- [x] **Mode 1** (full e2e suite, fresh stack): 7 test files passed, 36 tests passed, 1 skipped, 30 todo — `A1`, `A2`, new `E0` (concurrent), `B1`–`B7`, harness, stack — all green; stack tears down cleanly at the end
- [x] **Mode 2** (`E2E_DOCKER_KEEP_STACK=1`, preserved stack): ran the concurrent test twice in a row against the same stack — both green, stack preserved between runs

This PR is stacked on #76 (`add-x402-e2e-post-commit-lifecycle`); base auto-rebases to `main` when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)