### PR TITLE
test(x402-e2e): add operational failure-mode scenarios + nightly CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,48 @@ jobs:
       - run: pnpm test
 
       - run: pnpm format:check
+
+  # Runs the @p0 subset of the x402-e2e scenario suite against the real
+  # Docker stack. Always-on per PR. Cold image pulls + stack boot take
+  # 2–5 minutes; the @p0 subset itself completes in ~1–2 minutes. The
+  # full breadth (including @p1 / @p2 operational scenarios) runs in
+  # the nightly workflow.
+  e2e-p0:
+    name: e2e (@p0)
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.7.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - name: Run @p0 e2e suite
+        env:
+          E2E_DOCKER: "1"
+        run: pnpm --filter @bosonprotocol/x402-e2e test -- -t '@p0'
+
+      - name: Dump docker compose logs on failure
+        if: failure()
+        run: |
+          cd typescript/packages/x402-e2e
+          docker compose -f src/stack/compose.yaml logs --no-color > docker-compose.log || true
+
+      - name: Upload docker logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-p0-logs-${{ github.run_id }}
+          path: typescript/packages/x402-e2e/docker-compose.log
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,15 @@ jobs:
       matrix:
         node: [22, 24]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.7.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -59,13 +61,15 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.7.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -87,7 +91,7 @@ jobs:
 
       - name: Upload docker logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: e2e-p0-logs-${{ github.run_id }}
           path: typescript/packages/x402-e2e/docker-compose.log

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,13 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.7.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -62,7 +64,7 @@ jobs:
 
       - name: Upload docker logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: nightly-logs-${{ github.run_id }}
           path: typescript/packages/x402-e2e/docker-compose.log

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,69 @@
+name: Nightly e2e
+
+# Runs the full x402-e2e scenario suite (@p0 + @p1 + @p2) against the
+# real Docker stack on a daily schedule. Operational failure-mode
+# scenarios (F1 facilitator restart, F2 subgraph lag, F4 buyer key
+# rotation) live in the @p1 / @p2 tiers so they only exercise here —
+# the per-PR `e2e-p0` job in `ci.yml` skips them by tag filter.
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # 03:00 UTC daily
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  # Manual `workflow_dispatch` should not cancel a scheduled run in
+  # progress (and vice versa). Each is a deliberate request.
+  cancel-in-progress: false
+
+# Mirrors ci.yml: opt JS-action runtimes onto Node 24 ahead of
+# GitHub's June 2026 forced migration so deprecation warnings stay
+# off the log.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  e2e-full:
+    name: e2e (full suite)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.7.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - name: Run full e2e suite
+        env:
+          E2E_DOCKER: "1"
+          # operational.test.ts pauses / kills containers other test
+          # files depend on. `E2E_SEQUENTIAL=1` switches vitest into
+          # `fileParallelism: false` so the chaos in one file can't
+          # race the chain-touching tests in another.
+          E2E_SEQUENTIAL: "1"
+        run: pnpm --filter @bosonprotocol/x402-e2e test
+
+      - name: Dump docker compose logs
+        if: always()
+        run: |
+          cd typescript/packages/x402-e2e
+          docker compose -f src/stack/compose.yaml logs --no-color > docker-compose.log || true
+
+      - name: Upload docker logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-logs-${{ github.run_id }}
+          path: typescript/packages/x402-e2e/docker-compose.log
+          if-no-files-found: ignore

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,8 +54,8 @@ jobs:
           E2E_SEQUENTIAL: "1"
         run: pnpm --filter @bosonprotocol/x402-e2e test
 
-      - name: Dump docker compose logs
-        if: always()
+      - name: Dump docker compose logs on failure
+        if: failure()
         run: |
           cd typescript/packages/x402-e2e
           docker compose -f src/stack/compose.yaml logs --no-color > docker-compose.log || true

--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -167,7 +167,8 @@ with `-t '@p0'`. Priorities:
 | `@p1`    | post-commit lifecycle (B6, B7)                | `post-commit.test.ts`         |
 | `@p1`    | operational scenarios (F1)                    | `operational.test.ts`         |
 | `@p2`    | operational scenarios (F2, F4)                | `operational.test.ts`         |
-| `it.todo`| follow-up scenarios (B5, B8–9, C6–C10, D1–D4, E1–E3, A6–A8) | `_skeletons.test.ts` |
+| `@p1/@p2`| commit-time fulfillment (A6–A8)               | `_skeletons.test.ts`          |
+| `it.todo`| follow-up scenarios (B5, B8–9, C6–C10, D1–D4, E1–E3) | `_skeletons.test.ts`   |
 
 ### Running a tag subset
 

--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -31,7 +31,8 @@ src/
   stack/
     compose.yaml                  ← canonical Boson stack + 3 x402B services
     ipfs-config.sh                ← volume-mounted into the ipfs container
-    start.ts / stop.ts            ← programmatic docker compose up / down
+    start.ts / stop.ts            ← programmatic docker compose up / down (whole-stack lifecycle)
+    service-control.ts            ← per-service kill / pause / unpause / start (chaos for F1, F2)
     readiness.ts                  ← polls boson-protocol-node + boson-subgraph deploy.done markers
     paths.ts / exec.ts            ← internals
   harness/                          ← PR 5
@@ -56,10 +57,14 @@ test/
     globalSetup.ts                ← boots stack + seeds seller; gated on E2E_DOCKER
   scenarios/                      ← PR 6
     _setup.ts                     ← per-test scaffolding (in-process resource server, actors, asserter)
-    _buyer-setup.ts               ← mint + approve helpers for the `none` strategy
-    _skeletons.test.ts            ← it.todo declarations for PR 7 / PR 8 scenarios
-    commit.test.ts                ← A1 runnable + A2–A5 todo
-    validation-commit.test.ts     ← C1–C5/C8 todo (lands in PR 7)
+    _buyer-setup.ts               ← mint + approve helpers; `createFundedBuyer` + `rotateBuyer` (F4)
+    _seed-wallets.ts              ← per-FILE seed-wallet pool (one Boson seller per slot)
+    _skeletons.test.ts            ← it.todo anchors for unimplemented scenarios
+    commit.test.ts                ← A1, A2 runnable
+    post-commit.test.ts           ← B1–B4 (@p0), B6, B7 (@p1)
+    concurrent.test.ts            ← E0 — 20 parallel atomic commit-and-redeem
+    operational.test.ts           ← F1 (@p1), F2, F4 (@p2) — failure-mode chaos
+    validation-commit.test.ts     ← C1–C5, C8 (commit-time validation negatives)
 ```
 
 ## Bring the stack up
@@ -140,6 +145,67 @@ service's HTTP-level health probe (or root URL), and tears down. Allow
 
 Without `E2E_DOCKER=1`, the suite skips itself so the repo-wide
 `pnpm test` stays fast.
+
+## Scenario inventory
+
+Tests are tagged in the `describe(...)` title so vitest can filter
+with `-t '@p0'`. Priorities:
+
+- **`@p0`** — happy-path commit + post-commit lifecycle. Runs on
+  every PR in CI (see `.github/workflows/ci.yml`'s `e2e-p0` job).
+- **`@p1`** — secondary lifecycle paths + operational scenarios
+  with a tight blast radius. Runs nightly.
+- **`@p2`** — niche failure modes (subgraph lag, buyer key
+  rotation) and lower-impact transitions. Runs nightly.
+
+| Tag(s)   | Describe                                      | File                          |
+|----------|-----------------------------------------------|-------------------------------|
+| `@p0`    | commit-time scenarios (A1, A2)                | `commit.test.ts`              |
+| `@p0`    | concurrent commit-and-redeem (E0)             | `concurrent.test.ts`          |
+| `@p0`    | post-commit lifecycle (B1–B4)                 | `post-commit.test.ts`         |
+| `@p0`    | commit-time validations (C1–C5, C8)           | `validation-commit.test.ts`   |
+| `@p1`    | post-commit lifecycle (B6, B7)                | `post-commit.test.ts`         |
+| `@p1`    | operational scenarios (F1)                    | `operational.test.ts`         |
+| `@p2`    | operational scenarios (F2, F4)                | `operational.test.ts`         |
+| `it.todo`| follow-up scenarios (B5, B8–9, C6–C10, D1–D4, E1–E3, A6–A8) | `_skeletons.test.ts` |
+
+### Running a tag subset
+
+```sh
+# Matches the per-PR CI job — @p0 only.
+E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test -- -t '@p0'
+
+# Matches the nightly workflow — full breadth.
+# E2E_SEQUENTIAL=1 disables file-parallelism so the operational
+# scenarios (F1 kills the facilitator, F2 pauses the subgraph) can't
+# race the commit / post-commit tests in another worker.
+E2E_DOCKER=1 E2E_SEQUENTIAL=1 pnpm --filter @bosonprotocol/x402-e2e test
+
+# Single file (against a stack you launched manually via `pnpm stack:up`).
+E2E_DOCKER=1 E2E_DOCKER_KEEP_STACK=1 \
+  pnpm --filter @bosonprotocol/x402-e2e test operational
+```
+
+## CI workflows
+
+- **`.github/workflows/ci.yml`** runs on every PR + push to `main`:
+  - `build-test-lint` — Node 22 / 24 matrix; `pnpm build`,
+    `pnpm test`, `pnpm lint`, `pnpm format:check`.
+  - `e2e-p0` — boots the stack and runs the `@p0` scenario subset
+    via `vitest -t '@p0'`. 25-min timeout (cold image pull adds 2–5
+    min). Uploads `docker compose logs` on failure.
+- **`.github/workflows/nightly.yml`** runs daily at 03:00 UTC and on
+  manual `workflow_dispatch`:
+  - `e2e-full` — same stack boot, no tag filter — runs every
+    scenario including the operational failure-mode tests in the
+    `@p1` / `@p2` tiers. 60-min timeout. Uploads `docker compose
+    logs` on failure.
+
+Both workflows pin Node 22 for the e2e job (Docker is the heavy
+dependency, not the Node version) and set
+`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` per repo policy so
+`actions/checkout` / `setup-node` / etc. opt onto Node 24 ahead of
+GitHub's June 2026 forced migration.
 
 ## Conventions
 

--- a/typescript/packages/x402-e2e/src/stack/index.ts
+++ b/typescript/packages/x402-e2e/src/stack/index.ts
@@ -5,3 +5,10 @@ export { startStack, type StartStackOptions } from "./start.js";
 export { stopStack, type StopStackOptions } from "./stop.js";
 export { waitForStackReady, type WaitForReadyOptions } from "./readiness.js";
 export { COMPOSE_FILE } from "./paths.js";
+export {
+  killService,
+  pauseService,
+  startService,
+  unpauseService,
+  type KillServiceOptions,
+} from "./service-control.js";

--- a/typescript/packages/x402-e2e/src/stack/service-control.ts
+++ b/typescript/packages/x402-e2e/src/stack/service-control.ts
@@ -1,0 +1,67 @@
+// Per-service Docker control for chaos-injection scenarios.
+//
+// `start.ts` / `stop.ts` own the WHOLE-stack lifecycle (the
+// `globalSetup` contract). The helpers here target a single compose
+// service so operational tests can simulate a container dying,
+// restarting, or being temporarily paused mid-flow. Examples:
+//
+//   - F1: hard-kill `x402b-facilitator-http`, restart, verify recovery.
+//   - F2: pause `boson-subgraph` for a window to force indexer lag.
+//
+// Service names are the YAML keys in `compose.yaml` — the docker compose
+// CLI accepts the service name and derives the running container by
+// project name (implicit, derived from the compose-file directory).
+// Whole-stack helpers in `start.ts` / `stop.ts` use the same implicit
+// project name, so service-control commands always target the same
+// containers the suite booted.
+//
+// Every helper rejects on a non-zero exit so callers in `afterEach`
+// blocks can wrap in `try/finally` and surface the original failure.
+
+import { run } from "./exec.js";
+import { COMPOSE_FILE } from "./paths.js";
+
+export interface KillServiceOptions {
+  /** Unix signal sent to the container's PID 1. Defaults to `"SIGKILL"`. */
+  signal?: "SIGKILL" | "SIGTERM" | "SIGINT" | "SIGHUP";
+}
+
+/**
+ * Send a signal to the container's PID 1 (`docker compose kill`).
+ *
+ * Default `SIGKILL` simulates an abrupt crash — the container stops
+ * immediately without graceful shutdown. Use `SIGTERM` for a softer
+ * teardown when the test wants the service to flush state.
+ */
+export async function killService(name: string, options: KillServiceOptions = {}): Promise<void> {
+  const signal = options.signal ?? "SIGKILL";
+  await run("docker", ["compose", "-f", COMPOSE_FILE, "kill", "-s", signal, name]);
+}
+
+/**
+ * `docker compose start <service>` — resumes a stopped or killed
+ * container. The image is reused (no rebuild), so the restart is
+ * fast (~1 s for our services).
+ */
+export async function startService(name: string): Promise<void> {
+  await run("docker", ["compose", "-f", COMPOSE_FILE, "start", name]);
+}
+
+/**
+ * `docker compose pause <service>` — sends SIGSTOP via the container
+ * runtime, freezing every process inside the container without
+ * tearing the network or volumes down. Used by F2 to make
+ * `boson-subgraph` lag the chain while a commit is in flight.
+ *
+ * Must be paired with {@link unpauseService} — a paused container
+ * stays paused across test files. Wrap callers in `try/finally` so
+ * a mid-test failure doesn't leave the suite's subgraph frozen.
+ */
+export async function pauseService(name: string): Promise<void> {
+  await run("docker", ["compose", "-f", COMPOSE_FILE, "pause", name]);
+}
+
+/** `docker compose unpause <service>` — releases SIGSTOP. */
+export async function unpauseService(name: string): Promise<void> {
+  await run("docker", ["compose", "-f", COMPOSE_FILE, "unpause", name]);
+}

--- a/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
@@ -20,6 +20,8 @@ import {
 } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
+import { buildWalletClient } from "../../src/harness/clients.js";
+
 const ERC20_TEST_ABI = [
   {
     type: "function",
@@ -143,6 +145,40 @@ export interface CreateFundedBuyerArgs {
  * tokens via `ensureBuyerCanPay`; the seed wallet only needs to
  * cover gas.
  */
+export interface RotateBuyerArgs extends CreateFundedBuyerArgs {
+  /** Payment-asset address (typically `LOCAL_31337_0.contracts.testErc20`). */
+  assetAddress: Address;
+  /** Escrow address — the `spender` the rotated buyer approves. */
+  escrowAddress: Address;
+  /** Amount the rotated buyer must be able to pay (atomic units). */
+  amount: bigint;
+}
+
+/**
+ * Generate a fresh buyer EOA, fund it with native ETH from `funder`,
+ * and ensure it has at least `amount` of the payment asset both
+ * minted and approved against `escrowAddress`. Used by F4 (buyer
+ * key rotation) where the test needs a SECOND buyer key — fully
+ * funded and approved — to attempt a redeem against an exchange
+ * committed by the FIRST buyer key.
+ *
+ * Sequential: funds gas first, then mint + approve through the new
+ * EOA's wallet. The mint + approve calls go through `ensureBuyerCanPay`
+ * which we delegate to so the recipe stays in one place.
+ */
+export async function rotateBuyer(args: RotateBuyerArgs): Promise<LocalAccount> {
+  const account = await createFundedBuyer(args);
+  await ensureBuyerCanPay({
+    walletClient: buildWalletClient(account),
+    publicClient: args.publicClient,
+    buyerAddress: account.address,
+    assetAddress: args.assetAddress,
+    escrowAddress: args.escrowAddress,
+    amount: args.amount,
+  });
+  return account;
+}
+
 export async function createFundedBuyer(args: CreateFundedBuyerArgs): Promise<LocalAccount> {
   // `WalletClient` doesn't require `account` / `chain` at the type
   // level, so unguarded non-null assertions would crash with an opaque

--- a/typescript/packages/x402-e2e/test/scenarios/_seed-wallets.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_seed-wallets.ts
@@ -64,8 +64,9 @@ export const SEED_WALLETS = {
   validationCommit: toSlot(ACCOUNT_7),
   /** `concurrent.test.ts` — funds the 20 parallel buyers and registers the slot's seller. */
   concurrent: toSlot(ACCOUNT_13),
+  /** `operational.test.ts` — F1 / F2 / F4 failure-mode scenarios. */
+  operational: toSlot(ACCOUNT_10),
   /** Spare slots for future chain-touching scenario files. */
-  spareA: toSlot(ACCOUNT_10),
   spareB: toSlot(ACCOUNT_11),
   spareC: toSlot(ACCOUNT_12),
 } as const;

--- a/typescript/packages/x402-e2e/test/scenarios/_skeletons.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_skeletons.test.ts
@@ -38,6 +38,10 @@ describe.skipIf(!ENABLED)("@p2 commit-time validations — PR 7", () => {
 describe.skipIf(!ENABLED)("@p0/@p1 nextActions / channel routing — PR 7", () => {
   it.todo("D1 — post-commit nextActions[] matches ACTION_POST_STATE for the new state");
   it.todo("D2 — post-redeem nextActions[] shrinks to [completeExchange, raiseDispute]");
+  // D3 stays a todo: the client-side channel fallback chain
+  // (server → facilitator → onchain on 5xx / network error) isn't
+  // implemented today in `x402-client` / `x402-client-fetch`. The
+  // test will land alongside the feature work in its own PR.
   it.todo("D3 — server/facilitator/onchain channel fallback chain (kill facilitator)");
   it.todo(
     "D4 — `mcp` channel for buyer-side action — skipped until `@bosonprotocol/x402-agent` lands",
@@ -48,13 +52,6 @@ describe.skipIf(!ENABLED)("@p1/@p2 multi-party — PR 7", () => {
   it.todo("E1 — two concurrent buyers commit to the same offer → distinct exchangeIds");
   it.todo("E2 — buyer commits, then seller revokeVoucher → buyer refunded");
   it.todo("E3 — mutual resolveDispute requires both buyer + seller sigs (dual-sig regression)");
-});
-
-describe.skipIf(!ENABLED)("@p1/@p2 operational / failure-mode — PR 8", () => {
-  it.todo("F1 — facilitator restart mid-flight → client retries idempotently");
-  it.todo("F2 — subgraph indexer lag → server falls back to RPC ExchangeReader");
-  it.todo("F3 — meta-tx-gateway down during createSeller seed → clear error surfaces");
-  it.todo("F4 — buyer key rotation mid-flow → redeem rejected (from-address mismatch)");
 });
 
 describe.skipIf(!ENABLED)("@p1/@p2 commit-time fulfillment — PR 7", () => {

--- a/typescript/packages/x402-e2e/test/scenarios/operational.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/operational.test.ts
@@ -315,22 +315,11 @@ describe.skipIf(!ENABLED)("@p2 operational scenarios", () => {
     });
     const wrongBuyer = createBuyerActor({ account: rotatedAccount, publicClient });
 
-    await expect(
-      performBuyerPostCommitAction({
-        actionId: "boson-redeem",
-        buyer: wrongBuyer,
-        resourceServerUrl: ctx.resourceServerUrl,
-        exchangeId,
-        escrowAddress: ctx.escrowAddress,
-        network: ctx.network,
-      }),
-    ).rejects.toBeInstanceOf(PostCommitActionError);
-
-    // Replay the call to inspect the error shape — `rejects.toBeInstanceOf`
-    // consumes the rejection but doesn't expose it. The replay is
-    // deterministic (no state has changed on-chain) so the second
-    // attempt rejects with the same error.
-    let caught: PostCommitActionError | null = null;
+    // Capture the rejection from a single invocation so we can inspect
+    // status / body on the same error instance. Avoid the
+    // `expect(...).rejects` + replay pattern: it doubles runtime and
+    // assumes the call is perfectly deterministic across retries.
+    let caught: unknown = null;
     try {
       await performBuyerPostCommitAction({
         actionId: "boson-redeem",
@@ -341,11 +330,12 @@ describe.skipIf(!ENABLED)("@p2 operational scenarios", () => {
         network: ctx.network,
       });
     } catch (e) {
-      caught = e as PostCommitActionError;
+      caught = e;
     }
-    expect(caught).not.toBeNull();
-    expect(caught?.status).toBe(502);
-    const body = caught?.body as { code?: string; reason?: string; details?: unknown } | undefined;
+    expect(caught).toBeInstanceOf(PostCommitActionError);
+    const err = caught as PostCommitActionError;
+    expect(err.status).toBe(502);
+    const body = err.body as { code?: string; reason?: string; details?: unknown } | undefined;
     expect(body?.code).toBe("FACILITATOR_REJECTED");
     // The redeem MUST be rejected — that's the load-bearing assertion.
     // The specific facilitator-side code reflects which classification

--- a/typescript/packages/x402-e2e/test/scenarios/operational.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/operational.test.ts
@@ -1,0 +1,380 @@
+// Operational failure-mode scenarios — section F of the e2e plan.
+//
+// Each scenario starts the suite in a healthy state (globalSetup
+// brought every service up) and then injects targeted chaos —
+// killing a container mid-flight, pausing the subgraph, or rotating
+// the buyer's signing key — to prove the system either recovers
+// gracefully or rejects the invalid request with a clear error.
+//
+// Coverage in this file:
+//
+//   - F1 — facilitator restart mid-flight                @p1
+//   - F2 — subgraph indexer lag                          @p2
+//   - F4 — buyer key rotation, redeem rejected           @p2
+//
+// Deferred to a follow-up PR:
+//   - D3 — server/facilitator/onchain channel fallback (feature work
+//          on the client; tracked in `_skeletons.test.ts`).
+//   - F3 — meta-tx-gateway down during seed (gateway is not on the
+//          e2e payment hot path; removed from the suite).
+//
+// All scenarios gated behind `E2E_DOCKER=1` because they exercise
+// the live local stack (containers, subgraph, Diamond, facilitator).
+//
+// PARALLELISM WARNING: F1 kills the facilitator container and F2
+// pauses the subgraph container — both for a few seconds — to
+// inject failure. While that chaos is in flight, ANY other test
+// FILE that races against this one and tries to use the facilitator
+// or the subgraph WILL fail with transient errors. Vitest runs
+// test files in parallel by default; the suite-level escape hatch
+// is `E2E_SEQUENTIAL=1` (see `vitest.config.ts`), which the
+// nightly workflow sets. Local full-suite runs that omit
+// `E2E_SEQUENTIAL=1` will see sporadic failures in `commit.test.ts`
+// / `post-commit.test.ts` / `concurrent.test.ts` for the same
+// reason — that's a config issue, not a test bug.
+
+import { ExchangeState } from "@bosonprotocol/x402-actions";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { LOCAL_31337_0 } from "../../src/config/local-31337-0.js";
+import {
+  buildPublicClient,
+  buildWalletClient,
+  createBuyerActor,
+  performBuyerPostCommitAction,
+  PostCommitActionError,
+} from "../../src/harness/index.js";
+import { killService, pauseService, startService, unpauseService } from "../../src/stack/index.js";
+
+import { EXPECTED_PRICE } from "./_assertion-constants.js";
+import { createFundedBuyer, ensureBuyerCanPay, rotateBuyer } from "./_buyer-setup.js";
+import { ENABLED } from "./_flags.js";
+import { SEED_WALLETS } from "./_seed-wallets.js";
+import { createScenarioContext, type ScenarioContext } from "./_setup.js";
+
+const FACILITATOR_SERVICE = "x402b-facilitator-http";
+const SUBGRAPH_SERVICE = "boson-subgraph";
+
+/** Drive a fresh commit through the in-process resource server and return the new `exchangeId`. */
+async function commitFreshExchange(ctx: ScenarioContext): Promise<string> {
+  const res = await ctx.buyer.fetch(`${ctx.resourceServerUrl}/resource`);
+  if (res.status !== 200) {
+    throw new Error(
+      `[operational.test] failed to commit a fresh exchange: HTTP ${res.status} ${await res.text()}`,
+    );
+  }
+  const body = (await res.json()) as { x402b?: { exchangeId?: string } };
+  const exchangeId = body.x402b?.exchangeId;
+  if (typeof exchangeId !== "string" || exchangeId.length === 0) {
+    throw new Error(
+      `[operational.test] commit response missing exchangeId: ${JSON.stringify(body)}`,
+    );
+  }
+  return exchangeId;
+}
+
+/**
+ * Poll `<facilitatorUrl>/health` until it returns 200 or `budgetMs` elapses.
+ * Used after `startService` because docker reports the container started
+ * as soon as PID 1 forks — the HTTP listener inside the container only
+ * binds a moment later.
+ */
+async function waitForFacilitatorReady(facilitatorUrl: string, budgetMs = 30_000): Promise<void> {
+  const deadline = Date.now() + budgetMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${facilitatorUrl}/health`);
+      if (res.ok) return;
+    } catch {
+      // ECONNREFUSED while the listener spins up — fall through to retry.
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(
+    `[operational.test] facilitator at ${facilitatorUrl} did not become ready within ${budgetMs} ms`,
+  );
+}
+
+describe.skipIf(!ENABLED)("@p1 operational scenarios", () => {
+  let ctx: ScenarioContext;
+
+  beforeAll(async () => {
+    const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS.operational.account);
+    const buyerAccount = await createFundedBuyer({ funder, publicClient, fundEth: "2" });
+    ctx = await createScenarioContext({ slot: "operational", buyerAccount });
+    await ensureBuyerCanPay({
+      walletClient: buildWalletClient(buyerAccount),
+      publicClient,
+      buyerAddress: buyerAccount.address,
+      assetAddress: LOCAL_31337_0.contracts.testErc20,
+      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      amount: 10_000_000n,
+    });
+  });
+
+  afterAll(async () => {
+    // Belt-and-braces: if the test bailed before its own restart step,
+    // bring the facilitator back so the next test file isn't left
+    // staring at a dead container.
+    try {
+      await startService(FACILITATOR_SERVICE);
+      await waitForFacilitatorReady(ctx.facilitatorUrl);
+    } catch {
+      // Container may already be running — `start` on a healthy
+      // service is a no-op, but on Docker for Windows it occasionally
+      // errors with "container already started". Swallow.
+    }
+    await ctx?.teardown();
+  });
+
+  it("F1 — facilitator restart mid-flight → system recovers", async () => {
+    // Strategy:
+    //   1. Fire a commit fetch without awaiting.
+    //   2. After 150 ms (long enough for the request to reach the
+    //      facilitator but short enough that settle hasn't returned),
+    //      SIGKILL the facilitator container.
+    //   3. Start it back up and wait for /health to be reachable.
+    //   4. Resolve the original commit promise. Accept EITHER outcome:
+    //      the request returned 200 (settle landed before the kill, or
+    //      after restart on the client's retry) OR it threw / 5xx'd.
+    //   5. Issue a SECOND commit AFTER the restart and assert it
+    //      commits cleanly — this is the real proof that the facilitator
+    //      recovered (in-memory state, nonce manager, viem connection
+    //      pool, …).
+    //
+    // Limitation: the x402-client-fetch wrapper retries 402 once but
+    // does not iterate channels on facilitator-side failures (D3 is the
+    // feature work that would add that). So the "exactly one commit"
+    // invariant only holds if the original fetch fails; if it
+    // succeeds, the on-chain commit either landed before the kill or
+    // not at all. The follow-up commit is the load-bearing assertion.
+    const commitPromise = ctx.buyer.fetch(`${ctx.resourceServerUrl}/resource`);
+    await new Promise((r) => setTimeout(r, 150));
+    await killService(FACILITATOR_SERVICE, { signal: "SIGKILL" });
+    await startService(FACILITATOR_SERVICE);
+    await waitForFacilitatorReady(ctx.facilitatorUrl);
+
+    // Drain the original commit — its outcome is best-effort.
+    let originalExchangeId: string | null = null;
+    try {
+      const res = await commitPromise;
+      if (res.ok) {
+        const body = (await res.json()) as { x402b?: { exchangeId?: string } };
+        originalExchangeId =
+          typeof body.x402b?.exchangeId === "string" ? body.x402b.exchangeId : null;
+      }
+    } catch {
+      // Expected when the kill aborted the in-flight request.
+    }
+
+    // Follow-up commit — proves the facilitator recovered.
+    const followUpExchangeId = await commitFreshExchange(ctx);
+    expect(followUpExchangeId).toMatch(/^\d+$/);
+    await ctx.asserter.expect(followUpExchangeId, {
+      state: ExchangeState.COMMITTED,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc20,
+      price: EXPECTED_PRICE,
+    });
+
+    // If the original commit DID return success, the resulting exchange
+    // must also be a real on-chain COMMITTED state — not a stale
+    // pre-kill cached response. The two ids must be distinct (each
+    // commit signs a fresh FullOffer template, so they're different
+    // offers / exchanges).
+    if (originalExchangeId !== null) {
+      expect(originalExchangeId).not.toBe(followUpExchangeId);
+      await ctx.asserter.expect(originalExchangeId, {
+        state: ExchangeState.COMMITTED,
+        seller: ctx.seller.address,
+        exchangeToken: LOCAL_31337_0.contracts.testErc20,
+        price: EXPECTED_PRICE,
+      });
+    }
+  });
+});
+
+describe.skipIf(!ENABLED)("@p2 operational scenarios", () => {
+  let ctx: ScenarioContext;
+
+  beforeAll(async () => {
+    const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS.operational.account);
+    const buyerAccount = await createFundedBuyer({ funder, publicClient, fundEth: "2" });
+    ctx = await createScenarioContext({ slot: "operational", buyerAccount });
+    await ensureBuyerCanPay({
+      walletClient: buildWalletClient(buyerAccount),
+      publicClient,
+      buyerAddress: buyerAccount.address,
+      assetAddress: LOCAL_31337_0.contracts.testErc20,
+      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      amount: 10_000_000n,
+    });
+  });
+
+  afterAll(async () => {
+    await ctx?.teardown();
+  });
+
+  // F2 pauses the subgraph mid-test. If the test fails before its own
+  // `unpauseService`, the subgraph stays frozen for the rest of the
+  // suite. This belt-and-braces hook keeps the rest of the test file
+  // (and subsequent files) honest.
+  afterEach(async () => {
+    try {
+      await unpauseService(SUBGRAPH_SERVICE);
+    } catch {
+      // Already running / not paused — no-op.
+    }
+  });
+
+  it("F2 — subgraph indexer lag → reader recovers via waitForGraphNodeIndexing", async () => {
+    // Strategy:
+    //   1. Pause `boson-subgraph` so its indexer stops ingesting blocks.
+    //   2. Schedule an unpause after ~3 s.
+    //   3. Fire a commit. The chain mines on the 50 ms interval-mining
+    //      schedule globalSetup configured, so the commit tx lands
+    //      on-chain quickly. The server's exchange reader then calls
+    //      `coreSdk.waitForGraphNodeIndexing(chainHead)` which blocks
+    //      until the subgraph catches up — which won't happen until
+    //      we unpause.
+    //   4. Once the subgraph unpauses and catches up, the read
+    //      resolves, the resource server returns 200, and we assert
+    //      the on-chain state via the asserter.
+    //
+    // What this proves: the indexer-aware reader (`exchange-reader.ts`)
+    // does not collapse to `STATE_VERIFY_EXCHANGE_NOT_FOUND` when the
+    // subgraph happens to be behind the chain head at read time.
+    await pauseService(SUBGRAPH_SERVICE);
+    const unpauseAt = setTimeout(() => {
+      unpauseService(SUBGRAPH_SERVICE).catch(() => {
+        // Logged-but-ignored: a unit-test framework can't gracefully
+        // handle a background timer failure; the afterEach hook above
+        // will retry the unpause as a safety net.
+      });
+    }, 3_000);
+    try {
+      const exchangeId = await commitFreshExchange(ctx);
+      expect(exchangeId).toMatch(/^\d+$/);
+      await ctx.asserter.expect(exchangeId, {
+        state: ExchangeState.COMMITTED,
+        seller: ctx.seller.address,
+        exchangeToken: LOCAL_31337_0.contracts.testErc20,
+        price: EXPECTED_PRICE,
+      });
+    } finally {
+      clearTimeout(unpauseAt);
+      await unpauseService(SUBGRAPH_SERVICE).catch(() => {
+        /* afterEach will retry */
+      });
+    }
+  });
+
+  it("F4 — buyer key rotation → redeem rejected", async () => {
+    // Strategy:
+    //   1. Commit a fresh exchange from the describe's ctx.buyer
+    //      (signed by buyer-key A).
+    //   2. Mint + fund + approve a fresh EOA — buyer-key B — via
+    //      `rotateBuyer`.
+    //   3. Build a BuyerActor on key B and attempt `boson-redeem`
+    //      against the exchange owned by key A.
+    //   4. Expect a `PostCommitActionError` with a body that names
+    //      the rejection. The voucher is an ERC-721 minted to buyer
+    //      A; the protocol's `redeemVoucher` checks the on-chain
+    //      voucher owner against the meta-tx signer, so the
+    //      facilitator's pre-flight `simulate` step reverts with
+    //      "NOT_VOUCHER_HOLDER" (or equivalent), surfacing as
+    //      `FACILITATOR_REJECTED` with `facilitatorCode:
+    //      "SIMULATION_REVERT"` on the server side.
+    //
+    // Important: the facilitator's signature recovery itself passes
+    // (recovered signer = key B = metaTx.from). The rejection layer
+    // is the ON-CHAIN simulation, NOT a meta-tx signature mismatch.
+    // The test stays loose on the exact code so future tightening
+    // of the simulate step (e.g. structured revert classification)
+    // doesn't break this assertion — the proof of correctness is
+    // that the redeem is rejected and the on-chain voucher state
+    // stays COMMITTED.
+    const exchangeId = await commitFreshExchange(ctx);
+    await ctx.asserter.expect(exchangeId, {
+      state: ExchangeState.COMMITTED,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc20,
+      price: EXPECTED_PRICE,
+    });
+
+    const publicClient = buildPublicClient();
+    const rotatedAccount = await rotateBuyer({
+      funder: buildWalletClient(SEED_WALLETS.operational.account),
+      publicClient,
+      assetAddress: LOCAL_31337_0.contracts.testErc20,
+      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      amount: 10_000_000n,
+      fundEth: "0.5",
+    });
+    const wrongBuyer = createBuyerActor({ account: rotatedAccount, publicClient });
+
+    await expect(
+      performBuyerPostCommitAction({
+        actionId: "boson-redeem",
+        buyer: wrongBuyer,
+        resourceServerUrl: ctx.resourceServerUrl,
+        exchangeId,
+        escrowAddress: ctx.escrowAddress,
+        network: ctx.network,
+      }),
+    ).rejects.toBeInstanceOf(PostCommitActionError);
+
+    // Replay the call to inspect the error shape — `rejects.toBeInstanceOf`
+    // consumes the rejection but doesn't expose it. The replay is
+    // deterministic (no state has changed on-chain) so the second
+    // attempt rejects with the same error.
+    let caught: PostCommitActionError | null = null;
+    try {
+      await performBuyerPostCommitAction({
+        actionId: "boson-redeem",
+        buyer: wrongBuyer,
+        resourceServerUrl: ctx.resourceServerUrl,
+        exchangeId,
+        escrowAddress: ctx.escrowAddress,
+        network: ctx.network,
+      });
+    } catch (e) {
+      caught = e as PostCommitActionError;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught?.status).toBe(502);
+    const body = caught?.body as { code?: string; reason?: string; details?: unknown } | undefined;
+    expect(body?.code).toBe("FACILITATOR_REJECTED");
+    // The redeem MUST be rejected — that's the load-bearing assertion.
+    // The specific facilitator-side code reflects which classification
+    // path the revert took inside `facilitator/src/verify/simulate.ts`:
+    //   - `SIMULATION_REVERT` when viem's error chain exposes a
+    //     `RawContractError` / `ContractFunctionRevertedError`,
+    //   - `ONCHAIN_REVERT` when the tx was submitted and reverted,
+    //   - `BAD_META_TX_SIGNATURE` when sig recovery / sig-vs-from
+    //     check fails (the meta-tx itself is self-consistent here so
+    //     this path shouldn't fire, but we accept it for robustness),
+    //   - `INTERNAL_ERROR` when the revert happens but viem returns a
+    //     transport-layer wrapper that `isOnChainRevert` doesn't
+    //     classify — observed locally on Hardhat 31337 where the
+    //     revert reason surface differs from production EVM clients.
+    // Future tightening of the simulate step's revert classification
+    // would push the local F4 path into `SIMULATION_REVERT`; the test
+    // stays loose so that improvement doesn't break this assertion.
+    const facilitatorCode = (body?.details as { facilitatorCode?: string })?.facilitatorCode;
+    expect(facilitatorCode).toMatch(
+      /SIMULATION_REVERT|ONCHAIN_REVERT|BAD_META_TX_SIGNATURE|INTERNAL_ERROR/,
+    );
+
+    // On-chain voucher state must NOT have transitioned — exchange
+    // stays COMMITTED, since the rejection happened before settle.
+    await ctx.asserter.expect(exchangeId, {
+      state: ExchangeState.COMMITTED,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc20,
+      price: EXPECTED_PRICE,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `operational.test.ts` with **F1** (`@p1` facilitator restart mid-flight), **F2** (`@p2` subgraph indexer lag), **F4** (`@p2` buyer key rotation → redeem rejected). New `stack/service-control.ts` exposes `killService` / `pauseService` / `unpauseService` / `startService` for in-test chaos injection; `_buyer-setup.ts` gains a `rotateBuyer` helper for F4's second-key flow.
- Opens an always-on **`e2e-p0`** CI job in `ci.yml` (vitest `-t '@p0'`, 25-min timeout, uploads `docker compose logs` on failure) so every PR exercises the @p0 happy-path scenarios against the real Docker stack.
- New **`nightly.yml`** workflow runs the full suite daily at 03:00 UTC (and on `workflow_dispatch`) with `E2E_SEQUENTIAL=1` so the operational chaos can't race chain-touching tests in other files.

## Notable findings

- **F4 facilitator code is `INTERNAL_ERROR`, not `SIMULATION_REVERT`** — on local Hardhat 31337, the protocol's `NOT_VOUCHER_HOLDER` revert isn't classified by viem's `isOnChainRevert` walk in `facilitator/src/verify/simulate.ts`, so the catch-all classification fires. The redeem IS rejected correctly (server returns `502 FACILITATOR_REJECTED`); the test's regex accepts both codes for robustness. A future hardening of the revert classification would push this case into `SIMULATION_REVERT`.
- **F1's \"exactly one COMMITTED\" invariant is loose by design** — `x402-client-fetch` retries 402 once but does not re-iterate channels, so a killed-mid-flight commit either landed or it didn't (no double-commit risk in this client today). The load-bearing assertion is that a follow-up commit succeeds, proving the facilitator recovered cleanly. Documented in the test's leading comment.

## Out of scope

- **D3** (server → facilitator → onchain channel fallback chain) — feature work on `x402-client`, not test work. Stays as `it.todo` in `_skeletons.test.ts` with a pointer to the follow-up.
- **F3** (meta-tx-gateway down during seed) — dropped: the gateway isn't on the e2e seeder's code path nor on the payment hot path, so testing its absence proves nothing user-visible.
- **A8 / D4** (MCP scenarios) — unchanged `it.skip(\"until @bosonprotocol/x402-agent\")`.

## Test plan

- [x] `pnpm build && pnpm test && pnpm lint && pnpm format:check` — repo-wide, no Docker.
- [x] `E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test test/scenarios/operational.test.ts` against the live stack: **3/3 pass** (F1 12s, F2 9s, F4 22s).
- [x] `E2E_DOCKER=1 E2E_SEQUENTIAL=1 pnpm --filter @bosonprotocol/x402-e2e test` (full suite, sequential): **39 tests pass / 1 skipped / 26 todo** across 8 files, ~5 min wall.
- [ ] `e2e-p0` job runs green on this PR.
- [ ] Manual `gh workflow run nightly.yml --ref add-x402-e2e-pr8-operational-and-ci` to verify the nightly's full-suite invocation works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI: pinned tool versions, added a PR e2e job, and a nightly full e2e workflow; captures and uploads Docker compose logs on failures.

* **Tests**
  * Added Docker-backed PR e2e and nightly full-suite runs.
  * New operational failure-mode scenarios: service restart recovery, indexer lag recovery, and buyer key-rotation/reject handling.
  * Added per-service start/pause/kill controls, buyer-rotation helper, and updated seed-wallet slots.

* **Documentation**
  * Expanded e2e README with scenario inventory, tag-filtering, and run guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->