### PR TITLE
feat(x402-e2e): A3 ERC-3009 scenario + facilitator BPIP-12 queue fix

### DIFF
--- a/examples/resource-server/src/app.ts
+++ b/examples/resource-server/src/app.ts
@@ -20,7 +20,10 @@
 //    reader can be built from the env (see README).
 
 import { SESSION_ID_HEADER } from "@bosonprotocol/x402-core";
-import type { EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
+import type {
+  EscrowPaymentRequirements,
+  TokenAuthStrategy,
+} from "@bosonprotocol/x402-core/schemes/escrow";
 import {
   createX402bServer,
   type ExchangeReader,
@@ -52,6 +55,15 @@ export interface ResourceServerAppOptions {
    * Omitted in unit tests that don't have a live chain.
    */
   protocolConfig?: ProtocolConfig;
+  /**
+   * Token-auth strategies the host advertises in the 402 challenge.
+   * Defaults to the full set `["none", "erc3009", "permit", "permit2"]`
+   * so a forked deployment that pairs the example with a stock buyer
+   * gets the canonical client-preference order. Tests that need to
+   * isolate a single strategy (e.g. assert ERC-3009 is exercised
+   * end-to-end against a specific token mock) pass a narrower list.
+   */
+  tokenAuthStrategies?: readonly TokenAuthStrategy[];
 }
 
 export interface ResourceServerAppBundle {
@@ -77,6 +89,13 @@ function buildServerConfig(
   };
 }
 
+const DEFAULT_TOKEN_AUTH_STRATEGIES: readonly TokenAuthStrategy[] = [
+  "none",
+  "erc3009",
+  "permit",
+  "permit2",
+];
+
 export function createResourceServerApp(
   env: ResourceServerEnv,
   options: ResourceServerAppOptions,
@@ -85,6 +104,7 @@ export function createResourceServerApp(
   const exchangeReader = options.exchangeReader;
   const now = options.now ?? Date.now;
   const protocolConfig = options.protocolConfig;
+  const tokenAuthStrategies = options.tokenAuthStrategies ?? DEFAULT_TOKEN_AUTH_STRATEGIES;
 
   const server = createX402bServer(buildServerConfig(env, seller, exchangeReader));
 
@@ -191,10 +211,12 @@ export function createResourceServerApp(
       },
       asset: env.assetAddress,
       amount: env.amount,
-      // Settle path is end-to-end runnable only for `none` today; the
-      // other strategies are advertised so the buyer can pick one once
-      // the BPIP-12 envelope ships in the facilitator.
-      tokenAuthStrategies: ["none", "erc3009", "permit", "permit2"],
+      // BPIP-12's `executeMetaTransactionWithTokenTransferAuthorization`
+      // has shipped, so any of the four strategies is end-to-end
+      // settle-able when the matching token is in scope. Forks narrow
+      // the advertised set via `ResourceServerAppOptions.tokenAuthStrategies`
+      // when the asset only supports a subset (e.g. a non-EIP-3009 ERC-20).
+      tokenAuthStrategies,
       recipientId: env.sellerId,
       maxTimeoutSeconds: env.maxTimeoutSeconds,
     });

--- a/typescript/packages/client/src/client.ts
+++ b/typescript/packages/client/src/client.ts
@@ -115,23 +115,38 @@ export function createX402bClient(config: X402bClientConfig): X402bClient {
         requirements.escrowAddress as Address,
       );
 
-      // `policy.tokenAuthStrategy === "none"` is the explicit opt-out
-      // path: the buyer has approved the escrow off-band (e.g. a
-      // standing ERC-20 `approve`) and wants the payment to ride the
-      // protocol's `safeTransferFrom` fallback. The dispatcher in
-      // `buildAndSignTokenAuth` doesn't include `"none"` in its
-      // preference order, so without this short-circuit it would
-      // always pick the highest-ranked strategy the server advertises.
+      // `policy.tokenAuthStrategy` forces a specific strategy from the
+      // server's advertised set instead of letting the dispatcher pick
+      // by preference. The forced value must be in
+      // `requirements.tokenAuthStrategies`; otherwise the override is
+      // rejected. `"none"` short-circuits the dispatcher entirely (the
+      // buyer has approved the escrow off-band and the payment rides
+      // the protocol's `safeTransferFrom` fallback); for the other
+      // strategies the dispatcher is invoked with the advertised set
+      // narrowed to a single element so it must pick the requested one.
       let tokenAuth: Awaited<ReturnType<typeof buildAndSignTokenAuth>>["tokenAuth"] | undefined;
       let strategy: Awaited<ReturnType<typeof buildAndSignTokenAuth>>["strategy"];
-      if (config.policy?.tokenAuthStrategy === "none") {
-        if (!requirements.tokenAuthStrategies.includes("none")) {
+      const forcedStrategy = config.policy?.tokenAuthStrategy;
+      if (forcedStrategy !== undefined) {
+        if (!requirements.tokenAuthStrategies.includes(forcedStrategy)) {
           throw new UnsupportedTokenAuthError(
-            `policy.tokenAuthStrategy "none" is not in requirements.tokenAuthStrategies (${requirements.tokenAuthStrategies.join(", ")})`,
+            `policy.tokenAuthStrategy "${forcedStrategy}" is not in requirements.tokenAuthStrategies (${requirements.tokenAuthStrategies.join(", ")})`,
           );
         }
-        strategy = "none";
-        tokenAuth = undefined;
+        if (forcedStrategy === "none") {
+          strategy = "none";
+          tokenAuth = undefined;
+        } else {
+          const built = await buildAndSignTokenAuth({
+            requirements: { ...requirements, tokenAuthStrategies: [forcedStrategy] },
+            buyer,
+            coreSdk,
+            tokenDomainResolver: config.tokenDomainResolver,
+            publicClient: config.publicClients?.[chainId],
+          });
+          strategy = built.strategy;
+          tokenAuth = built.tokenAuth;
+        }
       } else {
         const built = await buildAndSignTokenAuth({
           requirements,

--- a/typescript/packages/client/src/client.ts
+++ b/typescript/packages/client/src/client.ts
@@ -35,7 +35,7 @@ import {
   type SignedWithdrawFunds,
 } from "./withdraw.js";
 import { buildAndSignTokenAuth } from "./token-auth/index.js";
-import { MaxAmountExceededError } from "./errors.js";
+import { MaxAmountExceededError, UnsupportedTokenAuthError } from "./errors.js";
 import type { ExchangeSummary, X402bClientConfig } from "./types.js";
 
 export interface X402bClient {
@@ -115,13 +115,34 @@ export function createX402bClient(config: X402bClientConfig): X402bClient {
         requirements.escrowAddress as Address,
       );
 
-      const { tokenAuth, strategy } = await buildAndSignTokenAuth({
-        requirements,
-        buyer,
-        coreSdk,
-        tokenDomainResolver: config.tokenDomainResolver,
-        publicClient: config.publicClients?.[chainId],
-      });
+      // `policy.tokenAuthStrategy === "none"` is the explicit opt-out
+      // path: the buyer has approved the escrow off-band (e.g. a
+      // standing ERC-20 `approve`) and wants the payment to ride the
+      // protocol's `safeTransferFrom` fallback. The dispatcher in
+      // `buildAndSignTokenAuth` doesn't include `"none"` in its
+      // preference order, so without this short-circuit it would
+      // always pick the highest-ranked strategy the server advertises.
+      let tokenAuth: Awaited<ReturnType<typeof buildAndSignTokenAuth>>["tokenAuth"] | undefined;
+      let strategy: Awaited<ReturnType<typeof buildAndSignTokenAuth>>["strategy"];
+      if (config.policy?.tokenAuthStrategy === "none") {
+        if (!requirements.tokenAuthStrategies.includes("none")) {
+          throw new UnsupportedTokenAuthError(
+            `policy.tokenAuthStrategy "none" is not in requirements.tokenAuthStrategies (${requirements.tokenAuthStrategies.join(", ")})`,
+          );
+        }
+        strategy = "none";
+        tokenAuth = undefined;
+      } else {
+        const built = await buildAndSignTokenAuth({
+          requirements,
+          buyer,
+          coreSdk,
+          tokenDomainResolver: config.tokenDomainResolver,
+          publicClient: config.publicClients?.[chainId],
+        });
+        strategy = built.strategy;
+        tokenAuth = built.tokenAuth;
+      }
 
       // Flow B (boson-createOfferCommitAndRedeem) carries the buyer's
       // delivery data along with the commit-time payload — there's no

--- a/typescript/packages/client/src/types.ts
+++ b/typescript/packages/client/src/types.ts
@@ -4,6 +4,7 @@
 
 import type { ClientState } from "@bosonprotocol/x402-core/state-machine";
 import type { TokenEip712Domain } from "@bosonprotocol/x402-core/eip712/token-auth";
+import type { TokenAuthStrategy } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { Address, Hex, PublicClient, TypedDataDomain, TypedDataParameter } from "viem";
 
 /**
@@ -25,6 +26,20 @@ export interface Policy {
   redeemMode?: RedeemMode;
   /** Atomic-units cap. If set, the client rejects requirements whose `amount` exceeds it. */
   maxAmount?: string;
+  /**
+   * Force a specific token-auth strategy instead of letting the
+   * dispatcher pick from `STRATEGY_PREFERENCE`. The chosen value MUST
+   * be in the server's advertised `tokenAuthStrategies` set;
+   * otherwise `handle402` throws `UnsupportedTokenAuthError`.
+   *
+   * Use `"none"` when the buyer has already approved the escrow off-band
+   * (e.g. via a standing ERC-20 `approve`) and wants the payment to ride
+   * the protocol's `safeTransferFrom` fallback — no token-auth payload is
+   * sent. The dispatcher's normal preference order (`erc3009` →
+   * `permit2` → `permit`) skips `"none"`, so this override is the only
+   * way to opt in.
+   */
+  tokenAuthStrategy?: TokenAuthStrategy;
 }
 
 export interface FulfillmentConfig {

--- a/typescript/packages/core/src/eip712/token-auth/fetch-token-domain.ts
+++ b/typescript/packages/core/src/eip712/token-auth/fetch-token-domain.ts
@@ -1,0 +1,103 @@
+// Shared resolver for a token contract's EIP-712 domain (`name`,
+// `version`). ERC-3009 (`ReceiveWithAuthorization`) and EIP-2612
+// (`Permit`) signers and the facilitator's verify path both need this
+// lookup — keeping it in a single place ensures signing and verification
+// stay in lock-step on one ABI surface and one fallback flow.
+//
+// Tries EIP-5267's canonical `eip712Domain()` view first; on a contract
+// that doesn't implement it, falls back to ERC-20 `name()` + EIP-2612
+// `version()` with `"1"` as the default if `version()` reverts (the
+// EIP-2612-specified default).
+//
+// Error handling: only `ContractFunctionExecutionError` is treated as
+// "method not implemented" and triggers a fallback. RPC / transport
+// failures propagate as-is so callers can distinguish them and surface a
+// clear failure rather than a silent fallback that fails again on the
+// next call. `name()` is required by ERC-20 so any failure there is a
+// real error and propagates.
+
+import { ContractFunctionExecutionError, type Address, type Hex, type PublicClient } from "viem";
+
+import type { TokenEip712Domain } from "./domain.js";
+
+export const EIP5267_ABI = [
+  {
+    type: "function",
+    name: "eip712Domain",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [
+      { name: "fields", type: "bytes1" },
+      { name: "name", type: "string" },
+      { name: "version", type: "string" },
+      { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
+      { name: "salt", type: "bytes32" },
+      { name: "extensions", type: "uint256[]" },
+    ],
+  },
+] as const;
+
+export const NAME_ABI = [
+  {
+    type: "function",
+    name: "name",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "string" }],
+  },
+] as const;
+
+export const VERSION_ABI = [
+  {
+    type: "function",
+    name: "version",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "string" }],
+  },
+] as const;
+
+export async function fetchTokenDomain(
+  publicClient: PublicClient,
+  token: Address,
+  chainId: number,
+): Promise<TokenEip712Domain> {
+  try {
+    const result = (await publicClient.readContract({
+      address: token,
+      abi: EIP5267_ABI,
+      functionName: "eip712Domain",
+    })) as readonly [Hex, string, string, bigint, Address, Hex, readonly bigint[]];
+    return {
+      name: result[1],
+      version: result[2],
+      chainId: Number(result[3]),
+      verifyingContract: result[4],
+    };
+  } catch (e) {
+    if (!(e instanceof ContractFunctionExecutionError)) {
+      throw e;
+    }
+    // EIP-5267 not implemented — fall back to name() + version().
+  }
+  const name = (await publicClient.readContract({
+    address: token,
+    abi: NAME_ABI,
+    functionName: "name",
+  })) as string;
+  let version = "1";
+  try {
+    version = (await publicClient.readContract({
+      address: token,
+      abi: VERSION_ABI,
+      functionName: "version",
+    })) as string;
+  } catch (e) {
+    if (!(e instanceof ContractFunctionExecutionError)) {
+      throw e;
+    }
+    // version() is optional per EIP-2612 — keep the default "1".
+  }
+  return { name, version, chainId, verifyingContract: token };
+}

--- a/typescript/packages/core/src/eip712/token-auth/index.ts
+++ b/typescript/packages/core/src/eip712/token-auth/index.ts
@@ -19,6 +19,7 @@
 
 export * from "./domain.js";
 export * from "./erc3009.js";
+export * from "./fetch-token-domain.js";
 export * from "./permit.js";
 export * from "./permit2.js";
 export * from "./approve.js";

--- a/typescript/packages/facilitator/src/internal/boson-action-abi.ts
+++ b/typescript/packages/facilitator/src/internal/boson-action-abi.ts
@@ -1,0 +1,17 @@
+// Single source of truth for the Boson post-commit action ABIs the
+// facilitator validates and recovers signatures against. Combines the
+// three relevant facet ABIs from `@bosonprotocol/common` so callers can
+// pass one constant to viem's `decodeFunctionData` and match by 4-byte
+// selector across the union — no hand-rolled `parseAbi` strings.
+//
+//   - redeem / cancel / revoke / completeExchange     → ExchangeHandler
+//   - raise / resolve / escalate / retractDispute     → DisputeHandler
+//   - withdrawFunds                                   → FundsHandler
+
+import { abis } from "@bosonprotocol/common";
+
+export const BOSON_POST_COMMIT_ACTION_ABI = [
+  ...(abis.IBosonExchangeHandlerABI as readonly unknown[]),
+  ...(abis.IBosonDisputeHandlerABI as readonly unknown[]),
+  ...(abis.IBosonFundsHandlerABI as readonly unknown[]),
+] as const satisfies readonly unknown[];

--- a/typescript/packages/facilitator/src/internal/build-bpip12-calldata.ts
+++ b/typescript/packages/facilitator/src/internal/build-bpip12-calldata.ts
@@ -30,7 +30,7 @@ const TRANSFER_STRATEGY_ID = {
   Permit2: 3,
 } as const;
 
-const META_TX_BPIP12_ABI = parseAbi([
+export const META_TX_BPIP12_ABI = parseAbi([
   "function executeMetaTransactionWithTokenTransferAuthorization(address userAddress, string functionName, bytes functionSignature, uint256 nonce, bytes signature, bytes tokenTransferAuthorization) returns (bytes)",
 ]);
 

--- a/typescript/packages/facilitator/src/internal/build-bpip12-calldata.ts
+++ b/typescript/packages/facilitator/src/internal/build-bpip12-calldata.ts
@@ -1,0 +1,178 @@
+// Encode the calldata for the BPIP-12 envelope
+// `MetaTransactionsHandlerFacet.executeMetaTransactionWithTokenTransferAuthorization`,
+// including the action-aware token-transfer authorisation queue.
+//
+// Why not route through `@bosonprotocol/core-sdk`'s
+// `metaTx.handler.executeMetaTransactionWithTokenTransferAuthorization`?
+// The SDK's `erc20.handler.encodeTransferAuthorizationQueue` only knows
+// how to encode strategy-typed entries (`ERC3009` / `EIP2612` / `Permit2`).
+// The deployed protocol additionally accepts an **empty entry** (`0x`) as
+// a shortcut for "no auth, fall back to ERC-20 allowance" — and the
+// commit-time meta-tx requires exactly that shape, with a leading empty
+// slot consumed by the zero-amount seller-deposit `transferFundsIn` call.
+// The SDK has no way to express that, so the facilitator builds the
+// queue and outer calldata directly via viem instead.
+
+import type { BosonTokenAuth } from "@bosonprotocol/x402-core/schemes/escrow";
+import { encodeAbiParameters, encodeFunctionData, parseAbi, type Hex } from "viem";
+
+import { preBuyerSkipSlots } from "./queue-layout.js";
+
+/**
+ * Strategy id matches `BosonTypes.TokenTransferAuthorizationStrategy`
+ * (see `boson-protocol-contracts/contracts/domain/BosonTypes.sol`).
+ * `None = 0` is unused by the off-chain caller — empty bytes already
+ * mean "fall back" — but the values are pinned to the on-chain enum.
+ */
+const TRANSFER_STRATEGY_ID = {
+  ERC3009: 1,
+  EIP2612: 2,
+  Permit2: 3,
+} as const;
+
+const META_TX_BPIP12_ABI = parseAbi([
+  "function executeMetaTransactionWithTokenTransferAuthorization(address userAddress, string functionName, bytes functionSignature, uint256 nonce, bytes signature, bytes tokenTransferAuthorization) returns (bytes)",
+]);
+
+const FALLBACK_ENTRY: Hex = "0x";
+
+/**
+ * Encode one token-auth entry as `abi.encode(uint8 strategy, bytes data)`,
+ * matching the layout the protocol's `consumeForTransfer` decodes. The
+ * `data` payload is strategy-specific and mirrors the SDK's
+ * `encodeTransferAuthorizationEntry` for parity.
+ */
+function encodeAuthEntry(tokenAuth: BosonTokenAuth): Hex {
+  switch (tokenAuth.kind) {
+    case "erc3009": {
+      const data = encodeAbiParameters(
+        [
+          { type: "uint256" },
+          { type: "uint256" },
+          { type: "bytes32" },
+          { type: "uint8" },
+          { type: "bytes32" },
+          { type: "bytes32" },
+        ],
+        [
+          BigInt(tokenAuth.data.validAfter),
+          BigInt(tokenAuth.data.validBefore),
+          tokenAuth.data.nonce as Hex,
+          tokenAuth.data.v,
+          tokenAuth.data.r as Hex,
+          tokenAuth.data.s as Hex,
+        ],
+      );
+      return encodeAbiParameters(
+        [{ type: "uint8" }, { type: "bytes" }],
+        [TRANSFER_STRATEGY_ID.ERC3009, data],
+      );
+    }
+    case "permit": {
+      const data = encodeAbiParameters(
+        [{ type: "uint256" }, { type: "uint8" }, { type: "bytes32" }, { type: "bytes32" }],
+        [
+          BigInt(tokenAuth.data.deadline),
+          tokenAuth.data.v,
+          tokenAuth.data.r as Hex,
+          tokenAuth.data.s as Hex,
+        ],
+      );
+      return encodeAbiParameters(
+        [{ type: "uint8" }, { type: "bytes" }],
+        [TRANSFER_STRATEGY_ID.EIP2612, data],
+      );
+    }
+    case "permit2": {
+      const data = encodeAbiParameters(
+        [{ type: "uint256" }, { type: "uint256" }, { type: "bytes" }],
+        [
+          BigInt(tokenAuth.data.nonce),
+          BigInt(tokenAuth.data.deadline),
+          tokenAuth.data.signature as Hex,
+        ],
+      );
+      return encodeAbiParameters(
+        [{ type: "uint8" }, { type: "bytes" }],
+        [TRANSFER_STRATEGY_ID.Permit2, data],
+      );
+    }
+    default: {
+      // Compile-time exhaustiveness — a new BosonTokenAuth variant must
+      // grow a matching case here.
+      const _exhaustive: never = tokenAuth;
+      throw new Error(
+        `facilitator/build-bpip12-calldata: unrecognised tokenAuth.kind '${(_exhaustive as { kind: string }).kind}'`,
+      );
+    }
+  }
+}
+
+export interface BuildBpip12QueueArgs {
+  /** Action id from `payload.payload.action` (e.g. `"boson-createOfferAndCommit"`). */
+  actionId: string;
+  /** Buyer's wire-format token-auth entry. */
+  tokenAuth: BosonTokenAuth;
+}
+
+/**
+ * Build the `abi.encode(bytes[] queue)` payload the protocol's
+ * `TokenTransferAuthorizationLib.loadQueue` parses, with a leading run
+ * of empty entries (one per pre-buyer `transferFundsIn` site) and the
+ * buyer's auth at the final index.
+ */
+export function buildBpip12QueueBytes(args: BuildBpip12QueueArgs): Hex {
+  const skipSlots = preBuyerSkipSlots(args.actionId);
+  const entries: Hex[] = [];
+  for (let i = 0; i < skipSlots; i++) {
+    entries.push(FALLBACK_ENTRY);
+  }
+  entries.push(encodeAuthEntry(args.tokenAuth));
+  return encodeAbiParameters([{ type: "bytes[]" }], [entries]);
+}
+
+export interface BuildBpip12CalldataArgs {
+  /** Diamond / escrow address — the `to` of the resulting transaction. */
+  escrowAddress: `0x${string}`;
+  /** Buyer EOA — first argument of the BPIP-12 envelope. */
+  userAddress: `0x${string}`;
+  /** Inner meta-tx function name (e.g. `"createOfferAndCommit(...)"`). */
+  functionName: string;
+  /** Inner meta-tx function signature (ABI-encoded `data`). */
+  functionSignature: Hex;
+  /** Meta-tx nonce. */
+  nonce: bigint;
+  /** Packed 65-byte buyer signature over the meta-tx digest (`r ++ s ++ v`). */
+  signature: Hex;
+  /** Action id — drives the queue layout via `preBuyerSkipSlots`. */
+  actionId: string;
+  /** Buyer's wire-format token-auth entry. */
+  tokenAuth: BosonTokenAuth;
+}
+
+/**
+ * Build the full calldata for
+ * `executeMetaTransactionWithTokenTransferAuthorization(...)` against
+ * the Boson Diamond — queue + outer envelope in one shot. Callers feed
+ * the result straight into `walletClient.sendTransaction(...)` (settle)
+ * or `publicClient.call(...)` (simulate).
+ */
+export function buildBpip12Calldata(args: BuildBpip12CalldataArgs): {
+  to: `0x${string}`;
+  data: Hex;
+} {
+  const queueBytes = buildBpip12QueueBytes({ actionId: args.actionId, tokenAuth: args.tokenAuth });
+  const data = encodeFunctionData({
+    abi: META_TX_BPIP12_ABI,
+    functionName: "executeMetaTransactionWithTokenTransferAuthorization",
+    args: [
+      args.userAddress,
+      args.functionName,
+      args.functionSignature,
+      args.nonce,
+      args.signature,
+      queueBytes,
+    ],
+  });
+  return { to: args.escrowAddress, data };
+}

--- a/typescript/packages/facilitator/src/internal/build-bpip12-calldata.ts
+++ b/typescript/packages/facilitator/src/internal/build-bpip12-calldata.ts
@@ -2,21 +2,31 @@
 // `MetaTransactionsHandlerFacet.executeMetaTransactionWithTokenTransferAuthorization`,
 // including the action-aware token-transfer authorisation queue.
 //
-// Why not route through `@bosonprotocol/core-sdk`'s
-// `metaTx.handler.executeMetaTransactionWithTokenTransferAuthorization`?
-// The SDK's `erc20.handler.encodeTransferAuthorizationQueue` only knows
-// how to encode strategy-typed entries (`ERC3009` / `EIP2612` / `Permit2`).
-// The deployed protocol additionally accepts an **empty entry** (`0x`) as
-// a shortcut for "no auth, fall back to ERC-20 allowance" — and the
-// commit-time meta-tx requires exactly that shape, with a leading empty
-// slot consumed by the zero-amount seller-deposit `transferFundsIn` call.
-// The SDK has no way to express that, so the facilitator builds the
-// queue and outer calldata directly via viem instead.
+// The outer envelope ABI comes from `@bosonprotocol/common`'s
+// `IBosonMetaTransactionsHandlerABI` — the canonical source kept in
+// lock-step with the deployed protocol.
+//
+// The queue contents are still built locally because core-sdk's
+// `erc20.handler.encodeTransferAuthorizationEntry` is an exhaustive
+// switch over `ERC3009 | EIP2612 | Permit2 | DAIPermit` with no way to
+// emit an **empty entry** (`0x`). On-chain
+// `TokenTransferAuthorizationLib.loadQueue` accepts `0x` as a shortcut
+// for "no auth, fall back to ERC-20 allowance" — and the commit-time
+// meta-tx requires exactly that shape, with a leading run of empty
+// slots consumed by the pre-buyer `transferFundsIn` calls (e.g. the
+// zero-amount seller-deposit slot in `createOfferAndCommit`).
+//
+// Follow-up: once core-sdk supports fallback queue entries, this file
+// can be retired in favour of
+// `metaTx.handler.executeMetaTransactionWithTokenTransferAuthorization({ returnTxInfo: true })`.
 
+import { abis } from "@bosonprotocol/common";
 import type { BosonTokenAuth } from "@bosonprotocol/x402-core/schemes/escrow";
-import { encodeAbiParameters, encodeFunctionData, parseAbi, type Hex } from "viem";
+import { encodeAbiParameters, encodeFunctionData, type Hex } from "viem";
 
 import { preBuyerSkipSlots } from "./queue-layout.js";
+
+const META_TX_HANDLER_ABI = abis.IBosonMetaTransactionsHandlerABI as readonly unknown[];
 
 /**
  * Strategy id matches `BosonTypes.TokenTransferAuthorizationStrategy`
@@ -29,10 +39,6 @@ const TRANSFER_STRATEGY_ID = {
   EIP2612: 2,
   Permit2: 3,
 } as const;
-
-export const META_TX_BPIP12_ABI = parseAbi([
-  "function executeMetaTransactionWithTokenTransferAuthorization(address userAddress, string functionName, bytes functionSignature, uint256 nonce, bytes signature, bytes tokenTransferAuthorization) returns (bytes)",
-]);
 
 const FALLBACK_ENTRY: Hex = "0x";
 
@@ -116,19 +122,19 @@ export interface BuildBpip12QueueArgs {
 }
 
 /**
- * Build the `abi.encode(bytes[] queue)` payload the protocol's
+ * Build the `bytes[]` queue the protocol's
  * `TokenTransferAuthorizationLib.loadQueue` parses, with a leading run
  * of empty entries (one per pre-buyer `transferFundsIn` site) and the
  * buyer's auth at the final index.
  */
-export function buildBpip12QueueBytes(args: BuildBpip12QueueArgs): Hex {
+export function buildBpip12Queue(args: BuildBpip12QueueArgs): Hex[] {
   const skipSlots = preBuyerSkipSlots(args.actionId);
   const entries: Hex[] = [];
   for (let i = 0; i < skipSlots; i++) {
     entries.push(FALLBACK_ENTRY);
   }
   entries.push(encodeAuthEntry(args.tokenAuth));
-  return encodeAbiParameters([{ type: "bytes[]" }], [entries]);
+  return entries;
 }
 
 export interface BuildBpip12CalldataArgs {
@@ -161,9 +167,9 @@ export function buildBpip12Calldata(args: BuildBpip12CalldataArgs): {
   to: `0x${string}`;
   data: Hex;
 } {
-  const queueBytes = buildBpip12QueueBytes({ actionId: args.actionId, tokenAuth: args.tokenAuth });
+  const queue = buildBpip12Queue({ actionId: args.actionId, tokenAuth: args.tokenAuth });
   const data = encodeFunctionData({
-    abi: META_TX_BPIP12_ABI,
+    abi: META_TX_HANDLER_ABI,
     functionName: "executeMetaTransactionWithTokenTransferAuthorization",
     args: [
       args.userAddress,
@@ -171,7 +177,7 @@ export function buildBpip12Calldata(args: BuildBpip12CalldataArgs): {
       args.functionSignature,
       args.nonce,
       args.signature,
-      queueBytes,
+      queue,
     ],
   });
   return { to: args.escrowAddress, data };

--- a/typescript/packages/facilitator/src/internal/build-settle-calldata.ts
+++ b/typescript/packages/facilitator/src/internal/build-settle-calldata.ts
@@ -1,35 +1,72 @@
-// Build the outer-envelope calldata via `@bosonprotocol/core-sdk`'s
-// `metaTx.handler` helpers in `returnTxInfo: true` mode.
+// Build the outer-envelope calldata for the simulate / settle paths.
 //
-// Used by the simulate (`eth_call`) pre-flight: we need just the
-// `{ to, data }` pair to drive `publicClient.call(...)`, not a full
-// `coreSdk.executeMetaTransaction(...)` submission. The handler
-// helpers dispatch on whether `transferAuthorizations` is provided —
-// the SDK's `executeMetaTransactionWithTokenTransferAuthorization`
-// is the BPIP-12 variant that consumes a token-transfer-authorization
-// queue alongside the meta-tx.
+// Two envelopes share this helper:
+//   - `executeMetaTransaction(...)` — the `"none"` token-auth path. The
+//     SDK's `metaTx.handler.executeMetaTransaction` returns a viem-
+//     submittable `{ to, data }` pair in `returnTxInfo: true` mode, and
+//     no queue is involved.
+//   - `executeMetaTransactionWithTokenTransferAuthorization(...)` — the
+//     BPIP-12 variant. We build this one via viem directly (see
+//     `build-bpip12-calldata.ts`) because the SDK's
+//     `erc20.handler.encodeTransferAuthorizationQueue` only encodes
+//     strategy-typed entries and can't represent the empty-bytes
+//     fallback slots the protocol expects ahead of the buyer's auth.
 
-import type { BosonMetaTx } from "@bosonprotocol/x402-core/schemes/escrow";
+import type {
+  BosonMetaTx,
+  BosonTokenAuth,
+  TokenAuthStrategy,
+} from "@bosonprotocol/x402-core/schemes/escrow";
 import { metaTx } from "@bosonprotocol/core-sdk";
 import { createCalldataOnlyWeb3LibAdapter } from "@bosonprotocol/x402-evm/adapters";
+import type { Hex } from "viem";
 
-import type { TransferAuthorization } from "./token-auth-lift.js";
+import { buildBpip12Calldata } from "./build-bpip12-calldata.js";
+import { packRsv } from "../verify/meta-tx-signature.js";
 
 const STUB_TAG = "@bosonprotocol/x402-facilitator:build-settle-calldata";
 
 export interface BuildSettleCalldataArgs {
+  /** Boson escrow (Diamond) address — accepts the schema's `Address` (`string`); cast to `0x${string}` inside. */
   escrowAddress: string;
+  /** Buyer EOA from the payload. */
   userAddress: string;
   metaTx: BosonMetaTx;
-  /** Omit or pass an empty array for the `tokenAuthStrategy: "none"` path. */
-  transferAuthorizations?: readonly TransferAuthorization[];
+  /** Action id from `payload.payload.action` — drives the BPIP-12 queue layout. */
+  actionId: string;
+  /** Strategy from `payload.payload.tokenAuthStrategy`. */
+  tokenAuthStrategy: TokenAuthStrategy;
+  /** Required when `tokenAuthStrategy !== "none"`. */
+  tokenAuth?: BosonTokenAuth;
 }
 
 export async function buildSettleCalldata(
   args: BuildSettleCalldataArgs,
-): Promise<{ to: string; data: string }> {
+): Promise<{ to: `0x${string}`; data: Hex }> {
+  if (args.tokenAuthStrategy !== "none") {
+    if (!args.tokenAuth) {
+      throw new Error(
+        `${STUB_TAG}: tokenAuthStrategy "${args.tokenAuthStrategy}" requires args.tokenAuth`,
+      );
+    }
+    return buildBpip12Calldata({
+      escrowAddress: args.escrowAddress as `0x${string}`,
+      userAddress: args.userAddress as `0x${string}`,
+      functionName: args.metaTx.functionName,
+      functionSignature: args.metaTx.functionSignature as Hex,
+      nonce: BigInt(args.metaTx.nonce),
+      signature: packRsv(
+        args.metaTx.sig.r as Hex,
+        args.metaTx.sig.s as Hex,
+        args.metaTx.sig.v,
+      ) as Hex,
+      actionId: args.actionId,
+      tokenAuth: args.tokenAuth,
+    });
+  }
+
   const web3Lib = createCalldataOnlyWeb3LibAdapter(STUB_TAG);
-  const baseArgs = {
+  const tx = await metaTx.handler.executeMetaTransaction({
     contractAddress: args.escrowAddress,
     web3Lib,
     userAddress: args.userAddress,
@@ -39,21 +76,13 @@ export async function buildSettleCalldata(
     sigR: args.metaTx.sig.r,
     sigS: args.metaTx.sig.s,
     sigV: args.metaTx.sig.v,
-    returnTxInfo: true as const,
-  };
-
-  const tx =
-    args.transferAuthorizations && args.transferAuthorizations.length > 0
-      ? await metaTx.handler.executeMetaTransactionWithTokenTransferAuthorization({
-          ...baseArgs,
-          transferAuthorizations: [...args.transferAuthorizations],
-        })
-      : await metaTx.handler.executeMetaTransaction(baseArgs);
+    returnTxInfo: true,
+  });
 
   if (tx.to === undefined || tx.data === undefined) {
     throw new Error(
       `${STUB_TAG}: core-sdk returned an envelope without to/data — core-sdk internals may have changed`,
     );
   }
-  return { to: tx.to, data: tx.data };
+  return { to: tx.to as `0x${string}`, data: tx.data as Hex };
 }

--- a/typescript/packages/facilitator/src/internal/queue-layout.ts
+++ b/typescript/packages/facilitator/src/internal/queue-layout.ts
@@ -1,0 +1,52 @@
+// Action-aware queue layout for BPIP-12 token-transfer authorisations.
+//
+// The deployed Boson protocol's `TokenTransferAuthorizationLib` requires the
+// off-chain caller to supply one queue slot per `transferFundsIn(...)` call
+// that fires inside the inner meta-tx — even zero-amount calls, which
+// advance the queue head via `discardNext()` without dispatching. The
+// facilitator therefore can't just send a one-entry queue carrying the
+// buyer's authorisation; it has to prepend a fallback marker for every
+// pre-buyer `transferFundsIn` site so the buyer's auth lands at the right
+// index.
+//
+// LIMITATION (tracked in #86): the pre-buyer slot is currently filled with
+// the empty-bytes `FALLBACK_ENTRY` marker, which means "no auth → use the
+// ERC-20 standing allowance". This is sufficient when `sellerDeposit == 0`
+// (the protocol calls `discardNext()` on the zero-amount path and never
+// decodes the entry) or when the seller has off-band approved the escrow
+// for `sellerDeposit`. A fully gasless flow with non-zero `sellerDeposit`
+// requires a SELLER-signed auth (ERC-3009 / Permit / Permit2) at slot 0;
+// the wire format + server + this module would need to grow to carry it.
+//
+// Mapping today (Boson protocol-contracts commit
+// `858661679cc8ba2be97eedf3cbc3acd0f5c1903e`):
+//
+//   - `boson-createOfferAndCommit`         — 1 pre-buyer slot
+//   - `boson-createOfferCommitAndRedeem`   — 1 pre-buyer slot
+//
+// Both call `createOfferInternal` (which `transferFundsIn`s the offer
+// creator's `sellerDeposit`, almost always `0` and thus consumed via
+// `discardNext()`) and *then* `commitToOfferInternal → encumberFunds →
+// validateIncomingPayment → transferFundsIn(price)` (the buyer-side pull
+// that needs the token auth). The atomic commit-and-redeem variant
+// additionally enters the redeem path, which doesn't move funds in, so
+// the queue layout is identical.
+//
+// Other actions (`boson-redeem`, `boson-completeExchange`, the dispute
+// family) don't pull buyer funds at all and travel via
+// `executeMetaTransaction` (no queue) — so the BPIP-12 envelope only ever
+// applies to the two commit-time actions above today.
+
+const PRE_BUYER_SKIP_SLOTS: Readonly<Record<string, number>> = {
+  "boson-createOfferAndCommit": 1,
+  "boson-createOfferCommitAndRedeem": 1,
+};
+
+/**
+ * Number of empty queue slots the facilitator must prepend before the
+ * buyer's token-auth entry. Returns `0` for any action the protocol
+ * doesn't pre-pull funds on; the buyer's auth then sits at index 0.
+ */
+export function preBuyerSkipSlots(actionId: string): number {
+  return PRE_BUYER_SKIP_SLOTS[actionId] ?? 0;
+}

--- a/typescript/packages/facilitator/src/perform-action/action-calldata.ts
+++ b/typescript/packages/facilitator/src/perform-action/action-calldata.ts
@@ -9,8 +9,9 @@ import type {
   ExchangeActionId,
 } from "@bosonprotocol/x402-core/state-machine";
 import { isEntityKeyedAction } from "@bosonprotocol/x402-core/state-machine";
-import { decodeFunctionData, parseAbi } from "viem";
+import { decodeFunctionData } from "viem";
 
+import { BOSON_POST_COMMIT_ACTION_ABI } from "../internal/boson-action-abi.js";
 import type { FacilitatorErrorCode } from "../types.js";
 
 /** Exchange-keyed post-commit actions: a single `exchangeId` argument decides scope. */
@@ -69,18 +70,6 @@ const ENTITY_ACTION_FUNCTIONS: Record<
     signature: "withdrawFunds(uint256,address[],uint256[])",
   },
 };
-
-const POST_COMMIT_ABI = parseAbi([
-  "function redeemVoucher(uint256 exchangeId)",
-  "function cancelVoucher(uint256 exchangeId)",
-  "function revokeVoucher(uint256 exchangeId)",
-  "function completeExchange(uint256 exchangeId)",
-  "function raiseDispute(uint256 exchangeId)",
-  "function resolveDispute(uint256 exchangeId, uint256 buyerPercent, bytes counterpartySig)",
-  "function escalateDispute(uint256 exchangeId)",
-  "function retractDispute(uint256 exchangeId)",
-  "function withdrawFunds(uint256 entityId, address[] tokenList, uint256[] tokenAmounts)",
-]);
 
 const UINT256_MAX = (1n << 256n) - 1n;
 
@@ -298,7 +287,7 @@ type DecodeResult =
 function decodeCalldata(functionSignature: string): DecodeResult {
   try {
     const decoded = decodeFunctionData({
-      abi: POST_COMMIT_ABI,
+      abi: BOSON_POST_COMMIT_ACTION_ABI,
       data: functionSignature as `0x${string}`,
     });
     return { ok: true, functionName: decoded.functionName, args: decoded.args };

--- a/typescript/packages/facilitator/src/perform-action/index.ts
+++ b/typescript/packages/facilitator/src/perform-action/index.ts
@@ -242,8 +242,9 @@ export async function performAction(
       escrowAddress,
       buyer: metaTx.from as `0x${string}`,
       metaTx,
+      actionId: input.action,
       tokenAuthStrategy,
-      tokenAuth: input.tokenAuth,
+      ...(input.tokenAuth !== undefined ? { tokenAuth: input.tokenAuth } : {}),
       publicClient: config.publicClient,
       relayerAddress: relayer,
     });

--- a/typescript/packages/facilitator/src/settle/index.ts
+++ b/typescript/packages/facilitator/src/settle/index.ts
@@ -206,8 +206,11 @@ export function mapSubmitError(e: unknown): Exclude<FacilitatorSettleResult, { o
     };
   }
   // core-sdk wraps adapter errors in its own Error. Walk the cause chain
-  // for a tagged RelayerSubmitError before falling back.
+  // for a tagged RelayerSubmitError before falling back. Also capture the
+  // first viem BaseError encountered (which may be `e` itself or a wrapped
+  // cause) so the ONCHAIN_REVERT classifier below sees wrapped reverts.
   let cursor: unknown = e;
+  let viemBase: BaseError | undefined = e instanceof BaseError ? e : undefined;
   while (cursor && typeof cursor === "object" && "cause" in cursor) {
     const cause = (cursor as { cause: unknown }).cause;
     if (cause instanceof RelayerSubmitError) {
@@ -217,11 +220,14 @@ export function mapSubmitError(e: unknown): Exclude<FacilitatorSettleResult, { o
         reason: cause.message,
       };
     }
+    if (!viemBase && cause instanceof BaseError) {
+      viemBase = cause;
+    }
     if (cause === cursor) break;
     cursor = cause;
   }
-  if (e instanceof BaseError) {
-    const reverted = e.walk(
+  if (viemBase) {
+    const reverted = viemBase.walk(
       (err) => err instanceof RawContractError || err instanceof ContractFunctionRevertedError,
     );
     if (reverted) {
@@ -230,7 +236,7 @@ export function mapSubmitError(e: unknown): Exclude<FacilitatorSettleResult, { o
           ? (reverted.reason ?? reverted.shortMessage ?? reverted.message)
           : reverted instanceof RawContractError
             ? reverted.message || reverted.shortMessage || "execution reverted"
-            : (e.shortMessage ?? e.message);
+            : (viemBase.shortMessage ?? viemBase.message);
       return {
         ok: false,
         code: "ONCHAIN_REVERT",
@@ -240,7 +246,7 @@ export function mapSubmitError(e: unknown): Exclude<FacilitatorSettleResult, { o
     return {
       ok: false,
       code: "INTERNAL_ERROR",
-      reason: e.shortMessage ?? e.message,
+      reason: viemBase.shortMessage ?? viemBase.message,
     };
   }
   return {

--- a/typescript/packages/facilitator/src/settle/index.ts
+++ b/typescript/packages/facilitator/src/settle/index.ts
@@ -2,32 +2,32 @@
 //
 // Pipeline:
 //   1. Run `verify()` first — bail on any failure.
-//   2. Build the optional `transferAuthorizations` queue from the
-//      buyer's wire-format `tokenAuth` payload.
-//   3. Submit via `coreSdk.executeMetaTransaction(...)` — the unified
-//      core-sdk entrypoint that routes between `executeMetaTransaction`
-//      (no token auth) and the BPIP-12
-//      `executeMetaTransactionWithTokenTransferAuthorization` based on
-//      whether `transferAuthorizations` is provided. The SDK drives the
-//      tx through the relayer-side viem-backed Web3LibAdapter, which
-//      submits via `walletClient.sendTransaction` and surfaces
-//      classified errors as a tagged `RelayerSubmitError`.
-//   4. Await the viem receipt; an on-chain revert surfaces as
+//   2. Submit via one of two envelopes:
+//      - `none` strategy → `coreSdk.executeMetaTransaction(...)`. The
+//        SDK builds the outer calldata and submits through the
+//        relayer-side viem-backed Web3LibAdapter, which classifies
+//        errors as a tagged `RelayerSubmitError`.
+//      - non-`none` strategies → `buildSettleCalldata` builds the
+//        BPIP-12 envelope with the action-aware queue layout (see
+//        `internal/build-bpip12-calldata.ts`) and we submit through
+//        `walletClient.sendTransaction` directly. The SDK's
+//        `encodeTransferAuthorizationQueue` can't express the
+//        empty-bytes fallback slots the protocol requires, so the
+//        BPIP-12 path bypasses it.
+//   3. Await the viem receipt; an on-chain revert surfaces as
 //      ONCHAIN_REVERT.
-//   5. Parse `BuyerCommitted` from the receipt to extract `exchangeId`.
+//   4. Parse `BuyerCommitted` from the receipt to extract `exchangeId`.
 //
 // All steps return discriminated-union results — no thrown errors leak
 // to the caller unless the underlying transport itself fails (those map
 // to INTERNAL_ERROR via toResult()).
 
 import { RelayerSubmitError } from "@bosonprotocol/x402-evm/adapters";
+import { BaseError, ContractFunctionRevertedError, RawContractError, type Hex } from "viem";
 
 import { toResult } from "../errors.js";
+import { buildSettleCalldata } from "../internal/build-settle-calldata.js";
 import { createFacilitatorCoreSdk } from "../internal/core-sdk-factory.js";
-import {
-  bosonTokenAuthToTransferAuthorization,
-  type TransferAuthorization,
-} from "../internal/token-auth-lift.js";
 import type {
   FacilitatorConfig,
   FacilitatorErrorCode,
@@ -52,55 +52,95 @@ export async function settle(
     const inner = input.payload.payload;
     const escrowAddress = input.requirements.escrowAddress as `0x${string}`;
 
-    // 2. Lift the buyer's tokenAuth (if any) into the SDK's
-    //    `TransferAuthorization` queue. The verify step already
-    //    validated payload structure, so a missing tokenAuth on a
-    //    non-"none" strategy would have been caught upstream — guard
-    //    again defensively here to keep `settle()` self-contained.
-    let transferAuthorizations: TransferAuthorization[] | undefined;
-    if (inner.tokenAuthStrategy !== "none") {
-      if (!inner.tokenAuth) {
-        return {
-          ok: false,
-          code: "INVALID_PAYLOAD",
-          reason: `tokenAuthStrategy "${inner.tokenAuthStrategy}" requires payload.tokenAuth but none was provided`,
-        };
-      }
-      transferAuthorizations = [bosonTokenAuthToTransferAuthorization(inner.tokenAuth)];
+    // 2. Defensive structural check. The verify step already enforces
+    //    this rule, but keeping the guard self-contained means a future
+    //    direct caller of `settle()` (e.g. an internal admin tool) gets
+    //    the same shape error rather than a confusing crash.
+    if (inner.tokenAuthStrategy !== "none" && !inner.tokenAuth) {
+      return {
+        ok: false,
+        code: "INVALID_PAYLOAD",
+        reason: `tokenAuthStrategy "${inner.tokenAuthStrategy}" requires payload.tokenAuth but none was provided`,
+      };
     }
 
-    // 3. Submit through coreSdk.executeMetaTransaction. The mixin routes
-    //    to executeMetaTransaction or
-    //    executeMetaTransactionWithTokenTransferAuthorization based on
-    //    whether transferAuthorizations is non-empty; the relayer wallet
-    //    pays gas via the configured Web3LibAdapter.
     const chain = parseChainId(input.network);
     if (!chain.ok) return chain;
-    const coreSdk = createFacilitatorCoreSdk({
-      walletClient: config.walletClient,
-      publicClient: config.publicClient,
-      chainId: chain.chainId,
-      escrowAddress,
-    });
 
     const buyer = inner.buyer as `0x${string}`;
     let txHash: `0x${string}`;
-    try {
-      const response = await coreSdk.executeMetaTransaction(
-        {
-          functionName: inner.metaTx.functionName,
-          functionSignature: inner.metaTx.functionSignature,
-          nonce: inner.metaTx.nonce,
-          sigR: inner.metaTx.sig.r,
-          sigS: inner.metaTx.sig.s,
-          sigV: inner.metaTx.sig.v,
-          transferAuthorizations,
-        },
-        { userAddress: buyer, contractAddress: escrowAddress },
-      );
-      txHash = response.hash as `0x${string}`;
-    } catch (e) {
-      return mapSubmitError(e);
+    if (inner.tokenAuthStrategy === "none") {
+      // 3a. `none` strategy → SDK's `executeMetaTransaction(...)`. The
+      //     mixin builds the outer-envelope calldata and submits through
+      //     the configured Web3LibAdapter, which classifies errors as
+      //     `RelayerSubmitError` for `mapSubmitError`.
+      const coreSdk = createFacilitatorCoreSdk({
+        walletClient: config.walletClient,
+        publicClient: config.publicClient,
+        chainId: chain.chainId,
+        escrowAddress,
+      });
+      try {
+        const response = await coreSdk.executeMetaTransaction(
+          {
+            functionName: inner.metaTx.functionName,
+            functionSignature: inner.metaTx.functionSignature,
+            nonce: inner.metaTx.nonce,
+            sigR: inner.metaTx.sig.r,
+            sigS: inner.metaTx.sig.s,
+            sigV: inner.metaTx.sig.v,
+          },
+          { userAddress: buyer, contractAddress: escrowAddress },
+        );
+        txHash = response.hash as `0x${string}`;
+      } catch (e) {
+        return mapSubmitError(e);
+      }
+    } else {
+      // 3b. Non-`none` strategy → BPIP-12 envelope. We bypass core-sdk's
+      //     `executeMetaTransaction` mixin because its
+      //     `encodeTransferAuthorizationQueue` can't express the
+      //     empty-bytes fallback slots the protocol expects ahead of
+      //     the buyer's auth (one per pre-buyer `transferFundsIn` site,
+      //     e.g. the zero-amount seller-deposit pull on
+      //     `createOfferAndCommit`). `buildSettleCalldata` builds the
+      //     queue + outer calldata via viem directly with the right
+      //     layout, and we submit through the same `walletClient`.
+      let calldata: { to: `0x${string}`; data: Hex };
+      try {
+        calldata = await buildSettleCalldata({
+          escrowAddress,
+          userAddress: buyer,
+          metaTx: inner.metaTx,
+          actionId: inner.action,
+          tokenAuthStrategy: inner.tokenAuthStrategy,
+          tokenAuth: inner.tokenAuth!,
+        });
+      } catch (e) {
+        return {
+          ok: false,
+          code: "INTERNAL_ERROR",
+          reason: e instanceof Error ? e.message : String(e),
+        };
+      }
+      try {
+        const relayer = config.walletClient.account;
+        if (relayer === undefined) {
+          return {
+            ok: false,
+            code: "INTERNAL_ERROR",
+            reason: "facilitator walletClient has no account bound",
+          };
+        }
+        txHash = await config.walletClient.sendTransaction({
+          account: relayer,
+          chain: config.walletClient.chain ?? null,
+          to: calldata.to,
+          data: calldata.data,
+        });
+      } catch (e) {
+        return mapSubmitError(e);
+      }
     }
 
     // 4. Wait for the viem receipt. We poll via publicClient directly
@@ -143,10 +183,19 @@ export async function settle(
 }
 
 /**
- * Map an error raised by `coreSdk.executeMetaTransaction(...)` to a
- * facilitator result. Errors thrown by the viem-backed adapter come out
- * as `RelayerSubmitError` carrying a stable code; anything else falls
- * back to `INTERNAL_ERROR` with the underlying message.
+ * Map a submission error to a facilitator result. Two paths:
+ *
+ *   - core-sdk path (the `none` strategy): the viem-backed adapter
+ *     throws `RelayerSubmitError` with a stable code; core-sdk wraps
+ *     that in its own error, so we walk the cause chain.
+ *   - direct-submit path (the BPIP-12 strategies): we call
+ *     `walletClient.sendTransaction` ourselves, so a contract revert
+ *     surfaces as a viem `ContractFunctionRevertedError` /
+ *     `RawContractError` and pre-flight failures (insufficient gas,
+ *     transport hiccups) come back as a plain `BaseError`.
+ *
+ * Anything we can't classify falls back to `INTERNAL_ERROR` carrying
+ * the underlying message.
  */
 export function mapSubmitError(e: unknown): Exclude<FacilitatorSettleResult, { ok: true }> {
   if (e instanceof RelayerSubmitError) {
@@ -170,6 +219,29 @@ export function mapSubmitError(e: unknown): Exclude<FacilitatorSettleResult, { o
     }
     if (cause === cursor) break;
     cursor = cause;
+  }
+  if (e instanceof BaseError) {
+    const reverted = e.walk(
+      (err) => err instanceof RawContractError || err instanceof ContractFunctionRevertedError,
+    );
+    if (reverted) {
+      const reason =
+        reverted instanceof ContractFunctionRevertedError
+          ? (reverted.reason ?? reverted.shortMessage ?? reverted.message)
+          : reverted instanceof RawContractError
+            ? reverted.message || reverted.shortMessage || "execution reverted"
+            : (e.shortMessage ?? e.message);
+      return {
+        ok: false,
+        code: "ONCHAIN_REVERT",
+        reason,
+      };
+    }
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      reason: e.shortMessage ?? e.message,
+    };
   }
   return {
     ok: false,

--- a/typescript/packages/facilitator/src/verify/index.ts
+++ b/typescript/packages/facilitator/src/verify/index.ts
@@ -180,8 +180,9 @@ export async function verify(
       escrowAddress,
       buyer: inner.buyer as `0x${string}`,
       metaTx: inner.metaTx,
+      actionId: inner.action,
       tokenAuthStrategy: inner.tokenAuthStrategy,
-      tokenAuth: inner.tokenAuth,
+      ...(inner.tokenAuth !== undefined ? { tokenAuth: inner.tokenAuth } : {}),
       publicClient: config.publicClient,
       relayerAddress: relayer,
     });

--- a/typescript/packages/facilitator/src/verify/meta-tx-signature.ts
+++ b/typescript/packages/facilitator/src/verify/meta-tx-signature.ts
@@ -34,8 +34,9 @@ import {
 } from "@bosonprotocol/x402-core/eip712";
 import type { Address, BosonMetaTx, Hex } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { ActionId } from "@bosonprotocol/x402-core/state-machine";
-import { decodeFunctionData, parseAbi, recoverTypedDataAddress } from "viem";
+import { decodeFunctionData, recoverTypedDataAddress } from "viem";
 
+import { BOSON_POST_COMMIT_ACTION_ABI } from "../internal/boson-action-abi.js";
 import type { StepResult } from "./structural.js";
 
 export interface VerifyMetaTxSignatureArgs {
@@ -223,28 +224,14 @@ async function recoverFromTypedData(
   }
 }
 
-// ABI used to decode the action-specific arguments out of
-// `metaTx.functionSignature`. Only the actions that need their args fed
-// into a typed-data builder are listed; commit-time and revoke skip
-// straight to the basic-MetaTransaction path.
-const ACTION_ARGS_ABI = parseAbi([
-  "function redeemVoucher(uint256 exchangeId)",
-  "function cancelVoucher(uint256 exchangeId)",
-  "function completeExchange(uint256 exchangeId)",
-  "function raiseDispute(uint256 exchangeId)",
-  "function retractDispute(uint256 exchangeId)",
-  "function escalateDispute(uint256 exchangeId)",
-  "function resolveDispute(uint256 exchangeId, uint256 buyerPercent, bytes counterpartySig)",
-  "function withdrawFunds(uint256 entityId, address[] tokenList, uint256[] tokenAmounts)",
-]);
-
 type DecodeFailure = { ok: false; code: "BAD_META_TX_SIGNATURE"; reason: string };
 
 // The exchange-keyed actions whose typed-data carries a single
 // `exchangeId` (`MetaTxExchange` primary type). Used to gate
-// `decodeExchangeIdArg` so a calldata buffer for a different ABI member
-// of `ACTION_ARGS_ABI` (e.g. `withdrawFunds`) can't slip through just
-// because its first argument also happens to be a `uint256`.
+// `decodeExchangeIdArg` so a calldata buffer for a different member of
+// `BOSON_POST_COMMIT_ACTION_ABI` (e.g. `withdrawFunds`) can't slip
+// through just because its first argument also happens to be a
+// `uint256`.
 const EXCHANGE_KEYED_FUNCTION_NAMES = new Set<string>([
   "redeemVoucher",
   "cancelVoucher",
@@ -259,7 +246,7 @@ function decodeExchangeIdArg(
 ): { ok: true; value: bigint } | DecodeFailure {
   try {
     const decoded = decodeFunctionData({
-      abi: ACTION_ARGS_ABI,
+      abi: BOSON_POST_COMMIT_ACTION_ABI,
       data: functionSignature as `0x${string}`,
     });
     if (!EXCHANGE_KEYED_FUNCTION_NAMES.has(decoded.functionName)) {
@@ -300,7 +287,7 @@ function decodeResolveDisputeArgs(functionSignature: string):
   | DecodeFailure {
   try {
     const decoded = decodeFunctionData({
-      abi: ACTION_ARGS_ABI,
+      abi: BOSON_POST_COMMIT_ACTION_ABI,
       data: functionSignature as `0x${string}`,
     });
     if (decoded.functionName !== "resolveDispute") {
@@ -343,7 +330,7 @@ function decodeWithdrawFundsArgs(functionSignature: string):
   | DecodeFailure {
   try {
     const decoded = decodeFunctionData({
-      abi: ACTION_ARGS_ABI,
+      abi: BOSON_POST_COMMIT_ACTION_ABI,
       data: functionSignature as `0x${string}`,
     });
     if (decoded.functionName !== "withdrawFunds") {

--- a/typescript/packages/facilitator/src/verify/simulate.ts
+++ b/typescript/packages/facilitator/src/verify/simulate.ts
@@ -33,10 +33,6 @@ import {
 } from "viem";
 
 import { buildSettleCalldata } from "../internal/build-settle-calldata.js";
-import {
-  bosonTokenAuthToTransferAuthorization,
-  type TransferAuthorization,
-} from "../internal/token-auth-lift.js";
 
 import type { StepResult } from "./structural.js";
 
@@ -44,6 +40,8 @@ export interface SimulateExecuteMetaTransactionArgs {
   escrowAddress: Address;
   buyer: Address;
   metaTx: BosonMetaTx;
+  /** Action id from the payload — drives the BPIP-12 queue layout. */
+  actionId: string;
   tokenAuthStrategy: TokenAuthStrategy;
   /** Required when `tokenAuthStrategy !== "none"`. */
   tokenAuth?: BosonTokenAuth;
@@ -55,25 +53,23 @@ export interface SimulateExecuteMetaTransactionArgs {
 export async function simulateExecuteMetaTransaction(
   args: SimulateExecuteMetaTransactionArgs,
 ): Promise<StepResult> {
-  let transferAuthorizations: TransferAuthorization[] | undefined;
-  if (args.tokenAuthStrategy !== "none") {
-    if (!args.tokenAuth) {
-      return {
-        ok: false,
-        code: "INVALID_PAYLOAD",
-        reason: `tokenAuthStrategy "${args.tokenAuthStrategy}" requires payload.tokenAuth but none was provided`,
-      };
-    }
-    transferAuthorizations = [bosonTokenAuthToTransferAuthorization(args.tokenAuth)];
+  if (args.tokenAuthStrategy !== "none" && !args.tokenAuth) {
+    return {
+      ok: false,
+      code: "INVALID_PAYLOAD",
+      reason: `tokenAuthStrategy "${args.tokenAuthStrategy}" requires payload.tokenAuth but none was provided`,
+    };
   }
 
-  let calldata: { to: string; data: string };
+  let calldata: { to: `0x${string}`; data: `0x${string}` };
   try {
     calldata = await buildSettleCalldata({
       escrowAddress: args.escrowAddress,
       userAddress: args.buyer,
       metaTx: args.metaTx,
-      transferAuthorizations,
+      actionId: args.actionId,
+      tokenAuthStrategy: args.tokenAuthStrategy,
+      ...(args.tokenAuth !== undefined ? { tokenAuth: args.tokenAuth } : {}),
     });
   } catch (e) {
     return {
@@ -86,8 +82,8 @@ export async function simulateExecuteMetaTransaction(
   try {
     await args.publicClient.call({
       account: args.relayerAddress as `0x${string}`,
-      to: calldata.to as `0x${string}`,
-      data: calldata.data as `0x${string}`,
+      to: calldata.to,
+      data: calldata.data,
     });
     return { ok: true };
   } catch (e) {

--- a/typescript/packages/facilitator/src/verify/token-auth-signature.ts
+++ b/typescript/packages/facilitator/src/verify/token-auth-signature.ts
@@ -21,7 +21,7 @@ import {
   recoverPermit2Signer,
   recoverPermitSigner,
 } from "@bosonprotocol/x402-core/eip712/token-auth";
-import type { PublicClient } from "viem";
+import type { Hex, PublicClient } from "viem";
 
 import { packRsv } from "./meta-tx-signature.js";
 import type { StepResult } from "./structural.js";

--- a/typescript/packages/facilitator/src/verify/token-auth-signature.ts
+++ b/typescript/packages/facilitator/src/verify/token-auth-signature.ts
@@ -13,14 +13,15 @@
 // when the token supports it, falling back to `name()` + `version()`
 // with a default `"1"` if `version()` reverts (the EIP-2612 default).
 
-import type { Address, BosonTokenAuth, Hex } from "@bosonprotocol/x402-core/schemes/escrow";
+import type { Address, BosonTokenAuth } from "@bosonprotocol/x402-core/schemes/escrow";
 import {
   type TokenEip712Domain,
+  fetchTokenDomain,
   recoverErc3009Signer,
   recoverPermit2Signer,
   recoverPermitSigner,
 } from "@bosonprotocol/x402-core/eip712/token-auth";
-import { ContractFunctionExecutionError, type PublicClient } from "viem";
+import type { PublicClient } from "viem";
 
 import { packRsv } from "./meta-tx-signature.js";
 import type { StepResult } from "./structural.js";
@@ -41,107 +42,6 @@ export interface VerifyTokenAuthSignatureArgs {
   tokenAuth: BosonTokenAuth;
   /** Used to look up the token's EIP-712 domain (`name` / `version`) for ERC-3009 and EIP-2612. */
   publicClient: PublicClient;
-}
-
-const EIP5267_ABI = [
-  {
-    type: "function",
-    name: "eip712Domain",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [
-      { name: "fields", type: "bytes1" },
-      { name: "name", type: "string" },
-      { name: "version", type: "string" },
-      { name: "chainId", type: "uint256" },
-      { name: "verifyingContract", type: "address" },
-      { name: "salt", type: "bytes32" },
-      { name: "extensions", type: "uint256[]" },
-    ],
-  },
-] as const;
-
-const NAME_ABI = [
-  {
-    type: "function",
-    name: "name",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [{ type: "string" }],
-  },
-] as const;
-
-const VERSION_ABI = [
-  {
-    type: "function",
-    name: "version",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [{ type: "string" }],
-  },
-] as const;
-
-/**
- * Look up the token's EIP-712 domain. Tries EIP-5267 first (one call,
- * canonical); falls back to `name()` + `version()` (with version
- * defaulting to `"1"` per EIP-2612 if `version()` reverts).
- *
- * Error handling: only `ContractFunctionExecutionError` is treated as
- * "method not implemented" and triggers the fallback. RPC / transport
- * failures (HTTP timeouts, JSON-RPC errors) propagate as-is so the
- * caller can distinguish them and surface a clear
- * `INTERNAL_ERROR` rather than a silent fallback that fails again on
- * the next call. `name()` is required by ERC-20 so any failure there
- * is a real error and propagates.
- *
- * Exported so tests can inject a mocked PublicClient and so future
- * caching layers can wrap it.
- */
-export async function fetchTokenDomain(
-  publicClient: PublicClient,
-  token: Address,
-  chainId: number,
-): Promise<TokenEip712Domain> {
-  try {
-    const result = (await publicClient.readContract({
-      address: token as `0x${string}`,
-      abi: EIP5267_ABI,
-      functionName: "eip712Domain",
-    })) as readonly [Hex, string, string, bigint, Address, Hex, readonly bigint[]];
-    return {
-      name: result[1],
-      version: result[2],
-      chainId: Number(result[3]),
-      verifyingContract: result[4] as `0x${string}`,
-    };
-  } catch (e) {
-    if (!(e instanceof ContractFunctionExecutionError)) {
-      // Transport / RPC failure — propagate. EIP-5267-not-implemented
-      // would surface as a ContractFunctionExecutionError; anything
-      // else means we couldn't reach the contract at all.
-      throw e;
-    }
-    // EIP-5267 not implemented — fall back to name() + version().
-  }
-  const name = (await publicClient.readContract({
-    address: token as `0x${string}`,
-    abi: NAME_ABI,
-    functionName: "name",
-  })) as string;
-  let version = "1";
-  try {
-    version = (await publicClient.readContract({
-      address: token as `0x${string}`,
-      abi: VERSION_ABI,
-      functionName: "version",
-    })) as string;
-  } catch (e) {
-    if (!(e instanceof ContractFunctionExecutionError)) {
-      throw e;
-    }
-    // version() is optional per EIP-2612 — keep the default.
-  }
-  return { name, version, chainId, verifyingContract: token as `0x${string}` };
 }
 
 export async function verifyTokenAuthSignature(

--- a/typescript/packages/facilitator/test/internal/queue-layout.test.ts
+++ b/typescript/packages/facilitator/test/internal/queue-layout.test.ts
@@ -1,12 +1,11 @@
-import { decodeAbiParameters, decodeFunctionData } from "viem";
+import { abis } from "@bosonprotocol/common";
+import { decodeFunctionData } from "viem";
 import { describe, expect, it } from "vitest";
 
-import {
-  META_TX_BPIP12_ABI,
-  buildBpip12Calldata,
-  buildBpip12QueueBytes,
-} from "../../src/internal/build-bpip12-calldata.js";
+import { buildBpip12Calldata, buildBpip12Queue } from "../../src/internal/build-bpip12-calldata.js";
 import { preBuyerSkipSlots } from "../../src/internal/queue-layout.js";
+
+const META_TX_HANDLER_ABI = abis.IBosonMetaTransactionsHandlerABI as readonly unknown[];
 
 const SAMPLE_ERC3009 = {
   kind: "erc3009" as const,
@@ -43,32 +42,30 @@ describe("preBuyerSkipSlots", () => {
   });
 });
 
-describe("buildBpip12QueueBytes", () => {
+describe("buildBpip12Queue", () => {
   it("prepends one empty entry for createOfferAndCommit and packs the auth at index 1", () => {
-    const queueBytes = buildBpip12QueueBytes({
+    const queue = buildBpip12Queue({
       actionId: "boson-createOfferAndCommit",
       tokenAuth: SAMPLE_ERC3009,
     });
-    const [entries] = decodeAbiParameters([{ type: "bytes[]" }], queueBytes);
-    expect(entries.length).toBe(2);
+    expect(queue.length).toBe(2);
     // Slot 0: empty bytes — the protocol's `discardNext()` advances past
     // this on the zero-amount seller-deposit `transferFundsIn`.
-    expect(entries[0]).toBe("0x");
+    expect(queue[0]).toBe("0x");
     // Slot 1: non-empty strategy-typed entry — the buyer's ERC-3009
     // auth, consumed by the price `transferFundsIn`.
-    expect(entries[1].startsWith("0x")).toBe(true);
-    expect(entries[1].length).toBeGreaterThan(2);
+    expect(queue[1].startsWith("0x")).toBe(true);
+    expect(queue[1].length).toBeGreaterThan(2);
   });
 
   it("places the auth at index 0 for actions with no pre-buyer skip slots", () => {
-    const queueBytes = buildBpip12QueueBytes({
+    const queue = buildBpip12Queue({
       actionId: "boson-redeem",
       tokenAuth: SAMPLE_ERC3009,
     });
-    const [entries] = decodeAbiParameters([{ type: "bytes[]" }], queueBytes);
-    expect(entries.length).toBe(1);
-    expect(entries[0].startsWith("0x")).toBe(true);
-    expect(entries[0].length).toBeGreaterThan(2);
+    expect(queue.length).toBe(1);
+    expect(queue[0].startsWith("0x")).toBe(true);
+    expect(queue[0].length).toBeGreaterThan(2);
   });
 });
 
@@ -92,20 +89,26 @@ describe("buildBpip12Calldata", () => {
     expect(calldata.to).toBe(escrow);
 
     const decoded = decodeFunctionData({
-      abi: META_TX_BPIP12_ABI,
+      abi: META_TX_HANDLER_ABI,
       data: calldata.data,
     });
     expect(decoded.functionName).toBe("executeMetaTransactionWithTokenTransferAuthorization");
-    const [decodedUser, decodedFnName, decodedFnSig, decodedNonce, decodedSig, queueBytes] =
-      decoded.args;
+    const [decodedUser, decodedFnName, decodedFnSig, decodedNonce, decodedSig, queue] =
+      decoded.args as readonly [
+        `0x${string}`,
+        string,
+        `0x${string}`,
+        bigint,
+        `0x${string}`,
+        readonly `0x${string}`[],
+      ];
     expect(decodedUser).toBe(buyer);
     expect(decodedFnName).toBe(functionName);
     expect(decodedFnSig).toBe(functionSignature);
     expect(decodedNonce).toBe(1n);
     expect(decodedSig).toBe(signature);
 
-    const [entries] = decodeAbiParameters([{ type: "bytes[]" }], queueBytes);
-    expect(entries.length).toBe(2);
-    expect(entries[0]).toBe("0x");
+    expect(queue.length).toBe(2);
+    expect(queue[0]).toBe("0x");
   });
 });

--- a/typescript/packages/facilitator/test/internal/queue-layout.test.ts
+++ b/typescript/packages/facilitator/test/internal/queue-layout.test.ts
@@ -1,7 +1,8 @@
-import { decodeAbiParameters, decodeFunctionData, parseAbi } from "viem";
+import { decodeAbiParameters, decodeFunctionData } from "viem";
 import { describe, expect, it } from "vitest";
 
 import {
+  META_TX_BPIP12_ABI,
   buildBpip12Calldata,
   buildBpip12QueueBytes,
 } from "../../src/internal/build-bpip12-calldata.js";
@@ -21,10 +22,6 @@ const SAMPLE_ERC3009 = {
     v: 27,
   },
 };
-
-const BPIP12_ABI = parseAbi([
-  "function executeMetaTransactionWithTokenTransferAuthorization(address userAddress, string functionName, bytes functionSignature, uint256 nonce, bytes signature, bytes tokenTransferAuthorization) returns (bytes)",
-]);
 
 describe("preBuyerSkipSlots", () => {
   it("returns 1 for createOfferAndCommit (zero-amount seller-deposit slot precedes the buyer pull)", () => {
@@ -95,7 +92,7 @@ describe("buildBpip12Calldata", () => {
     expect(calldata.to).toBe(escrow);
 
     const decoded = decodeFunctionData({
-      abi: BPIP12_ABI,
+      abi: META_TX_BPIP12_ABI,
       data: calldata.data,
     });
     expect(decoded.functionName).toBe("executeMetaTransactionWithTokenTransferAuthorization");

--- a/typescript/packages/facilitator/test/internal/queue-layout.test.ts
+++ b/typescript/packages/facilitator/test/internal/queue-layout.test.ts
@@ -1,0 +1,114 @@
+import { decodeAbiParameters, decodeFunctionData, parseAbi } from "viem";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBpip12Calldata,
+  buildBpip12QueueBytes,
+} from "../../src/internal/build-bpip12-calldata.js";
+import { preBuyerSkipSlots } from "../../src/internal/queue-layout.js";
+
+const SAMPLE_ERC3009 = {
+  kind: "erc3009" as const,
+  data: {
+    from: "0x1111111111111111111111111111111111111111",
+    to: "0x2222222222222222222222222222222222222222",
+    value: "1000000",
+    validAfter: 0,
+    validBefore: 0x6a36b768,
+    nonce: `0x${"77".repeat(32)}`,
+    r: `0x${"aa".repeat(32)}`,
+    s: `0x${"bb".repeat(32)}`,
+    v: 27,
+  },
+};
+
+const BPIP12_ABI = parseAbi([
+  "function executeMetaTransactionWithTokenTransferAuthorization(address userAddress, string functionName, bytes functionSignature, uint256 nonce, bytes signature, bytes tokenTransferAuthorization) returns (bytes)",
+]);
+
+describe("preBuyerSkipSlots", () => {
+  it("returns 1 for createOfferAndCommit (zero-amount seller-deposit slot precedes the buyer pull)", () => {
+    expect(preBuyerSkipSlots("boson-createOfferAndCommit")).toBe(1);
+  });
+
+  it("returns 1 for createOfferCommitAndRedeem (same pre-buyer layout as deferred commit)", () => {
+    expect(preBuyerSkipSlots("boson-createOfferCommitAndRedeem")).toBe(1);
+  });
+
+  it("returns 0 for actions without a pre-buyer transferFundsIn site", () => {
+    expect(preBuyerSkipSlots("boson-redeem")).toBe(0);
+    expect(preBuyerSkipSlots("boson-completeExchange")).toBe(0);
+    expect(preBuyerSkipSlots("boson-raiseDispute")).toBe(0);
+  });
+
+  it("returns 0 for unknown action ids (forward-compatible default)", () => {
+    expect(preBuyerSkipSlots("boson-future-commit")).toBe(0);
+  });
+});
+
+describe("buildBpip12QueueBytes", () => {
+  it("prepends one empty entry for createOfferAndCommit and packs the auth at index 1", () => {
+    const queueBytes = buildBpip12QueueBytes({
+      actionId: "boson-createOfferAndCommit",
+      tokenAuth: SAMPLE_ERC3009,
+    });
+    const [entries] = decodeAbiParameters([{ type: "bytes[]" }], queueBytes);
+    expect(entries.length).toBe(2);
+    // Slot 0: empty bytes — the protocol's `discardNext()` advances past
+    // this on the zero-amount seller-deposit `transferFundsIn`.
+    expect(entries[0]).toBe("0x");
+    // Slot 1: non-empty strategy-typed entry — the buyer's ERC-3009
+    // auth, consumed by the price `transferFundsIn`.
+    expect(entries[1].startsWith("0x")).toBe(true);
+    expect(entries[1].length).toBeGreaterThan(2);
+  });
+
+  it("places the auth at index 0 for actions with no pre-buyer skip slots", () => {
+    const queueBytes = buildBpip12QueueBytes({
+      actionId: "boson-redeem",
+      tokenAuth: SAMPLE_ERC3009,
+    });
+    const [entries] = decodeAbiParameters([{ type: "bytes[]" }], queueBytes);
+    expect(entries.length).toBe(1);
+    expect(entries[0].startsWith("0x")).toBe(true);
+    expect(entries[0].length).toBeGreaterThan(2);
+  });
+});
+
+describe("buildBpip12Calldata", () => {
+  it("targets the Boson Diamond and encodes the BPIP-12 envelope with the right queue layout", () => {
+    const escrow = `0x${"33".repeat(20)}` as const;
+    const buyer = `0x${"44".repeat(20)}` as const;
+    const functionName = "createOfferAndCommit(...)";
+    const functionSignature = `0x${"ab".repeat(50)}` as const;
+    const signature = `0x${"aa".repeat(32)}${"bb".repeat(32)}1b` as const;
+    const calldata = buildBpip12Calldata({
+      escrowAddress: escrow,
+      userAddress: buyer,
+      functionName,
+      functionSignature,
+      nonce: 1n,
+      signature,
+      actionId: "boson-createOfferAndCommit",
+      tokenAuth: SAMPLE_ERC3009,
+    });
+    expect(calldata.to).toBe(escrow);
+
+    const decoded = decodeFunctionData({
+      abi: BPIP12_ABI,
+      data: calldata.data,
+    });
+    expect(decoded.functionName).toBe("executeMetaTransactionWithTokenTransferAuthorization");
+    const [decodedUser, decodedFnName, decodedFnSig, decodedNonce, decodedSig, queueBytes] =
+      decoded.args;
+    expect(decodedUser).toBe(buyer);
+    expect(decodedFnName).toBe(functionName);
+    expect(decodedFnSig).toBe(functionSignature);
+    expect(decodedNonce).toBe(1n);
+    expect(decodedSig).toBe(signature);
+
+    const [entries] = decodeAbiParameters([{ type: "bytes[]" }], queueBytes);
+    expect(entries.length).toBe(2);
+    expect(entries[0]).toBe("0x");
+  });
+});

--- a/typescript/packages/x402-e2e/src/harness/buyer-actor.ts
+++ b/typescript/packages/x402-e2e/src/harness/buyer-actor.ts
@@ -18,6 +18,7 @@ import {
   createX402bClient,
   type Policy,
   type Signer,
+  type TokenDomainResolver,
   type X402bClient,
 } from "@bosonprotocol/x402-client";
 import { wrapFetchWithPayment } from "@bosonprotocol/x402-client-fetch";
@@ -44,6 +45,16 @@ export interface BuyerActorArgs {
    * instead of the default `auto` (which prefers deferred commit).
    */
   policy?: Policy;
+  /**
+   * Optional `TokenDomainResolver` — required for the ERC-3009 and
+   * EIP-2612 Permit token-auth strategies. Without it, those
+   * strategies fall through to the next preference (typically
+   * Permit2) per the client dispatcher's capability check, so the
+   * default A1 happy path that runs against Permit2 doesn't need it.
+   * Scenarios that exercise ERC-3009 / Permit specifically pass a
+   * `createChainTokenDomainResolver(publicClient)`.
+   */
+  tokenDomainResolver?: TokenDomainResolver;
 }
 
 /** Wrap a viem `LocalAccount` so it satisfies `@bosonprotocol/x402-client`'s `Signer` interface. */
@@ -78,6 +89,9 @@ export function createBuyerActor(args: BuyerActorArgs): BuyerActor {
     subgraphUrls: { [chainId]: args.subgraphUrl ?? LOCAL_31337_0.urls.subgraph },
     publicClients: { [chainId]: publicClient },
     ...(args.policy !== undefined ? { policy: args.policy } : {}),
+    ...(args.tokenDomainResolver !== undefined
+      ? { tokenDomainResolver: args.tokenDomainResolver }
+      : {}),
   });
 
   return {

--- a/typescript/packages/x402-e2e/src/harness/index.ts
+++ b/typescript/packages/x402-e2e/src/harness/index.ts
@@ -10,6 +10,7 @@ export {
 } from "./exchange-reader.js";
 
 export { createBuyerActor, type BuyerActor, type BuyerActorArgs } from "./buyer-actor.js";
+export { createChainTokenDomainResolver } from "./token-domain.js";
 export { createSellerActor, type SellerActor, type SellerActorArgs } from "./seller-actor.js";
 export {
   createResolverActor,

--- a/typescript/packages/x402-e2e/src/harness/token-domain.ts
+++ b/typescript/packages/x402-e2e/src/harness/token-domain.ts
@@ -6,55 +6,15 @@
 // (`name`, `version`), not the escrow's, and the resolver lets the
 // client read those without dragging in a chain-wide config blob.
 //
-// Mirrors the facilitator's `fetchTokenDomain` (which performs the same
-// lookup on the verify path): try EIP-5267's canonical `eip712Domain()`
-// first, fall back to `name()` + `version()` (with the EIP-2612 default
-// of `"1"` if `version()` reverts). The facilitator's copy lives inside
-// the facilitator package and isn't exported for reuse, so the harness
-// keeps its own minimal copy — short, self-contained, and matched
-// against the on-chain protocol's expectations.
+// The on-chain lookup itself (EIP-5267 → ERC-20 `name()` + EIP-2612
+// `version()` fallback) lives in
+// `@bosonprotocol/x402-core/eip712/token-auth`'s `fetchTokenDomain`, so
+// the harness and the facilitator's verify path read the same domain
+// from the same ABI surface — no risk of signing/verification drift.
 
 import type { TokenDomainResolver } from "@bosonprotocol/x402-client";
-import type { TokenEip712Domain } from "@bosonprotocol/x402-core/eip712/token-auth";
-import { ContractFunctionExecutionError, type Address, type Hex, type PublicClient } from "viem";
-
-const EIP5267_ABI = [
-  {
-    type: "function",
-    name: "eip712Domain",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [
-      { name: "fields", type: "bytes1" },
-      { name: "name", type: "string" },
-      { name: "version", type: "string" },
-      { name: "chainId", type: "uint256" },
-      { name: "verifyingContract", type: "address" },
-      { name: "salt", type: "bytes32" },
-      { name: "extensions", type: "uint256[]" },
-    ],
-  },
-] as const;
-
-const NAME_ABI = [
-  {
-    type: "function",
-    name: "name",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [{ type: "string" }],
-  },
-] as const;
-
-const VERSION_ABI = [
-  {
-    type: "function",
-    name: "version",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [{ type: "string" }],
-  },
-] as const;
+import { fetchTokenDomain } from "@bosonprotocol/x402-core/eip712/token-auth";
+import type { PublicClient } from "viem";
 
 /**
  * Build a `TokenDomainResolver` backed by an on-chain `PublicClient`.
@@ -65,48 +25,4 @@ const VERSION_ABI = [
  */
 export function createChainTokenDomainResolver(publicClient: PublicClient): TokenDomainResolver {
   return async (asset, chainId) => fetchTokenDomain(publicClient, asset, chainId);
-}
-
-async function fetchTokenDomain(
-  publicClient: PublicClient,
-  token: Address,
-  chainId: number,
-): Promise<TokenEip712Domain> {
-  try {
-    const result = (await publicClient.readContract({
-      address: token,
-      abi: EIP5267_ABI,
-      functionName: "eip712Domain",
-    })) as readonly [Hex, string, string, bigint, Address, Hex, readonly bigint[]];
-    return {
-      name: result[1],
-      version: result[2],
-      chainId: Number(result[3]),
-      verifyingContract: result[4],
-    };
-  } catch (e) {
-    if (!(e instanceof ContractFunctionExecutionError)) {
-      throw e;
-    }
-    // EIP-5267 not implemented — fall back to name() + version().
-  }
-  const name = (await publicClient.readContract({
-    address: token,
-    abi: NAME_ABI,
-    functionName: "name",
-  })) as string;
-  let version = "1";
-  try {
-    version = (await publicClient.readContract({
-      address: token,
-      abi: VERSION_ABI,
-      functionName: "version",
-    })) as string;
-  } catch (e) {
-    if (!(e instanceof ContractFunctionExecutionError)) {
-      throw e;
-    }
-    // version() is optional per EIP-2612 — keep the default "1".
-  }
-  return { name, version, chainId, verifyingContract: token };
 }

--- a/typescript/packages/x402-e2e/src/harness/token-domain.ts
+++ b/typescript/packages/x402-e2e/src/harness/token-domain.ts
@@ -1,0 +1,112 @@
+// `TokenDomainResolver` for ERC-3009 / EIP-2612 buyer signing.
+//
+// `@bosonprotocol/x402-client`'s dispatcher only picks ERC-3009 or
+// Permit when the caller supplies a `tokenDomainResolver` — both
+// strategies sign against the **token contract's** EIP-712 domain
+// (`name`, `version`), not the escrow's, and the resolver lets the
+// client read those without dragging in a chain-wide config blob.
+//
+// Mirrors the facilitator's `fetchTokenDomain` (which performs the same
+// lookup on the verify path): try EIP-5267's canonical `eip712Domain()`
+// first, fall back to `name()` + `version()` (with the EIP-2612 default
+// of `"1"` if `version()` reverts). The facilitator's copy lives inside
+// the facilitator package and isn't exported for reuse, so the harness
+// keeps its own minimal copy — short, self-contained, and matched
+// against the on-chain protocol's expectations.
+
+import type { TokenDomainResolver } from "@bosonprotocol/x402-client";
+import type { TokenEip712Domain } from "@bosonprotocol/x402-core/eip712/token-auth";
+import { ContractFunctionExecutionError, type Address, type Hex, type PublicClient } from "viem";
+
+const EIP5267_ABI = [
+  {
+    type: "function",
+    name: "eip712Domain",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [
+      { name: "fields", type: "bytes1" },
+      { name: "name", type: "string" },
+      { name: "version", type: "string" },
+      { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
+      { name: "salt", type: "bytes32" },
+      { name: "extensions", type: "uint256[]" },
+    ],
+  },
+] as const;
+
+const NAME_ABI = [
+  {
+    type: "function",
+    name: "name",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "string" }],
+  },
+] as const;
+
+const VERSION_ABI = [
+  {
+    type: "function",
+    name: "version",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "string" }],
+  },
+] as const;
+
+/**
+ * Build a `TokenDomainResolver` backed by an on-chain `PublicClient`.
+ * The same resolver works for any ERC-20 that publishes either an
+ * EIP-5267 `eip712Domain()` view or the EIP-2612 `name()`/`version()`
+ * pair. Used by the scenario harness to wire ERC-3009 + Permit signing
+ * for whichever test token the scenario picks.
+ */
+export function createChainTokenDomainResolver(publicClient: PublicClient): TokenDomainResolver {
+  return async (asset, chainId) => fetchTokenDomain(publicClient, asset, chainId);
+}
+
+async function fetchTokenDomain(
+  publicClient: PublicClient,
+  token: Address,
+  chainId: number,
+): Promise<TokenEip712Domain> {
+  try {
+    const result = (await publicClient.readContract({
+      address: token,
+      abi: EIP5267_ABI,
+      functionName: "eip712Domain",
+    })) as readonly [Hex, string, string, bigint, Address, Hex, readonly bigint[]];
+    return {
+      name: result[1],
+      version: result[2],
+      chainId: Number(result[3]),
+      verifyingContract: result[4],
+    };
+  } catch (e) {
+    if (!(e instanceof ContractFunctionExecutionError)) {
+      throw e;
+    }
+    // EIP-5267 not implemented — fall back to name() + version().
+  }
+  const name = (await publicClient.readContract({
+    address: token,
+    abi: NAME_ABI,
+    functionName: "name",
+  })) as string;
+  let version = "1";
+  try {
+    version = (await publicClient.readContract({
+      address: token,
+      abi: VERSION_ABI,
+      functionName: "version",
+    })) as string;
+  } catch (e) {
+    if (!(e instanceof ContractFunctionExecutionError)) {
+      throw e;
+    }
+    // version() is optional per EIP-2612 — keep the default "1".
+  }
+  return { name, version, chainId, verifyingContract: token };
+}

--- a/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
@@ -1,15 +1,19 @@
-// Buyer-side ERC-20 prep for the `none` token-auth strategy.
+// Buyer-side ERC-20 prep for the scenario suite.
 //
-// With `tokenAuthStrategy: "none"`, the buyer must have already
-// approved the escrow for at least `amount` of the payment asset
-// before committing — settle just calls `transferFrom` and reverts on
-// insufficient allowance. The other three strategies bundle their own
-// authorisation in the X-PAYMENT payload and don't need this.
+// Two flavours, picked by the scenario based on its `tokenAuthStrategy`:
 //
-// The local Boson stack ships the `Foreign20` test ERC-20 with a
-// public `mint(to, amount)`, so we mint the buyer enough to cover the
-// scenario amount before approving. Both calls are no-ops when
-// re-run with already-sufficient balance / allowance.
+//   - `ensureBuyerHasBalance` — mint payment tokens to the buyer if
+//     the balance falls short. ERC-3009, Permit, and Permit2 carry
+//     their own authorisation in the X-PAYMENT payload, so no
+//     allowance is needed; balance alone gates the settle.
+//   - `ensureBuyerCanPay` — calls `ensureBuyerHasBalance`, then ensures
+//     the escrow has a generous ERC-20 allowance. Required only for
+//     the `none` strategy, where settle just calls `transferFrom` and
+//     reverts on insufficient allowance.
+//
+// The local Boson stack's test ERC-20 mocks (`Foreign20`,
+// `MockERC3009Token`, `MockERC2612Token`) all expose a public
+// `mint(to, amount)`; both helpers re-use the same minimal ABI.
 
 import {
   parseEther,
@@ -60,27 +64,32 @@ const ERC20_TEST_ABI = [
   },
 ] as const;
 
-export interface BuyerSetupArgs {
+export interface EnsureBuyerHasBalanceArgs {
   /** Buyer's viem `WalletClient` (must hold native ETH for gas). */
   walletClient: WalletClient;
   /** Read-side `PublicClient`. */
   publicClient: PublicClient;
-  /** Payment-asset address (typically `LOCAL_31337_0.contracts.testErc20`). */
+  /** Payment-asset address. */
   assetAddress: Address;
-  /** Escrow address — the `spender` the buyer approves. */
-  escrowAddress: Address;
-  /** Amount the scenario will commit (decimal string of atomic units). */
+  /** Amount the scenario will commit (atomic units). */
   amount: bigint;
   /** Buyer's wallet address. */
   buyerAddress: Address;
 }
 
+export interface BuyerSetupArgs extends EnsureBuyerHasBalanceArgs {
+  /** Escrow address — the `spender` the buyer approves for the `none` strategy. */
+  escrowAddress: Address;
+}
+
 /**
- * Ensure the buyer has at least `amount` balance + allowance against
- * the escrow. Mints the deficit + sends an `approve` only when
- * necessary so re-runs of the same scenario don't burn gas pointlessly.
+ * Mint payment tokens to the buyer until their balance covers `amount`.
+ * Used by token-auth strategies (ERC-3009 / Permit / Permit2) that
+ * carry their own transfer authorisation in the X-PAYMENT payload —
+ * the escrow doesn't need a standing allowance, only a balance to
+ * pull from.
  */
-export async function ensureBuyerCanPay(args: BuyerSetupArgs): Promise<void> {
+export async function ensureBuyerHasBalance(args: EnsureBuyerHasBalanceArgs): Promise<void> {
   const balance = (await args.publicClient.readContract({
     address: args.assetAddress,
     abi: ERC20_TEST_ABI,
@@ -99,6 +108,17 @@ export async function ensureBuyerCanPay(args: BuyerSetupArgs): Promise<void> {
     });
     await args.publicClient.waitForTransactionReceipt({ hash: mintHash });
   }
+}
+
+/**
+ * Ensure the buyer has at least `amount` balance + allowance against
+ * the escrow. Used by the `none` token-auth strategy, where settle
+ * calls `transferFrom` and reverts on insufficient allowance. Both
+ * the mint and the approve are no-ops when re-run with sufficient
+ * balance / allowance.
+ */
+export async function ensureBuyerCanPay(args: BuyerSetupArgs): Promise<void> {
+  await ensureBuyerHasBalance(args);
 
   const allowance = (await args.publicClient.readContract({
     address: args.assetAddress,

--- a/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
@@ -92,6 +92,19 @@ export interface BuyerSetupArgs extends EnsureBuyerHasBalanceArgs {
  * pull from.
  */
 export async function ensureBuyerHasBalance(args: EnsureBuyerHasBalanceArgs): Promise<void> {
+  // `WalletClient` doesn't require `account` / `chain` at the type
+  // level, so unguarded non-null assertions would crash with an opaque
+  // viem error if a caller passed a bare client. Surface a clear
+  // harness-side message instead.
+  const walletAccount = args.walletClient.account;
+  const walletChain = args.walletClient.chain;
+  if (walletAccount === undefined || walletChain === undefined) {
+    throw new Error(
+      "[x402-e2e/_buyer-setup] ensureBuyerHasBalance requires a WalletClient with both `account` and `chain` set " +
+        "(use `buildWalletClient(account)`)",
+    );
+  }
+
   const balance = (await args.publicClient.readContract({
     address: args.assetAddress,
     abi: ERC20_TEST_ABI,
@@ -105,8 +118,8 @@ export async function ensureBuyerHasBalance(args: EnsureBuyerHasBalanceArgs): Pr
       abi: ERC20_TEST_ABI,
       functionName: "mint",
       args: [args.buyerAddress, args.amount - balance],
-      account: args.walletClient.account!,
-      chain: args.walletClient.chain!,
+      account: walletAccount,
+      chain: walletChain,
     });
     await args.publicClient.waitForTransactionReceipt({ hash: mintHash });
   }
@@ -121,6 +134,15 @@ export async function ensureBuyerHasBalance(args: EnsureBuyerHasBalanceArgs): Pr
  */
 export async function ensureBuyerCanPay(args: BuyerSetupArgs): Promise<void> {
   await ensureBuyerHasBalance(args);
+  // ensureBuyerHasBalance has already validated `account` / `chain`;
+  // re-extract them as locals for the type-narrowed writeContract call
+  // below without re-running the guard.
+  const walletAccount = args.walletClient.account;
+  const walletChain = args.walletClient.chain;
+  if (walletAccount === undefined || walletChain === undefined) {
+    // Unreachable — ensureBuyerHasBalance would have thrown above.
+    return;
+  }
 
   const allowance = (await args.publicClient.readContract({
     address: args.assetAddress,
@@ -137,8 +159,8 @@ export async function ensureBuyerCanPay(args: BuyerSetupArgs): Promise<void> {
       // Approve a generous cap so subsequent scenarios on the same
       // chain state don't need to re-approve; refunds untouched.
       args: [args.escrowAddress, args.amount * 1000n],
-      account: args.walletClient.account!,
-      chain: args.walletClient.chain!,
+      account: walletAccount,
+      chain: walletChain,
     });
     await args.publicClient.waitForTransactionReceipt({ hash: approveHash });
   }

--- a/typescript/packages/x402-e2e/test/scenarios/_setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_setup.ts
@@ -19,7 +19,7 @@ import {
   fetchProtocolConfig,
   readEnv,
 } from "@bosonprotocol/x402-example-resource-server";
-import type { TokenDomainResolver } from "@bosonprotocol/x402-client";
+import type { Policy, TokenDomainResolver } from "@bosonprotocol/x402-client";
 import type { TokenAuthStrategy } from "@bosonprotocol/x402-core/schemes/escrow";
 import { createServer, type AddressInfo } from "node:net";
 import { privateKeyToAccount, type LocalAccount } from "viem/accounts";
@@ -87,6 +87,14 @@ export interface ScenarioContextArgs {
    * needs no resolver).
    */
   tokenDomainResolver?: TokenDomainResolver;
+  /**
+   * Optional `Policy` override for the BuyerActor. Use this to pin a
+   * specific `tokenAuthStrategy` (e.g. `"none"` so the buyer doesn't
+   * sign a token-auth payload, and the protocol pulls funds via a
+   * standing ERC-20 allowance) or to switch `redeemMode` for atomic
+   * commit-and-redeem scenarios.
+   */
+  buyerPolicy?: Policy;
 }
 
 export interface ScenarioContext {
@@ -220,6 +228,7 @@ export async function createScenarioContext(args: ScenarioContextArgs): Promise<
     ...(args.tokenDomainResolver !== undefined
       ? { tokenDomainResolver: args.tokenDomainResolver }
       : {}),
+    ...(args.buyerPolicy !== undefined ? { policy: args.buyerPolicy } : {}),
   });
   const resolver = createResolverActor({ account: resolverAccount });
 

--- a/typescript/packages/x402-e2e/test/scenarios/_setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_setup.ts
@@ -19,6 +19,8 @@ import {
   fetchProtocolConfig,
   readEnv,
 } from "@bosonprotocol/x402-example-resource-server";
+import type { TokenDomainResolver } from "@bosonprotocol/x402-client";
+import type { TokenAuthStrategy } from "@bosonprotocol/x402-core/schemes/escrow";
 import { createServer, type AddressInfo } from "node:net";
 import { privateKeyToAccount, type LocalAccount } from "viem/accounts";
 
@@ -70,6 +72,21 @@ export interface ScenarioContextArgs {
   amount?: string;
   /** Override `MAX_TIMEOUT_SECONDS`. Defaults to `3600`. */
   maxTimeoutSeconds?: number;
+  /**
+   * Override the strategies the in-process resource server advertises
+   * in its 402 challenge. Defaults to the full set when omitted (the
+   * example's `DEFAULT_TOKEN_AUTH_STRATEGIES`). Tests that exercise
+   * a specific strategy (A3 ERC-3009, A4 Permit, A5 Permit2) narrow
+   * the list to force the client dispatcher's hand.
+   */
+  tokenAuthStrategies?: readonly TokenAuthStrategy[];
+  /**
+   * Optional `TokenDomainResolver` plumbed into the BuyerActor's
+   * `X402bClient`. Required by the client dispatcher for ERC-3009 and
+   * EIP-2612 Permit; omitted scenarios fall back to Permit2 (which
+   * needs no resolver).
+   */
+  tokenDomainResolver?: TokenDomainResolver;
 }
 
 export interface ScenarioContext {
@@ -183,7 +200,13 @@ export async function createScenarioContext(args: ScenarioContextArgs): Promise<
     escrowAddress: env.escrowAddress,
   });
 
-  const { app } = createResourceServerApp(env, { exchangeReader, protocolConfig });
+  const { app } = createResourceServerApp(env, {
+    exchangeReader,
+    protocolConfig,
+    ...(args.tokenAuthStrategies !== undefined
+      ? { tokenAuthStrategies: args.tokenAuthStrategies }
+      : {}),
+  });
   const httpServer = app.listen(port);
   await new Promise<void>((resolve, reject) => {
     httpServer.once("listening", resolve);
@@ -191,7 +214,13 @@ export async function createScenarioContext(args: ScenarioContextArgs): Promise<
   });
 
   const seller = createSellerActor({ account: sellerAccount });
-  const buyer = createBuyerActor({ account: buyerAccount, publicClient });
+  const buyer = createBuyerActor({
+    account: buyerAccount,
+    publicClient,
+    ...(args.tokenDomainResolver !== undefined
+      ? { tokenDomainResolver: args.tokenDomainResolver }
+      : {}),
+  });
   const resolver = createResolverActor({ account: resolverAccount });
 
   return {

--- a/typescript/packages/x402-e2e/test/scenarios/_setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_setup.ts
@@ -148,6 +148,21 @@ async function allocateFreePort(): Promise<number> {
   return port;
 }
 
+/**
+ * Pin the `none` token-auth strategy on both the in-process resource
+ * server's advertised strategies and the buyer policy. Spread into
+ * `createScenarioContext` for scenarios that don't exercise ERC-3009 /
+ * Permit / Permit2 path-specific behaviour — without the pin, the
+ * buyer client falls through to `permit2` (no `tokenDomainResolver`
+ * configured) and the on-chain `transferFrom` reverts with `ERC20:
+ * insufficient allowance` because `ensureBuyerCanPay` only approves
+ * the protocol Diamond, not the canonical Permit2 contract.
+ */
+export const NONE_TOKEN_AUTH_SCENARIO = {
+  tokenAuthStrategies: ["none"] as const,
+  buyerPolicy: { tokenAuthStrategy: "none" as const },
+} satisfies Pick<ScenarioContextArgs, "tokenAuthStrategies" | "buyerPolicy">;
+
 export async function createScenarioContext(args: ScenarioContextArgs): Promise<ScenarioContext> {
   const slot = SEED_WALLETS[args.slot];
   const sellerPk = slot.privateKey;

--- a/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
@@ -31,7 +31,7 @@ import { EXPECTED_PRICE, TX_HASH_REGEX } from "./_assertion-constants.js";
 import { createFundedBuyer, ensureBuyerCanPay, ensureBuyerHasBalance } from "./_buyer-setup.js";
 import { ENABLED } from "./_flags.js";
 import { SEED_WALLETS } from "./_seed-wallets.js";
-import { createScenarioContext, type ScenarioContext } from "./_setup.js";
+import { createScenarioContext, NONE_TOKEN_AUTH_SCENARIO, type ScenarioContext } from "./_setup.js";
 
 describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
   let ctx: ScenarioContext;
@@ -51,8 +51,7 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
     ctx = await createScenarioContext({
       slot: "commit",
       buyerAccount,
-      tokenAuthStrategies: ["none"],
-      buyerPolicy: { tokenAuthStrategy: "none" },
+      ...NONE_TOKEN_AUTH_SCENARIO,
     });
     // `none` strategy requires the buyer to have pre-approved the
     // escrow — settle just calls `safeTransferFrom`. Top up by ~10x
@@ -116,7 +115,7 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
     const atomicBuyer = createBuyerActor({
       account: buyerAccount,
       publicClient: ctx.buyer.publicClient,
-      policy: { redeemMode: "commit-and-redeem", tokenAuthStrategy: "none" },
+      policy: { ...NONE_TOKEN_AUTH_SCENARIO.buyerPolicy, redeemMode: "commit-and-redeem" },
     });
 
     const res = await atomicBuyer.fetch(`${ctx.resourceServerUrl}/resource`);

--- a/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
@@ -23,11 +23,12 @@ import {
   buildPublicClient,
   buildWalletClient,
   createBuyerActor,
+  createChainTokenDomainResolver,
   readXPaymentResponse,
 } from "../../src/harness/index.js";
 
 import { EXPECTED_PRICE, TX_HASH_REGEX } from "./_assertion-constants.js";
-import { createFundedBuyer, ensureBuyerCanPay } from "./_buyer-setup.js";
+import { createFundedBuyer, ensureBuyerCanPay, ensureBuyerHasBalance } from "./_buyer-setup.js";
 import { ENABLED } from "./_flags.js";
 import { SEED_WALLETS } from "./_seed-wallets.js";
 import { createScenarioContext, type ScenarioContext } from "./_setup.js";
@@ -132,11 +133,71 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
     });
   });
 
-  // Token-auth strategies. The resource server already advertises
-  // `["none","erc3009","permit","permit2"]`; PR6 follow-up implements
-  // these as their own beforeAll variants (different asset for
-  // erc3009 / permit, different cap for permit2).
-  it.todo("A3 — commit with `erc3009` token-auth (testErc3009)");
+  // Token-auth strategies. Each describe below pins
+  // `tokenAuthStrategies` to a single value so the client dispatcher
+  // can't fall back to a different strategy.
   it.todo("A4 — commit with `permit` token-auth (testErc2612)");
   it.todo("A5 — commit with `permit2` token-auth");
+});
+
+describe.skipIf(!ENABLED)("@p0 commit-time scenarios (ERC-3009)", () => {
+  let ctx: ScenarioContext;
+
+  beforeAll(async () => {
+    // Distinct buyer + describe-scoped context so the resource server
+    // advertises ONLY `erc3009` and the BuyerActor signs against the
+    // testErc3009 token's domain. Shares the file's `commit` seed slot
+    // with the @p0 describe above — vitest serialises describes within
+    // a file, so the slot's seller can handle both back-to-back.
+    const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS.commit.account);
+    const buyerAccount = await createFundedBuyer({ funder, publicClient });
+    ctx = await createScenarioContext({
+      slot: "commit",
+      buyerAccount,
+      assetAddress: LOCAL_31337_0.contracts.testErc3009,
+      tokenAuthStrategies: ["erc3009"],
+      tokenDomainResolver: createChainTokenDomainResolver(publicClient),
+    });
+    // ERC-3009's `ReceiveWithAuthorization` carries the transfer
+    // approval inline — the buyer only needs a balance, no allowance.
+    await ensureBuyerHasBalance({
+      walletClient: buildWalletClient(buyerAccount),
+      publicClient,
+      buyerAddress: buyerAccount.address,
+      assetAddress: LOCAL_31337_0.contracts.testErc3009,
+      amount: 10_000_000n,
+    });
+  });
+
+  afterAll(async () => {
+    await ctx?.teardown();
+  });
+
+  it("A3 — commit with `erc3009` token-auth (testErc3009)", async () => {
+    const res = await ctx.buyer.fetch(`${ctx.resourceServerUrl}/resource`);
+    expect(res.status, await res.clone().text()).toBe(200);
+
+    const body = (await res.json()) as {
+      ok?: boolean;
+      x402b?: { exchangeId?: string; txHash?: `0x${string}` };
+    };
+    expect(body.ok).toBe(true);
+    expect(typeof body.x402b?.exchangeId).toBe("string");
+
+    const decoded = readXPaymentResponse(res.headers);
+    expect(decoded?.exchangeId).toBe(body.x402b?.exchangeId);
+    expect(decoded?.txHash).toMatch(TX_HASH_REGEX);
+
+    // Same COMMITTED outcome as A1 — the strategy change is invisible
+    // post-settle, so we assert against the same on-chain shape but
+    // with `testErc3009` as the exchangeToken.
+    const exchangeId = body.x402b!.exchangeId!;
+    await ctx.asserter.expect(exchangeId, {
+      state: ExchangeState.COMMITTED,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc3009,
+      price: EXPECTED_PRICE,
+    });
+  });
 });

--- a/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
@@ -38,15 +38,26 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
   let buyerAccount: LocalAccount;
 
   beforeAll(async () => {
+    // A1/A2 explicitly exercise the `none` token-auth path: server
+    // advertises only `"none"` and the BuyerActor pins
+    // `policy.tokenAuthStrategy: "none"`. Without the pin, the client
+    // dispatcher would pick the highest-ranked strategy the server
+    // advertises (it never picks `"none"` on its own) — and `none`
+    // would silently slip into a different strategy's queue path,
+    // masking the protocol's behaviour under the test name.
     const publicClient = buildPublicClient();
     const funder = buildWalletClient(SEED_WALLETS.commit.account);
     buyerAccount = await createFundedBuyer({ funder, publicClient });
-    ctx = await createScenarioContext({ slot: "commit", buyerAccount });
-    // Over-provision the buyer for the whole describe — A1 spends 1
-    // USDC, A2's atomic flow spends another, and the to-be-unskipped
-    // A3–A5 each commit one more. Funding the deficit ~10x up-front
-    // keeps each test from re-minting (and matches the post-commit
-    // describe's pattern).
+    ctx = await createScenarioContext({
+      slot: "commit",
+      buyerAccount,
+      tokenAuthStrategies: ["none"],
+      buyerPolicy: { tokenAuthStrategy: "none" },
+    });
+    // `none` strategy requires the buyer to have pre-approved the
+    // escrow — settle just calls `safeTransferFrom`. Top up by ~10x
+    // the per-commit amount so successive tests in the describe don't
+    // need re-approvals.
     await ensureBuyerCanPay({
       walletClient: buildWalletClient(buyerAccount),
       publicClient,
@@ -105,7 +116,7 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
     const atomicBuyer = createBuyerActor({
       account: buyerAccount,
       publicClient: ctx.buyer.publicClient,
-      policy: { redeemMode: "commit-and-redeem" },
+      policy: { redeemMode: "commit-and-redeem", tokenAuthStrategy: "none" },
     });
 
     const res = await atomicBuyer.fetch(`${ctx.resourceServerUrl}/resource`);
@@ -158,6 +169,15 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios (ERC-3009)", () => {
       assetAddress: LOCAL_31337_0.contracts.testErc3009,
       tokenAuthStrategies: ["erc3009"],
       tokenDomainResolver: createChainTokenDomainResolver(publicClient),
+      // The local Boson stack mines at 50 ms intervals with `+1 s`
+      // per block → chain time runs ~20× wall-clock and drifts
+      // hours ahead after a few test cycles. The ERC-3009
+      // `validBefore` field is enforced against `block.timestamp`,
+      // so the default 1-hour wall-clock window can already be in
+      // the past by the time settle simulates. Stretch the window
+      // to the protocol's max (24 h wall-clock = up to ~75 min of
+      // useful chain-time validity at 20× drift).
+      maxTimeoutSeconds: 24 * 60 * 60,
     });
     // ERC-3009's `ReceiveWithAuthorization` carries the transfer
     // approval inline — the buyer only needs a balance, no allowance.

--- a/typescript/packages/x402-e2e/test/scenarios/concurrent.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/concurrent.test.ts
@@ -79,9 +79,17 @@ describe.skipIf(!ENABLED)("@p0 concurrent commit-and-redeem scenarios", () => {
     // `seller`, `asserter`, and `teardown` — `ctx.buyer` is unused
     // because the test drives its own 20-buyer fleet. The first
     // buyer account is passed in to satisfy the required arg.
+    //
+    // Pin the `none` token-auth strategy on the in-process resource
+    // server (and below on each BuyerActor's policy). Without it the
+    // buyer client falls through to `permit2` (no `tokenDomainResolver`
+    // is configured) and the on-chain `transferFrom` reverts with
+    // "ERC20: insufficient allowance" — the buyers only approved the
+    // protocol Diamond, not the canonical Permit2 contract.
     ctx = await createScenarioContext({
       slot: "concurrent",
       buyerAccount: buyerAccounts[0]!,
+      tokenAuthStrategies: ["none"],
     });
 
     // Step 3 — assemble 20 BuyerActors that all share a single
@@ -93,7 +101,7 @@ describe.skipIf(!ENABLED)("@p0 concurrent commit-and-redeem scenarios", () => {
       createBuyerActor({
         account,
         publicClient,
-        policy: { redeemMode: "commit-and-redeem" },
+        policy: { redeemMode: "commit-and-redeem", tokenAuthStrategy: "none" },
       }),
     );
   });

--- a/typescript/packages/x402-e2e/test/scenarios/concurrent.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/concurrent.test.ts
@@ -33,7 +33,7 @@ import {
 import { createFundedBuyer, ensureBuyerCanPay } from "./_buyer-setup.js";
 import { ENABLED } from "./_flags.js";
 import { SEED_WALLETS } from "./_seed-wallets.js";
-import { createScenarioContext, type ScenarioContext } from "./_setup.js";
+import { createScenarioContext, NONE_TOKEN_AUTH_SCENARIO, type ScenarioContext } from "./_setup.js";
 
 const CONCURRENT_BUYERS = 20;
 const PER_COMMIT_AMOUNT = 1_000_000n;
@@ -89,7 +89,7 @@ describe.skipIf(!ENABLED)("@p0 concurrent commit-and-redeem scenarios", () => {
     ctx = await createScenarioContext({
       slot: "concurrent",
       buyerAccount: buyerAccounts[0]!,
-      tokenAuthStrategies: ["none"],
+      tokenAuthStrategies: NONE_TOKEN_AUTH_SCENARIO.tokenAuthStrategies,
     });
 
     // Step 3 — assemble 20 BuyerActors that all share a single
@@ -101,7 +101,7 @@ describe.skipIf(!ENABLED)("@p0 concurrent commit-and-redeem scenarios", () => {
       createBuyerActor({
         account,
         publicClient,
-        policy: { redeemMode: "commit-and-redeem", tokenAuthStrategy: "none" },
+        policy: { ...NONE_TOKEN_AUTH_SCENARIO.buyerPolicy, redeemMode: "commit-and-redeem" },
       }),
     );
   });

--- a/typescript/packages/x402-e2e/test/scenarios/operational.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/operational.test.ts
@@ -102,7 +102,19 @@ describe.skipIf(!ENABLED)("@p1 operational scenarios", () => {
     const publicClient = buildPublicClient();
     const funder = buildWalletClient(SEED_WALLETS.operational.account);
     const buyerAccount = await createFundedBuyer({ funder, publicClient, fundEth: "2" });
-    ctx = await createScenarioContext({ slot: "operational", buyerAccount });
+    // Pin the `none` token-auth strategy on both the in-process resource
+    // server and the buyer policy — see the matching note in
+    // `post-commit.test.ts`. Without the pin, the buyer client falls
+    // through to `permit2` (no `tokenDomainResolver` configured) and
+    // the on-chain `transferFrom` reverts with "ERC20: insufficient
+    // allowance" because `ensureBuyerCanPay` only approves the
+    // protocol Diamond — not the canonical Permit2 contract.
+    ctx = await createScenarioContext({
+      slot: "operational",
+      buyerAccount,
+      tokenAuthStrategies: ["none"],
+      buyerPolicy: { tokenAuthStrategy: "none" },
+    });
     await ensureBuyerCanPay({
       walletClient: buildWalletClient(buyerAccount),
       publicClient,
@@ -202,7 +214,12 @@ describe.skipIf(!ENABLED)("@p2 operational scenarios", () => {
     const publicClient = buildPublicClient();
     const funder = buildWalletClient(SEED_WALLETS.operational.account);
     const buyerAccount = await createFundedBuyer({ funder, publicClient, fundEth: "2" });
-    ctx = await createScenarioContext({ slot: "operational", buyerAccount });
+    ctx = await createScenarioContext({
+      slot: "operational",
+      buyerAccount,
+      tokenAuthStrategies: ["none"],
+      buyerPolicy: { tokenAuthStrategy: "none" },
+    });
     await ensureBuyerCanPay({
       walletClient: buildWalletClient(buyerAccount),
       publicClient,

--- a/typescript/packages/x402-e2e/test/scenarios/operational.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/operational.test.ts
@@ -50,7 +50,7 @@ import { EXPECTED_PRICE } from "./_assertion-constants.js";
 import { createFundedBuyer, ensureBuyerCanPay, rotateBuyer } from "./_buyer-setup.js";
 import { ENABLED } from "./_flags.js";
 import { SEED_WALLETS } from "./_seed-wallets.js";
-import { createScenarioContext, type ScenarioContext } from "./_setup.js";
+import { createScenarioContext, NONE_TOKEN_AUTH_SCENARIO, type ScenarioContext } from "./_setup.js";
 
 const FACILITATOR_SERVICE = "x402b-facilitator-http";
 const SUBGRAPH_SERVICE = "boson-subgraph";
@@ -102,18 +102,10 @@ describe.skipIf(!ENABLED)("@p1 operational scenarios", () => {
     const publicClient = buildPublicClient();
     const funder = buildWalletClient(SEED_WALLETS.operational.account);
     const buyerAccount = await createFundedBuyer({ funder, publicClient, fundEth: "2" });
-    // Pin the `none` token-auth strategy on both the in-process resource
-    // server and the buyer policy — see the matching note in
-    // `post-commit.test.ts`. Without the pin, the buyer client falls
-    // through to `permit2` (no `tokenDomainResolver` configured) and
-    // the on-chain `transferFrom` reverts with "ERC20: insufficient
-    // allowance" because `ensureBuyerCanPay` only approves the
-    // protocol Diamond — not the canonical Permit2 contract.
     ctx = await createScenarioContext({
       slot: "operational",
       buyerAccount,
-      tokenAuthStrategies: ["none"],
-      buyerPolicy: { tokenAuthStrategy: "none" },
+      ...NONE_TOKEN_AUTH_SCENARIO,
     });
     await ensureBuyerCanPay({
       walletClient: buildWalletClient(buyerAccount),
@@ -217,8 +209,7 @@ describe.skipIf(!ENABLED)("@p2 operational scenarios", () => {
     ctx = await createScenarioContext({
       slot: "operational",
       buyerAccount,
-      tokenAuthStrategies: ["none"],
-      buyerPolicy: { tokenAuthStrategy: "none" },
+      ...NONE_TOKEN_AUTH_SCENARIO,
     });
     await ensureBuyerCanPay({
       walletClient: buildWalletClient(buyerAccount),

--- a/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
@@ -36,7 +36,7 @@ import { EXPECTED_PRICE, TX_HASH_REGEX } from "./_assertion-constants.js";
 import { createFundedBuyer, ensureBuyerCanPay } from "./_buyer-setup.js";
 import { ENABLED } from "./_flags.js";
 import { SEED_WALLETS } from "./_seed-wallets.js";
-import { createScenarioContext, type ScenarioContext } from "./_setup.js";
+import { createScenarioContext, NONE_TOKEN_AUTH_SCENARIO, type ScenarioContext } from "./_setup.js";
 
 /**
  * Drive a fresh `/resource` 402 retry → commit and return the
@@ -88,8 +88,7 @@ describe.skipIf(!ENABLED)("@p0 post-commit lifecycle scenarios", () => {
     ctx = await createScenarioContext({
       slot: "postCommit",
       buyerAccount,
-      tokenAuthStrategies: ["none"],
-      buyerPolicy: { tokenAuthStrategy: "none" },
+      ...NONE_TOKEN_AUTH_SCENARIO,
     });
     // Over-provision the buyer's allowance by ~10x the per-commit cap
     // so successive commits inside the describe don't need re-approval.
@@ -255,8 +254,7 @@ describe.skipIf(!ENABLED)("@p1 post-commit lifecycle scenarios", () => {
     ctx = await createScenarioContext({
       slot: "postCommit",
       buyerAccount,
-      tokenAuthStrategies: ["none"],
-      buyerPolicy: { tokenAuthStrategy: "none" },
+      ...NONE_TOKEN_AUTH_SCENARIO,
     });
     await ensureBuyerCanPay({
       walletClient: buildWalletClient(buyerAccount),

--- a/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
@@ -75,7 +75,22 @@ describe.skipIf(!ENABLED)("@p0 post-commit lifecycle scenarios", () => {
     // give the random buyer enough native ETH to cover all the local
     // mint + approve + transfer fees.
     const buyerAccount = await createFundedBuyer({ funder, publicClient, fundEth: "2" });
-    ctx = await createScenarioContext({ slot: "postCommit", buyerAccount });
+    // Pin the `none` token-auth strategy on both the in-process resource
+    // server and the buyer policy. Without this pin, the buyer client
+    // picks `permit2` (its default preference for clients without a
+    // `tokenDomainResolver`) and the on-chain `transferFrom` reverts
+    // with "ERC20: insufficient allowance" because the buyer has only
+    // approved the protocol Diamond — not the canonical Permit2
+    // contract that the Permit2 path transfers through. Post-commit
+    // scenarios just need a committed exchange as a starting state, so
+    // any working strategy is fine; `none` matches the allowance
+    // `ensureBuyerCanPay` sets up below.
+    ctx = await createScenarioContext({
+      slot: "postCommit",
+      buyerAccount,
+      tokenAuthStrategies: ["none"],
+      buyerPolicy: { tokenAuthStrategy: "none" },
+    });
     // Over-provision the buyer's allowance by ~10x the per-commit cap
     // so successive commits inside the describe don't need re-approval.
     await ensureBuyerCanPay({
@@ -237,7 +252,12 @@ describe.skipIf(!ENABLED)("@p1 post-commit lifecycle scenarios", () => {
     // and the slot's seller / funder can handle both describes' load.
     const funder = buildWalletClient(SEED_WALLETS.postCommit.account);
     const buyerAccount = await createFundedBuyer({ funder, publicClient, fundEth: "2" });
-    ctx = await createScenarioContext({ slot: "postCommit", buyerAccount });
+    ctx = await createScenarioContext({
+      slot: "postCommit",
+      buyerAccount,
+      tokenAuthStrategies: ["none"],
+      buyerPolicy: { tokenAuthStrategy: "none" },
+    });
     await ensureBuyerCanPay({
       walletClient: buildWalletClient(buyerAccount),
       publicClient,


### PR DESCRIPTION
## Summary

Promotes the A3 ERC-3009 token-auth scenario from `it.todo` to runnable, and fixes the facilitator-side correctness bug that A3 surfaced.

**Facilitator: action-aware BPIP-12 queue layout.** The deployed protocol's `createOfferAndCommit` calls `transferFundsIn` twice (seller-deposit slot — almost always zero-amount and consumed by `discardNext()` — then buyer price). The previous single-entry queue was eaten by the first call, so the buyer's auth never reached the price pull. Net effect: A1/A2 were *false-passing* under a silently-picked `permit2` strategy that fell back to `safeTransferFrom` via the standing escrow allowance `ensureBuyerCanPay` set up.

- New [`internal/queue-layout.ts`](typescript/packages/facilitator/src/internal/queue-layout.ts) — `preBuyerSkipSlots(actionId)`: `1` for `createOfferAndCommit` / `createOfferCommitAndRedeem`, `0` otherwise.
- New [`internal/build-bpip12-calldata.ts`](typescript/packages/facilitator/src/internal/build-bpip12-calldata.ts) — viem-direct queue + envelope encoder. Required because the SDK's `encodeTransferAuthorizationQueue` can't express the empty-bytes fallback marker the protocol expects at skip slots.
- [`build-settle-calldata.ts`](typescript/packages/facilitator/src/internal/build-settle-calldata.ts) — `none` keeps the SDK path; non-`none` routes through the new BPIP-12 builder.
- [`settle/index.ts`](typescript/packages/facilitator/src/settle/index.ts) — split into SDK (`none`) and direct `walletClient.sendTransaction` (BPIP-12) paths; `mapSubmitError` walks viem `BaseError` chains so the direct path also classifies reverts.
- `simulate.ts`, `verify/index.ts`, `perform-action/index.ts` plumb `actionId` through.
- New [`test/internal/queue-layout.test.ts`](typescript/packages/facilitator/test/internal/queue-layout.test.ts) covers skip-slot counts + the encoded queue's shape.

**Known limitation tracked in #86:** the empty-bytes fallback marker at the seller-deposit slot only succeeds when `sellerDeposit == 0` (current x402B demo default) or when the seller has off-band approved the escrow. A fully-gasless flow with non-zero `sellerDeposit` needs a seller-signed auth at slot 0 — a follow-up wire-format extension.

**Client: explicit `none` strategy.** Adds [`Policy.tokenAuthStrategy`](typescript/packages/client/src/types.ts) so a buyer can pin a specific strategy. Set to `"none"`, `handle402` skips the dispatcher and emits a `none`-strategy payload with no `tokenAuth` — the only way to opt in, since the default dispatcher (`erc3009 → permit2 → permit`) never picks it.

**Example resource server.** [`ResourceServerAppOptions.tokenAuthStrategies`](examples/resource-server/src/app.ts) lets a fork narrow the advertised set (defaults to the full `["none", "erc3009", "permit", "permit2"]`).

**E2E harness.** Adds a chain-backed [`createChainTokenDomainResolver`](typescript/packages/x402-e2e/src/harness/token-domain.ts) (EIP-5267 → `name()`+`version()` fallback), `BuyerActor.tokenDomainResolver`, and a `ScenarioContext.buyerPolicy` / `tokenAuthStrategies` / `tokenDomainResolver` plumbing point. `_buyer-setup.ts` splits into `ensureBuyerHasBalance` (mint-only, for ERC-3009/Permit/Permit2) and `ensureBuyerCanPay` (mint + approve, for `none`).

**E2E scenarios.**
- A1/A2 now pin `tokenAuthStrategies: ["none"]` + `buyerPolicy: { tokenAuthStrategy: "none" }` so they actually exercise `none` instead of the previously-false-passing `permit2` + standing-allowance fallback.
- A3 promoted from `it.todo` — pins `tokenAuthStrategies: ["erc3009"]`, uses `testErc3009`, wires the chain-backed domain resolver, asserts `COMMITTED`.
- A3 sets `maxTimeoutSeconds: 24h` so the ERC-3009 `validBefore` outlasts the 20× chain-time drift the local Hardhat stack accumulates after iterative `E2E_DOCKER_KEEP_STACK=1` runs (fresh stacks work at any setting).

## Out of scope (separate follow-ups)

- A4 (Permit) and A5 (Permit2) — same harness now in place, scenarios stay `it.todo`.
- The non-zero `sellerDeposit` queue extension (#86).

## Test plan

- [ ] `pnpm build`, `pnpm test`, `pnpm lint`, `pnpm format:check` — clean locally
- [ ] `E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test test/scenarios/commit.test.ts` against a fresh stack — A1 + A2 + A3 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable token-auth strategies (including explicit "none") across server, client, CLI harness and tests.
  * Token-domain resolver and token EIP‑712 domain fetch exposed for signing.
  * Calldata/authorization queue builder for meta-transaction token-auth submissions.

* **Improvements**
  * Client policy can pin/force token-auth strategy; flows branch for "none" vs token-auth.
  * Tighter validation and clearer error classification for unsupported strategies and on-chain reverts.

* **Tests**
  * Added unit and e2e tests covering queue layout, calldata encoding, and token-auth scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->