### PR TITLE
perf(docker): share BuildKit caches and route example builds through turbo

### DIFF
--- a/examples/facilitator-http/Dockerfile
+++ b/examples/facilitator-http/Dockerfile
@@ -17,7 +17,7 @@ FROM base AS deps
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY --parents typescript/packages/*/package.json examples/*/package.json ./
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
-    pnpm install --frozen-lockfile \
+    pnpm install --frozen-lockfile --include-workspace-root \
     --filter @bosonprotocol/x402-example-facilitator-http...
 
 # --- Stage 2: build + deploy (invalidated when source changes) ---
@@ -25,13 +25,18 @@ RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
 # exports map points at it). The trailing `...` includes transitive
 # workspace deps (x402-core, x402-evm, x402-actions, x402-fulfillment).
 #
+# Invoke turbo (not recursive pnpm) so the .turbo cache mount short-
+# circuits unchanged packages by content hash. `--include-workspace-root`
+# on the install above is what makes `pnpm exec turbo` resolvable here.
+#
 # `pnpm deploy --legacy` flattens the virtual store into a self-contained
 # dir; --legacy keeps the pnpm-9 deploy semantics. See
 # examples/webhook-sink/Dockerfile for the longer rationale.
 FROM deps AS build
 COPY . .
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
-    pnpm --filter @bosonprotocol/x402-facilitator-express... build
+    --mount=type=cache,id=turbo,target=/repo/.turbo \
+    pnpm exec turbo run build --filter=@bosonprotocol/x402-facilitator-express...
 RUN pnpm --filter @bosonprotocol/x402-example-facilitator-http deploy --legacy /deploy
 
 # --- Stage 3: runtime ---

--- a/examples/resource-server/Dockerfile
+++ b/examples/resource-server/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.7-labs
 #
 # Build from the monorepo root so the root pnpm-lock.yaml is in context:
 #   docker build -t x402b-resource-server -f examples/resource-server/Dockerfile .
@@ -9,25 +9,41 @@ FROM node:22-alpine AS base
 RUN corepack enable
 WORKDIR /repo
 
+# --- Stage 1: install (cache key = lockfile + workspace manifests) ---
+# Source code is NOT copied here, so this layer only invalidates when
+# pnpm-lock.yaml or a package.json changes. BuildKit's pnpm-store cache
+# mount reuses tarballs across rebuilds even when install does re-run.
 FROM base AS deps
-COPY . .
-RUN pnpm install --frozen-lockfile \
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
+COPY --parents typescript/packages/*/package.json examples/*/package.json ./
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --include-workspace-root \
     --filter @bosonprotocol/x402-example-resource-server...
 
+# --- Stage 2: build + deploy (invalidated when source changes) ---
 # Build the workspace deps the example imports (tsup emits dist/ + the
 # exports map points at it). The trailing `...` includes transitive
 # workspace deps (x402-core, x402-evm, x402-actions, x402-fulfillment,
 # x402-server).
-RUN pnpm --filter @bosonprotocol/x402-server-express... build
-
-# See examples/webhook-sink/Dockerfile for the rationale behind
-# `pnpm deploy --legacy` (flattens the virtual store into a self-contained
-# dir; --legacy keeps the pnpm-9 deploy semantics).
+#
+# Invoke turbo (not recursive pnpm) so the .turbo cache mount short-
+# circuits unchanged packages by content hash. `--include-workspace-root`
+# on the install above is what makes `pnpm exec turbo` resolvable here.
+#
+# `pnpm deploy --legacy` flattens the virtual store into a self-contained
+# dir; --legacy keeps the pnpm-9 deploy semantics. See
+# examples/webhook-sink/Dockerfile for the longer rationale.
+FROM deps AS build
+COPY . .
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    --mount=type=cache,id=turbo,target=/repo/.turbo \
+    pnpm exec turbo run build --filter=@bosonprotocol/x402-server-express...
 RUN pnpm --filter @bosonprotocol/x402-example-resource-server deploy --legacy /deploy
 
+# --- Stage 3: runtime ---
 FROM node:22-alpine AS runtime
 WORKDIR /app
-COPY --from=deps /deploy ./
+COPY --from=build /deploy ./
 
 ENV PORT=4001
 EXPOSE 4001

--- a/typescript/packages/x402-e2e/src/bin/resource-server.Dockerfile
+++ b/typescript/packages/x402-e2e/src/bin/resource-server.Dockerfile
@@ -19,7 +19,7 @@ FROM base AS deps
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY --parents typescript/packages/*/package.json examples/*/package.json ./
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
-    pnpm install --frozen-lockfile \
+    pnpm install --frozen-lockfile --include-workspace-root \
     --filter @bosonprotocol/x402-e2e...
 
 # --- Stage 2: build + deploy (invalidated when source changes) ---
@@ -27,10 +27,15 @@ RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
 # + the exports map points at it). The trailing `...` includes the
 # transitive workspace chain (x402-core, x402-evm, x402-actions,
 # x402-fulfillment, x402-server, x402-server-express, x402-example-resource-server).
+#
+# Invoke turbo (not recursive pnpm) so the .turbo cache mount short-
+# circuits unchanged packages by content hash. `--include-workspace-root`
+# on the install above is what makes `pnpm exec turbo` resolvable here.
 FROM deps AS build
 COPY . .
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
-    pnpm --filter @bosonprotocol/x402-example-resource-server... build
+    --mount=type=cache,id=turbo,target=/repo/.turbo \
+    pnpm exec turbo run build --filter=@bosonprotocol/x402-example-resource-server...
 RUN pnpm --filter @bosonprotocol/x402-e2e deploy --legacy /deploy
 
 # --- Stage 3: runtime ---


### PR DESCRIPTION
## Summary

Three changes to the example service Dockerfiles so unchanged-deps rebuilds drop to seconds and changed-deps rebuilds reuse cross-build caches.

- **Align `examples/resource-server/Dockerfile` on the three-stage template** (deps / build / runtime) the other Dockerfiles already use. It was previously doing `COPY . .` before `pnpm install`, so any source edit invalidated the install layer; now `pnpm install` only re-runs when manifests / lockfile change.
- **Add `--mount=type=cache,id=turbo,target=/repo/.turbo`** on the build step in the three Dockerfiles that drive a `tsup` workspace build (resource-server, facilitator-http, x402-e2e bin). `webhook-sink` has no `tsup` build step — left untouched per the plan.
- **Route the build through `turbo` instead of recursive `pnpm`.** The previous `pnpm --filter <pkg>... build` ran each filtered package's `build` script directly and never consulted turbo's content-hash cache, so the new turbo cache mount had no effect. The build line is now `pnpm exec turbo run build --filter=<pkg>...`. `pnpm install` gets `--include-workspace-root` so the turbo binary is present in the build stage.

## Measured impact

Built `x402b-resource-server` via `docker compose -f typescript/packages/x402-e2e/src/stack/compose.yaml build [...] x402b-resource-server` on Docker Desktop / WSL2:

| Build | Time |
|---|---|
| Cold (`--no-cache`) | 79s |
| Warm rebuild after touching `examples/resource-server/src/index.ts` | **23s** (≈3.4× faster) |

On the warm rebuild, the `deps` layer cache-hit (no `pnpm install`), and turbo cache-hit 6 of 7 packages — only the one whose `src/` actually changed re-ran. Cache mounts are shared by `id=` so subsequent builds of `x402b-facilitator-http` will reuse the same pnpm-store and turbo caches without re-downloading or re-building.

## Test plan

- [x] `pnpm build && pnpm test && pnpm lint && pnpm format:check` — all green
- [x] `docker compose -f typescript/packages/x402-e2e/src/stack/compose.yaml build --no-cache x402b-resource-server` — cold build produces a working image (79s)
- [x] Warm rebuild after a source touch — 23s, turbo `Tasks: 7 successful / Cached: 6 cached`
- [ ] Reviewer: cold-build baseline on your machine vs. warm rebuild to confirm the speedup reproduces
- [ ] Reviewer: `pnpm --filter @bosonprotocol/x402-e2e stack:up` brings all services healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized Docker build configuration for examples to improve build performance and reliability through enhanced caching strategies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->