### PR TITLE
ci(e2e): route @p0 filter through dedicated test:p0 script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,13 @@ jobs:
       - name: Run @p0 e2e suite
         env:
           E2E_DOCKER: "1"
-        run: pnpm --filter @bosonprotocol/x402-e2e test -- -t '@p0'
+        # Uses the `test:p0` script (rather than `test -- -t '@p0'`) because
+        # pnpm v10 forwards the `--` separator literally and vitest then
+        # parses `-t @p0` as positional file patterns instead of the
+        # `--testNamePattern` flag, which would re-enable the @p1/@p2
+        # operational chaos tests (they kill the facilitator container
+        # mid-flow and race the chain-touching tests in other files).
+        run: pnpm --filter @bosonprotocol/x402-e2e test:p0
 
       - name: Dump docker compose logs on failure
         if: failure()

--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -173,8 +173,11 @@ with `-t '@p0'`. Priorities:
 ### Running a tag subset
 
 ```sh
-# Matches the per-PR CI job — @p0 only.
-E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test -- -t '@p0'
+# Matches the per-PR CI job — @p0 only. Routed through the dedicated
+# `test:p0` script because pnpm v10 forwards `--` literally and vitest
+# would parse `-t @p0` as a positional file pattern (re-running the
+# full @p1 / @p2 breadth instead of filtering).
+E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test:p0
 
 # Matches the nightly workflow — full breadth.
 # E2E_SEQUENTIAL=1 disables file-parallelism so the operational

--- a/typescript/packages/x402-e2e/package.json
+++ b/typescript/packages/x402-e2e/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "tsc --noEmit",
     "test": "vitest run",
+    "test:p0": "vitest run -t @p0",
     "lint": "eslint src test scripts --max-warnings 0",
     "stack:up": "tsx scripts/stack-up.ts",
     "stack:down": "tsx scripts/stack-down.ts",


### PR DESCRIPTION
pnpm v10 forwards the `--` separator literally rather than consuming it, so `pnpm --filter @bosonprotocol/x402-e2e test -- -t '@p0'` spawns `vitest run "--" "-t" "@p0"`. vitest then parses `-t @p0` as positional file patterns (matching nothing useful) instead of the `--testNamePattern` flag — every test file runs, and operational.test.ts races the chain-touching files in parallel. F1's SIGKILL of x402b-facilitator-http lands while A1/A2/B1–B4 are inside their /settle round-trip, so each surfaces as HTTP 502 FACILITATOR_UNREACHABLE.

Add a dedicated `test:p0` script that invokes vitest with the `-t @p0` flag directly (no pnpm passthrough), and point CI at it. The nightly workflow is unchanged: it still runs the full suite with `E2E_SEQUENTIAL=1`, which is the documented escape hatch for the operational chaos to coexist with the chain-touching files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing documentation with refined instructions for running e2e test subsets and priority-level test suites

* **Chores**
  * Refactored CI workflow configuration to improve e2e test execution approach
  * Added new `test:p0` script enabling developers to run priority-level end-to-end test suites independently

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->