### PR TITLE
test(x402-e2e): browser-paywall scenarios (BR1-BR3) + HTML 402 on example resource-server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: ['**']
+    branches: ["**"]
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,13 @@ jobs:
 
       - run: pnpm build
 
+      # The browser-paywall scenarios (test/browser/paywall.test.ts) drive a
+      # headless Chromium via Playwright. `pnpm install` fetches the npm
+      # package but not the browser binary, so install it (+ system libs)
+      # explicitly. Only Chromium is used, so skip the other engines.
+      - name: Install Playwright Chromium
+        run: pnpm --filter @bosonprotocol/x402-e2e exec playwright install --with-deps chromium
+
       - name: Run @p0 e2e suite
         env:
           E2E_DOCKER: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: ['**']
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,6 +46,13 @@ jobs:
 
       - run: pnpm build
 
+      # The browser-paywall scenarios (test/browser/paywall.test.ts) drive a
+      # headless Chromium via Playwright. `pnpm install` fetches the npm
+      # package but not the browser binary, so install it (+ system libs)
+      # explicitly. Only Chromium is used, so skip the other engines.
+      - name: Install Playwright Chromium
+        run: pnpm --filter @bosonprotocol/x402-e2e exec playwright install --with-deps chromium
+
       - name: Run full e2e suite
         env:
           E2E_DOCKER: "1"

--- a/examples/resource-server/package.json
+++ b/examples/resource-server/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@bosonprotocol/x402-actions": "workspace:^",
     "@bosonprotocol/x402-core": "workspace:^",
+    "@bosonprotocol/x402-paywall": "workspace:^",
     "@bosonprotocol/x402-server": "workspace:^",
     "@bosonprotocol/x402-server-express": "workspace:^",
     "express": "^4.21.2",

--- a/examples/resource-server/src/app.ts
+++ b/examples/resource-server/src/app.ts
@@ -267,6 +267,12 @@ export function createResourceServerApp(
   // facilitator-side callbacks inside the compose network), which the
   // browser running on the host can't resolve.
   const paywallBranch = async (req: Request, res: Response, next: NextFunction) => {
+    // The 402 representation is content-negotiated on `Accept` (HTML
+    // paywall vs JSON), so advertise that to caches/intermediaries to
+    // stop them serving one variant to a client that asked for the
+    // other. Set unconditionally so both the HTML branch below and the
+    // downstream JSON 402 inherit it.
+    res.vary("Accept");
     if (req.header("X-PAYMENT") !== undefined) {
       next();
       return;

--- a/examples/resource-server/src/app.ts
+++ b/examples/resource-server/src/app.ts
@@ -21,6 +21,7 @@
 
 import { SESSION_ID_HEADER } from "@bosonprotocol/x402-core";
 import type { EscrowPaymentRequirements } from "@bosonprotocol/x402-core/schemes/escrow";
+import { evmEscrowPaywall } from "@bosonprotocol/x402-paywall";
 import {
   createX402bServer,
   type ExchangeReader,
@@ -229,13 +230,54 @@ export function createResourceServerApp(
     }
   });
 
-  app.get("/resource", expressMiddleware(server, { resolveRequirements }), (_req, res) => {
-    res.json({
-      ok: true,
-      x402b: res.locals.x402b,
-      resource: "example resource bytes",
-    });
-  });
+  // Browser paywall branch — emitted only when (a) the buyer hasn't
+  // already signed an X-PAYMENT header for the retry, and (b) the
+  // Accept negotiation explicitly prefers `text/html` over
+  // `application/json`. The `['json', 'html']` argument order means a
+  // missing-or-`*/*` Accept resolves to `'json'`, so non-browser
+  // callers (the e2e harness, raw curl, any client without an Accept
+  // header) keep getting the existing JSON 402 — only browsers that
+  // listed `text/html` ahead of catch-all flip to the HTML body.
+  //
+  // `currentUrl` is derived from the inbound request rather than
+  // `env.publicUrl` so it matches the browser's view of the origin —
+  // `env.publicUrl` may point at `host.docker.internal:4001` (used by
+  // facilitator-side callbacks inside the compose network), which the
+  // browser running on the host can't resolve.
+  const paywallBranch = async (req: Request, res: Response, next: NextFunction) => {
+    if (req.header("X-PAYMENT") !== undefined) {
+      next();
+      return;
+    }
+    if (req.accepts(["json", "html"]) !== "html") {
+      next();
+      return;
+    }
+    try {
+      const requirements = await resolveRequirements(req);
+      const host = req.get("host");
+      const currentUrl = host
+        ? `${req.protocol}://${host}${req.originalUrl}`
+        : env.publicUrl + req.originalUrl;
+      const html = evmEscrowPaywall.generateHtml({ requirements, currentUrl }, env.paywallConfig);
+      res.status(402).type("html").send(html);
+    } catch (e) {
+      next(e);
+    }
+  };
+
+  app.get(
+    "/resource",
+    paywallBranch,
+    expressMiddleware(server, { resolveRequirements }),
+    (_req, res) => {
+      res.json({
+        ok: true,
+        x402b: res.locals.x402b,
+        resource: "example resource bytes",
+      });
+    },
+  );
 
   app.use(mountX402b(server, { resolveRequirements }));
 

--- a/examples/resource-server/src/config.ts
+++ b/examples/resource-server/src/config.ts
@@ -3,6 +3,7 @@
 // (required / optional / asAddress / asHex32 / asInt helpers) so both
 // example apps fail the same way on the same kind of bad input.
 
+import type { PaywallConfig } from "@bosonprotocol/x402-paywall";
 import type { Address, Hex } from "viem";
 
 export interface ResourceServerEnv {
@@ -34,6 +35,13 @@ export interface ResourceServerEnv {
   subgraphUrl?: string;
   /** HTTP listen port. */
   port: number;
+  /**
+   * Optional paywall config forwarded to `evmEscrowPaywall.generateHtml`
+   * when the resource server emits an HTML 402. `undefined` falls back
+   * to the React app's in-code defaults (`appName: "x402B paywall"`,
+   * etc.).
+   */
+  paywallConfig?: PaywallConfig;
 }
 
 function required(name: string): string {
@@ -94,9 +102,29 @@ function asHttpUrl(value: string, name: string): string {
   return value;
 }
 
+function readPaywallConfig(): PaywallConfig | undefined {
+  // Build only the fields the operator explicitly sets — `undefined`
+  // entries would otherwise survive JSON serialization into the injected
+  // `window.x402b.config` and override the React app's in-code defaults.
+  const appName = process.env.PAYWALL_APP_NAME;
+  const appLogo = process.env.PAYWALL_APP_LOGO;
+  const walletConnectProjectId = process.env.PAYWALL_WALLETCONNECT_PROJECT_ID;
+  const testnet = process.env.PAYWALL_TESTNET === "1";
+  if (!appName && !appLogo && !walletConnectProjectId && !testnet) {
+    return undefined;
+  }
+  return {
+    ...(appName ? { appName } : {}),
+    ...(appLogo ? { appLogo } : {}),
+    ...(walletConnectProjectId ? { walletConnectProjectId } : {}),
+    ...(testnet ? { testnet: true } : {}),
+  };
+}
+
 export function readEnv(): ResourceServerEnv {
   const chainId = asInt(optional("CHAIN_ID", "31337"), "CHAIN_ID", { min: 1 });
   const subgraphRaw = process.env.SUBGRAPH_URL;
+  const paywallConfig = readPaywallConfig();
   return {
     publicUrl: asHttpUrl(required("RESOURCE_SERVER_URL"), "RESOURCE_SERVER_URL"),
     rpcNode: asHttpUrl(required("RPC_NODE"), "RPC_NODE"),
@@ -117,5 +145,6 @@ export function readEnv(): ResourceServerEnv {
       ? { subgraphUrl: asHttpUrl(subgraphRaw, "SUBGRAPH_URL") }
       : {}),
     port: asInt(optional("PORT", "4001"), "PORT", { min: 1, max: 65535 }),
+    ...(paywallConfig !== undefined ? { paywallConfig } : {}),
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@bosonprotocol/x402-core':
         specifier: workspace:^
         version: link:../../typescript/packages/core
+      '@bosonprotocol/x402-paywall':
+        specifier: workspace:^
+        version: link:../../typescript/packages/paywall
       '@bosonprotocol/x402-server':
         specifier: workspace:^
         version: link:../../typescript/packages/server
@@ -436,10 +439,10 @@ importers:
         version: 19.2.6(react@19.2.6)
       viem:
         specifier: ^2.39.3
-        version: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       wagmi:
         specifier: ^2.14.0
-        version: 2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        version: 2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: ^20.17.10
@@ -588,6 +591,9 @@ importers:
       '@types/node':
         specifier: ^20.17.10
         version: 20.19.40
+      playwright:
+        specifier: ^1.49.0
+        version: 1.60.0
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -3435,6 +3441,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4099,6 +4110,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
@@ -5133,16 +5154,16 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
-  '@base-org/account@2.4.0(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@base-org/account@2.4.0(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@coinbase/cdp-sdk': 1.50.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.6.9(typescript@5.9.3)(zod@4.4.3)
       preact: 10.24.2
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zustand: 5.0.3(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
     transitivePeerDependencies:
       - '@types/react'
@@ -5372,15 +5393,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.6.9(typescript@5.9.3)(zod@4.4.3)
       preact: 10.24.2
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zustand: 5.0.3(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
     transitivePeerDependencies:
       - '@types/react'
@@ -5916,11 +5937,11 @@ snapshots:
       '@ethersproject/properties': 5.8.0
       '@ethersproject/strings': 5.8.0
 
-  '@gemini-wallet/core@0.3.2(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@gemini-wallet/core@0.3.2(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
     dependencies:
       '@metamask/rpc-errors': 7.0.2
       eventemitter3: 5.0.1
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6243,24 +6264,24 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-common@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-common@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-controllers@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       valtio: 1.13.2(@types/react@19.2.15)(react@19.2.6)
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6289,12 +6310,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-pay@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-pay@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@4.4.3)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@19.2.15)(react@19.2.6)
     transitivePeerDependencies:
@@ -6329,12 +6350,12 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@3.25.76)':
+  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@4.4.3)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@4.4.3)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
     transitivePeerDependencies:
@@ -6366,10 +6387,10 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-ui@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-ui@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -6401,16 +6422,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@3.25.76)':
+  '@reown/appkit-utils@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@4.4.3)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@reown/appkit-polyfills': 1.7.8
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       valtio: 1.13.2(@types/react@19.2.15)(react@19.2.6)
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6450,21 +6471,21 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reown/appkit@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit@1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-pay': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-pay': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@3.25.76)
+      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@4.4.3)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.15)(react@19.2.6))(zod@4.4.3)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.21.0
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.15)(react@19.2.6)
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6643,9 +6664,9 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.3':
     optional: true
 
-  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       events: 3.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -6653,10 +6674,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -7396,19 +7417,19 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
-  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
+  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)))(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@base-org/account': 2.4.0(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@gemini-wallet/core': 0.3.2(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@base-org/account': 2.4.0(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@gemini-wallet/core': 0.3.2(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       '@metamask/sdk': 0.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      porto: 0.2.35(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3))
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -7449,11 +7470,11 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/core@2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@wagmi/core@2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
     optionalDependencies:
       '@tanstack/query-core': 5.100.14
@@ -7464,7 +7485,7 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -7478,7 +7499,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -7508,7 +7529,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/core@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -7522,7 +7543,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -7556,18 +7577,18 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@reown/appkit': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit': 1.7.8(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/types': 2.21.1
-      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7690,16 +7711,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/sign-client@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@walletconnect/core': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/core': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7726,16 +7747,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
-      '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7824,7 +7845,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/universal-provider@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/universal-provider@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -7833,9 +7854,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -7864,7 +7885,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -7873,9 +7894,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -7904,7 +7925,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/utils@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -7922,7 +7943,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -7948,7 +7969,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -7966,7 +7987,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -8020,10 +8041,10 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
-  abitype@1.0.8(typescript@5.9.3)(zod@3.25.76):
+  abitype@1.0.8(typescript@5.9.3)(zod@4.4.3):
     optionalDependencies:
       typescript: 5.9.3
-      zod: 3.25.76
+      zod: 4.4.3
 
   abitype@1.2.3(typescript@5.9.3)(zod@3.22.4):
     optionalDependencies:
@@ -8899,6 +8920,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -9451,28 +9475,28 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
+  ox@0.6.7(typescript@5.9.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.4.3)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.9(typescript@5.9.3)(zod@3.25.76):
+  ox@0.6.9(typescript@5.9.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.4.3)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -9587,25 +9611,33 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   pngjs@5.0.0: {}
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3)):
     dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       hono: 4.12.23
       idb-keyval: 6.2.4
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.17(typescript@5.9.3)(zod@4.4.3)
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zod: 4.4.3
       zustand: 5.0.13(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
     optionalDependencies:
       '@tanstack/react-query': 5.100.14(react@19.2.6)
       react: 19.2.6
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -10252,15 +10284,15 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.0.8(typescript@5.9.3)(zod@4.4.3)
       isows: 1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.6.7(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.6.7(typescript@5.9.3)(zod@4.4.3)
       ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
@@ -10450,14 +10482,14 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  wagmi@2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
+  wagmi@2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3):
     dependencies:
       '@tanstack/react-query': 5.100.14(react@19.2.6)
-      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)))(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@2.19.5(@tanstack/query-core@5.100.14)(@tanstack/react-query@5.100.14(react@19.2.6))(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.14)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       react: 19.2.6
       use-sync-external-store: 1.4.0(react@19.2.6)
-      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/typescript/packages/core/src/eip712/token-auth/domain.ts
+++ b/typescript/packages/core/src/eip712/token-auth/domain.ts
@@ -1,5 +1,4 @@
-// EIP-712 domain shape every BPIP-12 token-auth signer expects, plus the
-// on-chain helper that resolves it from the token contract.
+// EIP-712 domain shape every BPIP-12 token-auth signer expects.
 //
 // Both ERC-3009 (`ReceiveWithAuthorization`) and EIP-2612 (`Permit`) sign
 // against the *token contract's* EIP-712 domain. Per their respective
@@ -11,7 +10,7 @@
 // required while still allowing additional EIP-712 domain fields a token
 // might publish (e.g. `salt`).
 
-import type { Address, Hex, PublicClient } from "viem";
+import type { Address, Hex } from "viem";
 
 export interface TokenEip712Domain {
   /** Token's `EIP712Domain.name`, e.g. `"USD Coin"`. */
@@ -23,122 +22,4 @@ export interface TokenEip712Domain {
   verifyingContract: Address;
   /** Optional extra domain field some tokens publish. */
   salt?: Hex;
-}
-
-const EIP5267_ABI = [
-  {
-    type: "function",
-    name: "eip712Domain",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [
-      { name: "fields", type: "bytes1" },
-      { name: "name", type: "string" },
-      { name: "version", type: "string" },
-      { name: "chainId", type: "uint256" },
-      { name: "verifyingContract", type: "address" },
-      { name: "salt", type: "bytes32" },
-      { name: "extensions", type: "uint256[]" },
-    ],
-  },
-] as const;
-
-const NAME_ABI = [
-  {
-    type: "function",
-    name: "name",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [{ type: "string" }],
-  },
-] as const;
-
-const VERSION_ABI = [
-  {
-    type: "function",
-    name: "version",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [{ type: "string" }],
-  },
-] as const;
-
-// Duck-type check for viem's `ContractFunctionExecutionError` (and the
-// other `ContractFunction*Error` subclasses it nests as a `cause`).
-// We compare by `.name` rather than `instanceof` because the paywall's
-// browser IIFE bundle ends up with multiple viem class instances
-// (esbuild inlines viem along several import chains —
-// `@bosonprotocol/x402-core`, `@bosonprotocol/x402-client-browser`,
-// wagmi, and direct paywall imports — and class identity is not
-// preserved across them). An `instanceof` check there would falsely
-// re-throw what's really a "method not implemented" revert. Name
-// strings are stable across bundles (viem sets them via
-// `Object.defineProperty(this, "name", ...)`) and plain `Error` from
-// transport failures still falls through to the rethrow path because
-// its `.name` is `"Error"`.
-function isContractFunctionError(e: unknown): boolean {
-  if (!(e instanceof Error)) return false;
-  return e.name.startsWith("ContractFunction");
-}
-
-/**
- * Look up the token's EIP-712 domain. Tries EIP-5267 first (one call,
- * canonical); falls back to `name()` + `version()` (with version
- * defaulting to `"1"` per EIP-2612 if `version()` reverts).
- *
- * Error handling: only contract-level errors (any `ContractFunction*`
- * class viem throws via `getContractError`) are treated as "method not
- * implemented" and trigger the fallback. RPC / transport failures
- * (HTTP timeouts, JSON-RPC errors) propagate as-is so the caller can
- * distinguish them and surface a clear internal error rather than a
- * silent fallback that fails again on the next call. `name()` is
- * required by ERC-20 so any failure there is a real error and
- * propagates.
- *
- * Both the facilitator (recovering a signature) and the browser paywall
- * (about to sign one) call this against the same chain — keeping the
- * lookup in one place keeps signer and verifier in lockstep.
- */
-export async function fetchTokenDomain(
-  publicClient: PublicClient,
-  token: Address,
-  chainId: number,
-): Promise<TokenEip712Domain> {
-  try {
-    const result = (await publicClient.readContract({
-      address: token,
-      abi: EIP5267_ABI,
-      functionName: "eip712Domain",
-    })) as readonly [Hex, string, string, bigint, Address, Hex, readonly bigint[]];
-    return {
-      name: result[1],
-      version: result[2],
-      chainId: Number(result[3]),
-      verifyingContract: result[4],
-    };
-  } catch (e) {
-    if (!isContractFunctionError(e)) {
-      throw e;
-    }
-    // EIP-5267 not implemented — fall back to name() + version().
-  }
-  const name = (await publicClient.readContract({
-    address: token,
-    abi: NAME_ABI,
-    functionName: "name",
-  })) as string;
-  let version = "1";
-  try {
-    version = (await publicClient.readContract({
-      address: token,
-      abi: VERSION_ABI,
-      functionName: "version",
-    })) as string;
-  } catch (e) {
-    if (!isContractFunctionError(e)) {
-      throw e;
-    }
-    // version() is optional per EIP-2612 — keep the default.
-  }
-  return { name, version, chainId, verifyingContract: token };
 }

--- a/typescript/packages/core/src/eip712/token-auth/domain.ts
+++ b/typescript/packages/core/src/eip712/token-auth/domain.ts
@@ -1,4 +1,5 @@
-// EIP-712 domain shape every BPIP-12 token-auth signer expects.
+// EIP-712 domain shape every BPIP-12 token-auth signer expects, plus the
+// on-chain helper that resolves it from the token contract.
 //
 // Both ERC-3009 (`ReceiveWithAuthorization`) and EIP-2612 (`Permit`) sign
 // against the *token contract's* EIP-712 domain. Per their respective
@@ -10,7 +11,7 @@
 // required while still allowing additional EIP-712 domain fields a token
 // might publish (e.g. `salt`).
 
-import type { Address, Hex } from "viem";
+import type { Address, Hex, PublicClient } from "viem";
 
 export interface TokenEip712Domain {
   /** Token's `EIP712Domain.name`, e.g. `"USD Coin"`. */
@@ -22,4 +23,122 @@ export interface TokenEip712Domain {
   verifyingContract: Address;
   /** Optional extra domain field some tokens publish. */
   salt?: Hex;
+}
+
+const EIP5267_ABI = [
+  {
+    type: "function",
+    name: "eip712Domain",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [
+      { name: "fields", type: "bytes1" },
+      { name: "name", type: "string" },
+      { name: "version", type: "string" },
+      { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
+      { name: "salt", type: "bytes32" },
+      { name: "extensions", type: "uint256[]" },
+    ],
+  },
+] as const;
+
+const NAME_ABI = [
+  {
+    type: "function",
+    name: "name",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "string" }],
+  },
+] as const;
+
+const VERSION_ABI = [
+  {
+    type: "function",
+    name: "version",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "string" }],
+  },
+] as const;
+
+// Duck-type check for viem's `ContractFunctionExecutionError` (and the
+// other `ContractFunction*Error` subclasses it nests as a `cause`).
+// We compare by `.name` rather than `instanceof` because the paywall's
+// browser IIFE bundle ends up with multiple viem class instances
+// (esbuild inlines viem along several import chains —
+// `@bosonprotocol/x402-core`, `@bosonprotocol/x402-client-browser`,
+// wagmi, and direct paywall imports — and class identity is not
+// preserved across them). An `instanceof` check there would falsely
+// re-throw what's really a "method not implemented" revert. Name
+// strings are stable across bundles (viem sets them via
+// `Object.defineProperty(this, "name", ...)`) and plain `Error` from
+// transport failures still falls through to the rethrow path because
+// its `.name` is `"Error"`.
+function isContractFunctionError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  return e.name.startsWith("ContractFunction");
+}
+
+/**
+ * Look up the token's EIP-712 domain. Tries EIP-5267 first (one call,
+ * canonical); falls back to `name()` + `version()` (with version
+ * defaulting to `"1"` per EIP-2612 if `version()` reverts).
+ *
+ * Error handling: only contract-level errors (any `ContractFunction*`
+ * class viem throws via `getContractError`) are treated as "method not
+ * implemented" and trigger the fallback. RPC / transport failures
+ * (HTTP timeouts, JSON-RPC errors) propagate as-is so the caller can
+ * distinguish them and surface a clear internal error rather than a
+ * silent fallback that fails again on the next call. `name()` is
+ * required by ERC-20 so any failure there is a real error and
+ * propagates.
+ *
+ * Both the facilitator (recovering a signature) and the browser paywall
+ * (about to sign one) call this against the same chain — keeping the
+ * lookup in one place keeps signer and verifier in lockstep.
+ */
+export async function fetchTokenDomain(
+  publicClient: PublicClient,
+  token: Address,
+  chainId: number,
+): Promise<TokenEip712Domain> {
+  try {
+    const result = (await publicClient.readContract({
+      address: token,
+      abi: EIP5267_ABI,
+      functionName: "eip712Domain",
+    })) as readonly [Hex, string, string, bigint, Address, Hex, readonly bigint[]];
+    return {
+      name: result[1],
+      version: result[2],
+      chainId: Number(result[3]),
+      verifyingContract: result[4],
+    };
+  } catch (e) {
+    if (!isContractFunctionError(e)) {
+      throw e;
+    }
+    // EIP-5267 not implemented — fall back to name() + version().
+  }
+  const name = (await publicClient.readContract({
+    address: token,
+    abi: NAME_ABI,
+    functionName: "name",
+  })) as string;
+  let version = "1";
+  try {
+    version = (await publicClient.readContract({
+      address: token,
+      abi: VERSION_ABI,
+      functionName: "version",
+    })) as string;
+  } catch (e) {
+    if (!isContractFunctionError(e)) {
+      throw e;
+    }
+    // version() is optional per EIP-2612 — keep the default.
+  }
+  return { name, version, chainId, verifyingContract: token };
 }

--- a/typescript/packages/core/src/eip712/token-auth/fetch-token-domain.ts
+++ b/typescript/packages/core/src/eip712/token-auth/fetch-token-domain.ts
@@ -58,6 +58,15 @@ export const VERSION_ABI = [
   },
 ] as const;
 
+// EIP-5267 `fields` bitmask: bit i (LSB-first) is set when domain field
+// i — in EIP-712's canonical field order (name, version, chainId,
+// verifyingContract, salt) — is present. We only need the `salt` bit:
+// tokens whose domain includes `salt` computed their domain separator
+// with it, so the signature won't recover unless we carry it through;
+// tokens that omit `salt` return a zero `bytes32` we must drop, or the
+// extra field corrupts the domain we hash against.
+const EIP5267_SALT_BIT = 0x10;
+
 // Duck-type check for viem's `ContractFunctionExecutionError` (and the
 // other `ContractFunction*Error` subclasses it nests as a `cause`).
 // We compare by `.name` rather than `instanceof` because the paywall's
@@ -105,11 +114,13 @@ export async function fetchTokenDomain(
       abi: EIP5267_ABI,
       functionName: "eip712Domain",
     })) as readonly [Hex, string, string, bigint, Address, Hex, readonly bigint[]];
+    const hasSalt = (Number(result[0]) & EIP5267_SALT_BIT) !== 0;
     return {
       name: result[1],
       version: result[2],
       chainId: Number(result[3]),
       verifyingContract: result[4],
+      salt: hasSalt ? result[5] : undefined,
     };
   } catch (e) {
     if (!isContractFunctionError(e)) {

--- a/typescript/packages/core/src/eip712/token-auth/fetch-token-domain.ts
+++ b/typescript/packages/core/src/eip712/token-auth/fetch-token-domain.ts
@@ -16,7 +16,7 @@
 // next call. `name()` is required by ERC-20 so any failure there is a
 // real error and propagates.
 
-import { ContractFunctionExecutionError, type Address, type Hex, type PublicClient } from "viem";
+import { type Address, type Hex, type PublicClient } from "viem";
 
 import type { TokenEip712Domain } from "./domain.js";
 
@@ -58,6 +58,42 @@ export const VERSION_ABI = [
   },
 ] as const;
 
+// Duck-type check for viem's `ContractFunctionExecutionError` (and the
+// other `ContractFunction*Error` subclasses it nests as a `cause`).
+// We compare by `.name` rather than `instanceof` because the paywall's
+// browser IIFE bundle ends up with multiple viem class instances
+// (esbuild inlines viem along several import chains —
+// `@bosonprotocol/x402-core`, `@bosonprotocol/x402-client-browser`,
+// wagmi, and direct paywall imports — and class identity is not
+// preserved across them). An `instanceof` check there would falsely
+// re-throw what's really a "method not implemented" revert. Name
+// strings are stable across bundles (viem sets them via
+// `Object.defineProperty(this, "name", ...)`) and plain `Error` from
+// transport failures still falls through to the rethrow path because
+// its `.name` is `"Error"`.
+function isContractFunctionError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  return e.name.startsWith("ContractFunction");
+}
+
+/**
+ * Look up the token's EIP-712 domain. Tries EIP-5267 first (one call,
+ * canonical); falls back to `name()` + `version()` (with version
+ * defaulting to `"1"` per EIP-2612 if `version()` reverts).
+ *
+ * Error handling: only contract-level errors (any `ContractFunction*`
+ * class viem throws via `getContractError`) are treated as "method not
+ * implemented" and trigger the fallback. RPC / transport failures
+ * (HTTP timeouts, JSON-RPC errors) propagate as-is so the caller can
+ * distinguish them and surface a clear internal error rather than a
+ * silent fallback that fails again on the next call. `name()` is
+ * required by ERC-20 so any failure there is a real error and
+ * propagates.
+ *
+ * Both the facilitator (recovering a signature) and the browser paywall
+ * (about to sign one) call this against the same chain — keeping the
+ * lookup in one place keeps signer and verifier in lockstep.
+ */
 export async function fetchTokenDomain(
   publicClient: PublicClient,
   token: Address,
@@ -76,7 +112,7 @@ export async function fetchTokenDomain(
       verifyingContract: result[4],
     };
   } catch (e) {
-    if (!(e instanceof ContractFunctionExecutionError)) {
+    if (!isContractFunctionError(e)) {
       throw e;
     }
     // EIP-5267 not implemented — fall back to name() + version().
@@ -94,10 +130,10 @@ export async function fetchTokenDomain(
       functionName: "version",
     })) as string;
   } catch (e) {
-    if (!(e instanceof ContractFunctionExecutionError)) {
+    if (!isContractFunctionError(e)) {
       throw e;
     }
-    // version() is optional per EIP-2612 — keep the default "1".
+    // version() is optional per EIP-2612 — keep the default.
   }
   return { name, version, chainId, verifyingContract: token };
 }

--- a/typescript/packages/core/test/eip712/token-auth/domain.test.ts
+++ b/typescript/packages/core/test/eip712/token-auth/domain.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { ContractFunctionExecutionError, type PublicClient } from "viem";
+
+import { fetchTokenDomain } from "../../../src/eip712/token-auth/index.js";
+
+const TOKEN = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" as const;
+const CHAIN_ID = 31337;
+
+// Mimics the wrapper viem produces via `getContractError` — the outer
+// throwable is always a `ContractFunctionExecutionError` regardless of
+// the inner `cause` (revert / zero-data / etc.).
+function contractFunctionError(message: string): ContractFunctionExecutionError {
+  return new ContractFunctionExecutionError(new Error(message), {
+    abi: [],
+    functionName: "stub",
+  });
+}
+
+// Same shape minus the prototype chain — exercises the name-based
+// duck-type check in `fetchTokenDomain`. Mirrors what the paywall's
+// browser IIFE bundle ends up with when esbuild inlines viem along
+// several import chains and class identity stops being preserved.
+function nameOnlyContractFunctionError(): Error {
+  const e = new Error("ContractFunctionExecutionError (duck-typed)");
+  e.name = "ContractFunctionExecutionError";
+  return e;
+}
+
+interface Stubs {
+  eip712Domain?: () => unknown;
+  name?: () => unknown;
+  version?: () => unknown;
+}
+
+function buildClient(stubs: Stubs): PublicClient {
+  return {
+    readContract: async ({ functionName }: { functionName: string }) => {
+      const stub = stubs[functionName as keyof Stubs];
+      if (!stub) throw new Error(`unexpected readContract call: ${functionName}`);
+      return stub();
+    },
+  } as unknown as PublicClient;
+}
+
+describe("fetchTokenDomain", () => {
+  it("returns the EIP-5267 result when the token implements eip712Domain()", async () => {
+    const client = buildClient({
+      eip712Domain: () =>
+        ["0x0f", "USD Coin", "2", 8453n, TOKEN, `0x${"00".repeat(32)}`, []] as const,
+    });
+    const domain = await fetchTokenDomain(client, TOKEN, CHAIN_ID);
+    expect(domain).toEqual({
+      name: "USD Coin",
+      version: "2",
+      chainId: 8453,
+      verifyingContract: TOKEN,
+    });
+  });
+
+  it("falls back to name() + version() when eip712Domain() throws a ContractFunctionExecutionError", async () => {
+    const client = buildClient({
+      eip712Domain: () => {
+        throw contractFunctionError("function selector was not recognized");
+      },
+      name: () => "ERC3009Token",
+      version: () => "2",
+    });
+    expect(await fetchTokenDomain(client, TOKEN, CHAIN_ID)).toEqual({
+      name: "ERC3009Token",
+      version: "2",
+      chainId: CHAIN_ID,
+      verifyingContract: TOKEN,
+    });
+  });
+
+  it("falls back even when the thrown error only matches by name (regression: dual viem instances in browser bundle)", async () => {
+    const client = buildClient({
+      eip712Domain: () => {
+        throw nameOnlyContractFunctionError();
+      },
+      name: () => "ERC3009Token",
+      version: () => "1",
+    });
+    expect(await fetchTokenDomain(client, TOKEN, CHAIN_ID)).toEqual({
+      name: "ERC3009Token",
+      version: "1",
+      chainId: CHAIN_ID,
+      verifyingContract: TOKEN,
+    });
+  });
+
+  it("defaults version to '1' when version() reverts (EIP-2612 default)", async () => {
+    const client = buildClient({
+      eip712Domain: () => {
+        throw contractFunctionError("eip712Domain not implemented");
+      },
+      name: () => "ERC3009Token",
+      version: () => {
+        throw contractFunctionError("version() not implemented");
+      },
+    });
+    expect(await fetchTokenDomain(client, TOKEN, CHAIN_ID)).toEqual({
+      name: "ERC3009Token",
+      version: "1",
+      chainId: CHAIN_ID,
+      verifyingContract: TOKEN,
+    });
+  });
+
+  it("propagates transport-level errors (plain Error) without falling back", async () => {
+    const transportError = new Error("ECONNREFUSED: RPC unreachable");
+    const client = buildClient({
+      eip712Domain: () => {
+        throw transportError;
+      },
+    });
+    await expect(fetchTokenDomain(client, TOKEN, CHAIN_ID)).rejects.toBe(transportError);
+  });
+});

--- a/typescript/packages/core/test/eip712/token-auth/domain.test.ts
+++ b/typescript/packages/core/test/eip712/token-auth/domain.test.ts
@@ -57,6 +57,36 @@ describe("fetchTokenDomain", () => {
     });
   });
 
+  it("includes salt when the EIP-5267 fields bitmask sets the salt bit (0x10)", async () => {
+    const salt = `0x${"ab".repeat(32)}` as const;
+    const client = buildClient({
+      // 0x1f = name|version|chainId|verifyingContract|salt
+      eip712Domain: () => ["0x1f", "USD Coin", "2", 8453n, TOKEN, salt, []] as const,
+    });
+    expect(await fetchTokenDomain(client, TOKEN, CHAIN_ID)).toEqual({
+      name: "USD Coin",
+      version: "2",
+      chainId: 8453,
+      verifyingContract: TOKEN,
+      salt,
+    });
+  });
+
+  it("drops a non-zero salt when the fields bitmask leaves the salt bit unset", async () => {
+    const client = buildClient({
+      // 0x0f leaves the salt bit (0x10) unset, so the returned salt is
+      // not part of the domain and must not be carried through.
+      eip712Domain: () =>
+        ["0x0f", "USD Coin", "2", 8453n, TOKEN, `0x${"ab".repeat(32)}`, []] as const,
+    });
+    expect(await fetchTokenDomain(client, TOKEN, CHAIN_ID)).toEqual({
+      name: "USD Coin",
+      version: "2",
+      chainId: 8453,
+      verifyingContract: TOKEN,
+    });
+  });
+
   it("falls back to name() + version() when eip712Domain() throws a ContractFunctionExecutionError", async () => {
     const client = buildClient({
       eip712Domain: () => {

--- a/typescript/packages/facilitator/src/verify/token-auth-signature.ts
+++ b/typescript/packages/facilitator/src/verify/token-auth-signature.ts
@@ -9,18 +9,20 @@
 // buyer, the asset and recipient must match the requirements, etc.
 //
 // For ERC-3009 / EIP-2612 we need the token's EIP-712 domain
-// (`name`, `version`). We resolve it via EIP-5267's `eip712Domain()`
-// when the token supports it, falling back to `name()` + `version()`
-// with a default `"1"` if `version()` reverts (the EIP-2612 default).
+// (`name`, `version`). `fetchTokenDomain` (shared with the browser
+// paywall) resolves it via EIP-5267's `eip712Domain()` when the token
+// supports it, falling back to `name()` + `version()` with a default
+// `"1"` if `version()` reverts.
 
 import type { Address, BosonTokenAuth, Hex } from "@bosonprotocol/x402-core/schemes/escrow";
 import {
   type TokenEip712Domain,
+  fetchTokenDomain,
   recoverErc3009Signer,
   recoverPermit2Signer,
   recoverPermitSigner,
 } from "@bosonprotocol/x402-core/eip712/token-auth";
-import { ContractFunctionExecutionError, type PublicClient } from "viem";
+import type { PublicClient } from "viem";
 
 import { packRsv } from "./meta-tx-signature.js";
 import type { StepResult } from "./structural.js";
@@ -41,107 +43,6 @@ export interface VerifyTokenAuthSignatureArgs {
   tokenAuth: BosonTokenAuth;
   /** Used to look up the token's EIP-712 domain (`name` / `version`) for ERC-3009 and EIP-2612. */
   publicClient: PublicClient;
-}
-
-const EIP5267_ABI = [
-  {
-    type: "function",
-    name: "eip712Domain",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [
-      { name: "fields", type: "bytes1" },
-      { name: "name", type: "string" },
-      { name: "version", type: "string" },
-      { name: "chainId", type: "uint256" },
-      { name: "verifyingContract", type: "address" },
-      { name: "salt", type: "bytes32" },
-      { name: "extensions", type: "uint256[]" },
-    ],
-  },
-] as const;
-
-const NAME_ABI = [
-  {
-    type: "function",
-    name: "name",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [{ type: "string" }],
-  },
-] as const;
-
-const VERSION_ABI = [
-  {
-    type: "function",
-    name: "version",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [{ type: "string" }],
-  },
-] as const;
-
-/**
- * Look up the token's EIP-712 domain. Tries EIP-5267 first (one call,
- * canonical); falls back to `name()` + `version()` (with version
- * defaulting to `"1"` per EIP-2612 if `version()` reverts).
- *
- * Error handling: only `ContractFunctionExecutionError` is treated as
- * "method not implemented" and triggers the fallback. RPC / transport
- * failures (HTTP timeouts, JSON-RPC errors) propagate as-is so the
- * caller can distinguish them and surface a clear
- * `INTERNAL_ERROR` rather than a silent fallback that fails again on
- * the next call. `name()` is required by ERC-20 so any failure there
- * is a real error and propagates.
- *
- * Exported so tests can inject a mocked PublicClient and so future
- * caching layers can wrap it.
- */
-export async function fetchTokenDomain(
-  publicClient: PublicClient,
-  token: Address,
-  chainId: number,
-): Promise<TokenEip712Domain> {
-  try {
-    const result = (await publicClient.readContract({
-      address: token as `0x${string}`,
-      abi: EIP5267_ABI,
-      functionName: "eip712Domain",
-    })) as readonly [Hex, string, string, bigint, Address, Hex, readonly bigint[]];
-    return {
-      name: result[1],
-      version: result[2],
-      chainId: Number(result[3]),
-      verifyingContract: result[4] as `0x${string}`,
-    };
-  } catch (e) {
-    if (!(e instanceof ContractFunctionExecutionError)) {
-      // Transport / RPC failure — propagate. EIP-5267-not-implemented
-      // would surface as a ContractFunctionExecutionError; anything
-      // else means we couldn't reach the contract at all.
-      throw e;
-    }
-    // EIP-5267 not implemented — fall back to name() + version().
-  }
-  const name = (await publicClient.readContract({
-    address: token as `0x${string}`,
-    abi: NAME_ABI,
-    functionName: "name",
-  })) as string;
-  let version = "1";
-  try {
-    version = (await publicClient.readContract({
-      address: token as `0x${string}`,
-      abi: VERSION_ABI,
-      functionName: "version",
-    })) as string;
-  } catch (e) {
-    if (!(e instanceof ContractFunctionExecutionError)) {
-      throw e;
-    }
-    // version() is optional per EIP-2612 — keep the default.
-  }
-  return { name, version, chainId, verifyingContract: token as `0x${string}` };
 }
 
 export async function verifyTokenAuthSignature(

--- a/typescript/packages/paywall/src/app/EvmEscrowPaywall.tsx
+++ b/typescript/packages/paywall/src/app/EvmEscrowPaywall.tsx
@@ -16,13 +16,16 @@
 // token authorization) happen inside that single call.
 
 import { createX402bClient, signerFromWalletClient } from "@bosonprotocol/x402-client-browser";
+import { fetchTokenDomain } from "@bosonprotocol/x402-core/eip712/token-auth";
 import { useMemo, useRef, useState } from "react";
+import type { Address } from "viem";
 import {
   useAccount,
   useChainId,
   useConnect,
   useConnectors,
   useDisconnect,
+  usePublicClient,
   useSwitchChain,
   useWalletClient,
 } from "wagmi";
@@ -56,6 +59,11 @@ export function EvmEscrowPaywall({ state }: Props) {
   const enabledConnectors = useConnectors();
   const { disconnect } = useDisconnect();
   const { data: walletClient } = useWalletClient();
+  // PublicClient for the required chain (the wagmi Providers tree is
+  // configured with that chain). Used to read the token's EIP-712 domain
+  // on-chain so the buyer signs against the same `{ name, version }` the
+  // facilitator will recover against — see fetchTokenDomain.
+  const publicClient = usePublicClient({ chainId: requiredChainId });
 
   const [status, setStatus] = useState<Status>("idle");
   const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
@@ -96,16 +104,34 @@ export function EvmEscrowPaywall({ state }: Props) {
       setStatus("signing");
       setErrorMessage(undefined);
       try {
+        if (!publicClient) {
+          setStatus("error");
+          setErrorMessage(
+            `No public RPC client is available for chain ${requiredChainId}; cannot resolve the token's EIP-712 domain.`,
+          );
+          return;
+        }
         const signer = signerFromWalletClient(walletClient);
-        const tokenDomain = lookupTokenDomain(config?.tokenDomains, requirements.asset);
+        const tokenDomainOverride = lookupTokenDomain(config?.tokenDomains, requirements.asset);
         const client = createX402bClient({
           signer,
-          tokenDomainResolver: async (asset, chainId) => ({
-            name: tokenDomain?.name ?? asset,
-            version: tokenDomain?.version ?? "1",
-            chainId,
-            verifyingContract: asset,
-          }),
+          // Resolve the token's EIP-712 domain on-chain (EIP-5267 →
+          // name() + version()) so the buyer signs against the same
+          // `{ name, version }` the facilitator will recover against.
+          // `paywallConfig.tokenDomains` remains an explicit override for
+          // tokens whose deployed `name()` differs from the EIP-712 name
+          // they actually sign against.
+          tokenDomainResolver: async (asset, chainId) => {
+            if (tokenDomainOverride) {
+              return {
+                name: tokenDomainOverride.name,
+                version: tokenDomainOverride.version,
+                chainId,
+                verifyingContract: asset,
+              };
+            }
+            return fetchTokenDomain(publicClient, asset as Address, chainId);
+          },
           ...(requirements.fulfillment?.required && selectedFulfillment
             ? { fulfillment: { option: selectedFulfillment, data: null } }
             : {}),

--- a/typescript/packages/paywall/src/app/EvmEscrowPaywall.tsx
+++ b/typescript/packages/paywall/src/app/EvmEscrowPaywall.tsx
@@ -153,7 +153,7 @@ export function EvmEscrowPaywall({ state }: Props) {
   }
 
   return (
-    <div className="x402b-paywall">
+    <div className="x402b-paywall" data-testid="paywall-root" data-paywall-status={status}>
       <header className="x402b-header">
         {config?.appLogo ? <img className="x402b-logo" src={config.appLogo} alt="" /> : null}
         <h1>{config?.appName ?? "Payment required"}</h1>
@@ -206,6 +206,7 @@ export function EvmEscrowPaywall({ state }: Props) {
         <button
           type="button"
           className="x402b-pay"
+          data-testid="paywall-pay"
           disabled={!isConnected || status === "signing" || status === "submitting"}
           onClick={handlePay}
         >
@@ -217,7 +218,11 @@ export function EvmEscrowPaywall({ state }: Props) {
                 ? "Loaded"
                 : "Pay & redeem"}
         </button>
-        {errorMessage ? <p className="x402b-error">{errorMessage}</p> : null}
+        {errorMessage ? (
+          <p className="x402b-error" data-testid="paywall-error">
+            {errorMessage}
+          </p>
+        ) : null}
       </section>
 
       <PaywallFooter config={config} />
@@ -267,6 +272,7 @@ function ConnectorList(props: {
           <button
             type="button"
             className="x402b-connector"
+            data-testid={`paywall-connector-${c.id}`}
             disabled={props.disabled}
             onClick={() => props.onConnect(c.id)}
           >
@@ -287,12 +293,14 @@ function WalletStatus(props: {
   return (
     <div className="x402b-wallet-status">
       {props.wrongNetwork ? (
-        <p className="x402b-warning">
+        <p className="x402b-warning" data-testid="paywall-wrong-network">
           Connected to chain {props.connectedChainId}; the payment requires {props.requiredChainId}.
           The Pay button will request a network switch.
         </p>
       ) : (
-        <p className="x402b-ok">Wallet connected.</p>
+        <p className="x402b-ok" data-testid="paywall-wallet-connected">
+          Wallet connected.
+        </p>
       )}
       <button type="button" className="x402b-disconnect" onClick={props.onDisconnect}>
         Disconnect

--- a/typescript/packages/paywall/src/app/chain.ts
+++ b/typescript/packages/paywall/src/app/chain.ts
@@ -8,6 +8,7 @@
 import {
   base,
   baseSepolia,
+  hardhat,
   mainnet,
   optimism,
   optimismSepolia,
@@ -16,6 +17,17 @@ import {
   sepolia,
   type Chain,
 } from "viem/chains";
+
+// Override viem's `hardhat` chain so its default RPC matches the
+// canonical local Boson environment endpoint
+// (`envConfigs.local[0].jsonRpcUrl` in @bosonprotocol/common =
+// `http://127.0.0.1:8545`). Lifted as a constant rather than imported
+// so we don't drag common's 1.5 MB ABI bundle into the browser build —
+// mirrors the pattern in `x402-e2e/src/config/local-31337-0.ts`.
+const localBoson: Chain = {
+  ...hardhat,
+  rpcUrls: { default: { http: ["http://127.0.0.1:8545"] } },
+};
 
 const KNOWN_CHAINS: Record<number, Chain> = {
   [mainnet.id]: mainnet,
@@ -26,6 +38,7 @@ const KNOWN_CHAINS: Record<number, Chain> = {
   [optimismSepolia.id]: optimismSepolia,
   [polygon.id]: polygon,
   [polygonAmoy.id]: polygonAmoy,
+  [localBoson.id]: localBoson,
 };
 
 const CAIP2_PATTERN = /^eip155:(\d+)$/;

--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -164,6 +164,7 @@ with `-t '@p0'`. Priorities:
 | `@p0`    | concurrent commit-and-redeem (E0)             | `concurrent.test.ts`          |
 | `@p0`    | post-commit lifecycle (B1–B4)                 | `post-commit.test.ts`         |
 | `@p0`    | commit-time validations (C1–C5, C8)           | `validation-commit.test.ts`   |
+| `@p0`    | browser paywall (BR1–BR3)                     | `browser/paywall.test.ts`     |
 | `@p1`    | post-commit lifecycle (B6, B7)                | `post-commit.test.ts`         |
 | `@p1`    | operational scenarios (F1)                    | `operational.test.ts`         |
 | `@p2`    | operational scenarios (F2, F4)                | `operational.test.ts`         |
@@ -305,3 +306,47 @@ await asserter.expect(decoded!.exchangeId!, {
   through. See [`src/harness/seed.ts`](./src/harness/seed.ts) header
   for rationale.
 - **No scenario tests yet** — those land in PR 6 alongside CI wiring.
+
+## Browser scenarios
+
+`test/browser/paywall.test.ts` drives a real headless chromium (via
+the `playwright` library, not `@vitest/browser`) through the
+`@bosonprotocol/x402-paywall` HTML 402 flow end-to-end. Three
+scenarios:
+
+- **BR1** (`@p0`) — happy path: server emits the paywall HTML, an
+  injected EIP-1193 mock (backed by a viem private key on the Node
+  side via `BrowserContext.exposeFunction`) signs the X-PAYMENT
+  payload, the buyer's retry settles on-chain, and the on-chain
+  `ExchangeState.COMMITTED` is asserted via the subgraph reader.
+- **BR2** (`@p0`) — the mock wallet rejects `eth_signTypedData_v4`
+  with `code: 4001`; the paywall surfaces the error in
+  `[data-testid="paywall-error"]` and no on-chain commit happens.
+- **BR3** (`@p0`) — the mock wallet reports the wrong chain id and
+  rejects `wallet_switchEthereumChain`; the paywall shows the
+  wrong-network warning, `Pay` surfaces the rejection, no commit.
+
+Slot: `browser` (`SEED_WALLETS.browser` → `ACCOUNT_14`). All three
+scenarios live in one file so they run sequentially against the same
+in-process resource server — the paywall doesn't yet stamp
+`X-Session-Id`, so concurrent flows would race on the
+`FALLBACK_KEY` session slot in the resource server's session cache.
+
+### Local prerequisites
+
+`playwright` ships its own chromium download (~150MB) via its
+postinstall hook. Cached under `PLAYWRIGHT_BROWSERS_PATH` if set;
+otherwise under each install's `node_modules/playwright/.local-browsers`.
+CI should cache that path to avoid re-downloading per job. Set
+`PLAYWRIGHT_SKIP_DOWNLOAD=1` to opt out (browser tests will fail to
+launch).
+
+### Running only the browser file
+
+```sh
+E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test:browser
+```
+
+Equivalent to `vitest run test/browser`. Combine with
+`E2E_DOCKER_KEEP_STACK=1` and a manual `pnpm stack:up` for fast inner
+loops.

--- a/typescript/packages/x402-e2e/package.json
+++ b/typescript/packages/x402-e2e/package.json
@@ -9,6 +9,7 @@
     "build": "tsc --noEmit",
     "test": "vitest run",
     "test:p0": "vitest run -t @p0",
+    "test:browser": "vitest run test/browser",
     "lint": "eslint src test scripts --max-warnings 0",
     "stack:up": "tsx scripts/stack-up.ts",
     "stack:down": "tsx scripts/stack-down.ts",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.17.10",
+    "playwright": "^1.49.0",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"
   }

--- a/typescript/packages/x402-e2e/src/bin/resource-server.ts
+++ b/typescript/packages/x402-e2e/src/bin/resource-server.ts
@@ -10,8 +10,22 @@
 // The reader's subgraph URL comes from the `SUBGRAPH_URL` env the
 // canonical compose already wires to the in-container subgraph
 // endpoint (`http://host.docker.internal:8000/subgraphs/name/boson/corecomponents`).
+//
+// Seller self-seeding: the example's `readEnv` requires a `SELLER_ID`,
+// but on a fresh devnet stack the seller entity behind the configured
+// `SELLER_PK` doesn't exist yet — and the on-chain numeric id can't be
+// known until `createSeller` has been called. The entrypoint mirrors
+// the harness's `seedSuite` flow: look up the subgraph for a seller
+// whose `assistant` matches `SELLER_PK`'s address, call `createSeller`
+// when absent, then override `env.sellerId` with the resolved id
+// before constructing the app. Without this step, the buyer's
+// `createOfferAndCommit` reverts `NotAssistant()` because the recovered
+// `offer.creator` isn't a registered assistant on chain. Idempotent —
+// a re-boot against a stack where the seller already exists is a
+// no-op lookup.
 
-import type { Address, PublicClient } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import type { Address, Hex, PublicClient } from "viem";
 
 import {
   createResourceServerApp,
@@ -20,8 +34,10 @@ import {
   type ProtocolConfig,
 } from "@bosonprotocol/x402-example-resource-server";
 
-import { buildPublicClient } from "../harness/clients.js";
+import { buildPublicClient, buildWalletClient } from "../harness/clients.js";
+import { buildCreateSellerCallback } from "../harness/create-seller.js";
 import { createSubgraphExchangeReader } from "../harness/exchange-reader.js";
+import { seedSuite } from "../harness/seed.js";
 
 // `docker compose up --wait` only blocks until each container reports
 // healthy; the contracts inside `boson-protocol-node` are still
@@ -106,12 +122,62 @@ async function waitForProtocolConfigInitialized(args: {
   }
 }
 
+/**
+ * Look up — or create — the Boson seller entity whose assistant is
+ * the address derived from `sellerPk`. Returns the resolved seller id
+ * (decimal string) so the caller can override `env.sellerId` before
+ * handing it to `createResourceServerApp`. Idempotent against an
+ * already-registered seller: the subgraph hit short-circuits before
+ * any on-chain write.
+ */
+async function ensureSellerEntity(args: {
+  sellerPk: Hex;
+  rpcUrl: string;
+  publicClient: PublicClient;
+  escrowAddress: Address;
+  chainId: number;
+  subgraphUrl: string;
+}): Promise<string> {
+  const sellerAccount = privateKeyToAccount(args.sellerPk);
+  console.log(
+    `[x402-e2e/resource-server] ensuring seller entity for assistant ${sellerAccount.address}…`,
+  );
+  const walletClient = buildWalletClient(sellerAccount, { rpcUrl: args.rpcUrl });
+  const createSeller = buildCreateSellerCallback({
+    walletClient,
+    publicClient: args.publicClient,
+    escrowAddress: args.escrowAddress,
+    chainId: args.chainId,
+    subgraphUrl: args.subgraphUrl,
+  });
+  const state = await seedSuite({
+    sellerAddress: sellerAccount.address,
+    subgraphUrl: args.subgraphUrl,
+    escrowAddress: args.escrowAddress,
+    chainId: args.chainId,
+    createSeller,
+  });
+  console.log(
+    `[x402-e2e/resource-server] seller entity ready: id=${state.seller.id}, assistant=${state.seller.assistant}`,
+  );
+  return state.seller.id;
+}
+
 async function main(): Promise<void> {
+  // The example's `readEnv` flags `SELLER_ID` as required so library
+  // operators always pin the on-chain seller id at boot. The harness
+  // can't — the id is only knowable after `createSeller` lands. Inject
+  // a placeholder so `readEnv`'s validator accepts the env, then
+  // overwrite `env.sellerId` further down with the real value resolved
+  // by `ensureSellerEntity`. The placeholder is never observed by the
+  // app because the override happens before `createResourceServerApp`.
+  process.env.SELLER_ID ??= "0";
+
   const env = readEnv();
 
   if (env.subgraphUrl === undefined) {
     throw new Error(
-      "[x402-e2e/resource-server] SUBGRAPH_URL is required so the entrypoint can construct the subgraph-backed ExchangeReader",
+      "[x402-e2e/resource-server] SUBGRAPH_URL is required so the entrypoint can construct the subgraph-backed ExchangeReader and self-seed the seller entity",
     );
   }
 
@@ -133,6 +199,15 @@ async function main(): Promise<void> {
     escrowAddress: env.escrowAddress,
   });
 
+  const sellerId = await ensureSellerEntity({
+    sellerPk: env.sellerPk,
+    rpcUrl: env.rpcNode,
+    publicClient,
+    escrowAddress: env.escrowAddress,
+    chainId: env.chainId,
+    subgraphUrl: env.subgraphUrl,
+  });
+
   const exchangeReader = createSubgraphExchangeReader({
     subgraphUrl: env.subgraphUrl,
     escrowAddress: env.escrowAddress,
@@ -140,7 +215,10 @@ async function main(): Promise<void> {
     publicClient,
   });
 
-  const { app, seller } = createResourceServerApp(env, { exchangeReader, protocolConfig });
+  const { app, seller } = createResourceServerApp(
+    { ...env, sellerId },
+    { exchangeReader, protocolConfig },
+  );
 
   const server = app.listen(env.port, () => {
     console.log(

--- a/typescript/packages/x402-e2e/src/bin/resource-server.ts
+++ b/typescript/packages/x402-e2e/src/bin/resource-server.ts
@@ -27,6 +27,8 @@
 import { privateKeyToAccount } from "viem/accounts";
 import { getAddress, type Address, type Hex, type PublicClient } from "viem";
 
+import { CoreSDK } from "@bosonprotocol/core-sdk";
+import { asCoreSdkReadAdapter } from "@bosonprotocol/x402-server";
 import {
   createResourceServerApp,
   fetchProtocolConfig,
@@ -59,6 +61,36 @@ import { seedSuite } from "../harness/seed.js";
 // entrypoint can't `docker compose exec` against the protocol node.
 const ESCROW_DEPLOY_TIMEOUT_MS = 10 * 60_000;
 const ESCROW_DEPLOY_POLL_INTERVAL_MS = 2_000;
+
+// The `boson-subgraph` (graph-node) container reports healthy long
+// before the `boson/corecomponents` subgraph has been deployed and
+// indexed up to the chain head. Cold subgraph deploys can take a
+// while, so reuse the same generous 10-minute ceiling as the escrow /
+// config gates.
+const SUBGRAPH_READY_TIMEOUT_MS = 10 * 60_000;
+const SUBGRAPH_READY_POLL_INTERVAL_MS = 2_000;
+
+/** CoreSDK exposes `waitForGraphNodeIndexing` via the subgraph mixin; narrow to that surface. */
+interface CoreSdkWithIndexerWait {
+  waitForGraphNodeIndexing(blockNumber?: number): Promise<void>;
+}
+
+/**
+ * Throwing `Web3LibAdapter` stub — read-only paths through CoreSDK
+ * never invoke `web3Lib`, so any access surfaces as a loud error
+ * rather than a silent network call. Mirrors the stubs in
+ * `src/harness/seed.ts` and `src/harness/exchange-reader.ts`.
+ */
+function createReadOnlyWeb3LibStub(): never {
+  const handler: ProxyHandler<object> = {
+    get(_target, prop) {
+      throw new Error(
+        `[x402-e2e/resource-server] read-only CoreSDK should not invoke web3Lib.${String(prop)}`,
+      );
+    },
+  };
+  return new Proxy({}, handler) as never;
+}
 
 // Target balance minted to each `BUYER_WALLETS` entry on boot. 100 USDC
 // at 6dp = 100× the default offer price (AMOUNT=1000000), so a browser
@@ -126,6 +158,68 @@ async function waitForProtocolConfigInitialized(args: {
       );
     }
     await sleep(ESCROW_DEPLOY_POLL_INTERVAL_MS);
+  }
+}
+
+/**
+ * Block until the `boson-subgraph` is ready to serve the seller
+ * lookup — both *responsive* (the `boson/corecomponents` subgraph is
+ * deployed and serving GraphQL) and *caught up* to the current chain
+ * head. A plain `depends_on` only waits for the graph-node container
+ * to start, and the container reports healthy well before the subgraph
+ * is deployed/indexed, so on a cold stack the first
+ * `getSellersByAddress` (in `seedSuite`) would throw and crash boot.
+ *
+ * Gating on indexing-to-head also fixes a latent idempotency bug: on a
+ * re-boot against a stack whose seller already exists, an under-indexed
+ * subgraph reports it absent, which would trigger a spurious
+ * `createSeller` (and an on-chain revert). Waiting for the head
+ * guarantees an already-registered seller is visible before the lookup.
+ *
+ * Builds a read-only CoreSDK with a throwing `web3Lib` stub (mirrors
+ * `seed.ts` / `exchange-reader.ts`) — no on-chain writes happen here.
+ */
+async function waitForSubgraphReady(args: {
+  publicClient: PublicClient;
+  subgraphUrl: string;
+  escrowAddress: Address;
+  chainId: number;
+  sellerAddress: Address;
+}): Promise<void> {
+  const deadline = Date.now() + SUBGRAPH_READY_TIMEOUT_MS;
+  console.log(
+    `[x402-e2e/resource-server] waiting for subgraph ${args.subgraphUrl} to be ready (deployed and indexed to head)…`,
+  );
+  const sdk = new CoreSDK({
+    web3Lib: createReadOnlyWeb3LibStub() as never,
+    subgraphUrl: args.subgraphUrl,
+    protocolDiamond: args.escrowAddress,
+    chainId: args.chainId,
+  });
+  const indexerWait = sdk as unknown as CoreSdkWithIndexerWait;
+  const coreSdkRead = asCoreSdkReadAdapter(sdk);
+  while (true) {
+    try {
+      // `cacheTime: 0` defeats viem's block-number cache so we wait on
+      // the freshest head, not a stale cached one (see exchange-reader.ts).
+      const head = await args.publicClient.getBlockNumber({ cacheTime: 0 });
+      // Resolves only once the subgraph exists and its indexer has
+      // reached `head`; throws while the endpoint isn't serving yet.
+      await indexerWait.waitForGraphNodeIndexing(Number(head));
+      // Final liveness check on the exact query path the seller lookup
+      // uses. Return value is irrelevant — we only care it doesn't throw.
+      await coreSdkRead.getSellersByAddress(args.sellerAddress);
+      console.log(`[x402-e2e/resource-server] subgraph ${args.subgraphUrl} is ready`);
+      return;
+    } catch {
+      // Subgraph not deployed / not yet indexed — keep polling.
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `[x402-e2e/resource-server] timed out after ${SUBGRAPH_READY_TIMEOUT_MS / 1000}s waiting for subgraph ${args.subgraphUrl} to be ready`,
+      );
+    }
+    await sleep(SUBGRAPH_READY_POLL_INTERVAL_MS);
   }
 }
 
@@ -260,6 +354,19 @@ async function main(): Promise<void> {
   const protocolConfig = await waitForProtocolConfigInitialized({
     publicClient,
     escrowAddress: env.escrowAddress,
+  });
+
+  // Gate on the subgraph being deployed and indexed to the chain head
+  // before the seller lookup in `ensureSellerEntity` — on a cold stack
+  // the graph-node container is up but the subgraph isn't serving yet,
+  // which would otherwise crash the first `getSellersByAddress`.
+  const sellerAddress = privateKeyToAccount(env.sellerPk).address;
+  await waitForSubgraphReady({
+    publicClient,
+    subgraphUrl: env.subgraphUrl,
+    escrowAddress: env.escrowAddress,
+    chainId: env.chainId,
+    sellerAddress,
   });
 
   const sellerId = await ensureSellerEntity({

--- a/typescript/packages/x402-e2e/src/bin/resource-server.ts
+++ b/typescript/packages/x402-e2e/src/bin/resource-server.ts
@@ -25,7 +25,7 @@
 // no-op lookup.
 
 import { privateKeyToAccount } from "viem/accounts";
-import type { Address, Hex, PublicClient } from "viem";
+import { getAddress, type Address, type Hex, type PublicClient } from "viem";
 
 import {
   createResourceServerApp,
@@ -37,6 +37,7 @@ import {
 import { buildPublicClient, buildWalletClient } from "../harness/clients.js";
 import { buildCreateSellerCallback } from "../harness/create-seller.js";
 import { createSubgraphExchangeReader } from "../harness/exchange-reader.js";
+import { ensureTokenBalance } from "../harness/fund.js";
 import { seedSuite } from "../harness/seed.js";
 
 // `docker compose up --wait` only blocks until each container reports
@@ -58,6 +59,12 @@ import { seedSuite } from "../harness/seed.js";
 // entrypoint can't `docker compose exec` against the protocol node.
 const ESCROW_DEPLOY_TIMEOUT_MS = 10 * 60_000;
 const ESCROW_DEPLOY_POLL_INTERVAL_MS = 2_000;
+
+// Target balance minted to each `BUYER_WALLETS` entry on boot. 100 USDC
+// at 6dp = 100× the default offer price (AMOUNT=1000000), so a browser
+// demo can pay ~100 times before re-funding — well above the "repeat
+// ≥20×" requirement.
+const BUYER_FUND_AMOUNT = 100_000_000n;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -163,6 +170,62 @@ async function ensureSellerEntity(args: {
   return state.seller.id;
 }
 
+/**
+ * Parse the optional `BUYER_WALLETS` env — a comma-separated list of
+ * wallet addresses to fund on boot — into checksummed addresses.
+ * Returns `[]` when unset/empty. Throws a clear, prefixed error on a
+ * malformed entry so a typo surfaces at boot rather than as an opaque
+ * mint revert.
+ */
+function parseBuyerWallets(raw: string | undefined): Address[] {
+  if (raw === undefined) return [];
+  return raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .map((entry) => {
+      try {
+        return getAddress(entry);
+      } catch {
+        throw new Error(
+          `[x402-e2e/resource-server] BUYER_WALLETS contains an invalid address: ${entry}`,
+        );
+      }
+    });
+}
+
+/**
+ * Mint each listed buyer wallet up to `BUYER_FUND_AMOUNT` of the
+ * payment asset so a human-driven browser wallet can pay the paywall.
+ * Signs the mints with `sellerPk` — the entrypoint's already-funded
+ * account; the mock token's `mint` is public, so any funded signer
+ * works. Sequential to avoid racing the signer's nonce. Idempotent —
+ * a wallet already at the target is skipped.
+ */
+async function fundBuyerWallets(args: {
+  wallets: Address[];
+  assetAddress: Address;
+  sellerPk: Hex;
+  rpcUrl: string;
+  publicClient: PublicClient;
+}): Promise<void> {
+  const walletClient = buildWalletClient(privateKeyToAccount(args.sellerPk), {
+    rpcUrl: args.rpcUrl,
+  });
+  for (const wallet of args.wallets) {
+    console.log(
+      `[x402-e2e/resource-server] funding buyer wallet ${wallet} with ${BUYER_FUND_AMOUNT} of ${args.assetAddress}…`,
+    );
+    await ensureTokenBalance({
+      walletClient,
+      publicClient: args.publicClient,
+      tokenAddress: args.assetAddress,
+      owner: wallet,
+      targetBalance: BUYER_FUND_AMOUNT,
+    });
+  }
+}
+
 async function main(): Promise<void> {
   // The example's `readEnv` flags `SELLER_ID` as required so library
   // operators always pin the on-chain seller id at boot. The harness
@@ -207,6 +270,19 @@ async function main(): Promise<void> {
     chainId: env.chainId,
     subgraphUrl: env.subgraphUrl,
   });
+
+  // Optionally pre-fund human-driven browser wallets so a developer can
+  // connect MetaMask and pay the paywall without a separate mint step.
+  const buyerWallets = parseBuyerWallets(process.env.BUYER_WALLETS);
+  if (buyerWallets.length > 0) {
+    await fundBuyerWallets({
+      wallets: buyerWallets,
+      assetAddress: env.assetAddress,
+      sellerPk: env.sellerPk,
+      rpcUrl: env.rpcNode,
+      publicClient,
+    });
+  }
 
   const exchangeReader = createSubgraphExchangeReader({
     subgraphUrl: env.subgraphUrl,

--- a/typescript/packages/x402-e2e/src/harness/fund.ts
+++ b/typescript/packages/x402-e2e/src/harness/fund.ts
@@ -1,0 +1,90 @@
+// Shared ERC-20 funding primitives for the local Boson stack.
+//
+// The local stack ships mock ERC-20s (`Foreign20`, `MockERC3009Token`,
+// `MockERC2612Token`) that all expose a public `mint(to, amount)`, so
+// any funded signer can top up an arbitrary wallet for tests/demos.
+// This module centralises the ABI + the idempotent top-up so both the
+// scenario buyer-setup (`test/scenarios/_buyer-setup.ts`) and the
+// dockerised resource-server entrypoint (`src/bin/resource-server.ts`)
+// reuse one recipe.
+
+import type { Address, PublicClient, WalletClient } from "viem";
+
+export const ERC20_TEST_ABI = [
+  {
+    type: "function",
+    name: "mint",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "owner", type: "address" }],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "allowance",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ type: "uint256" }],
+  },
+] as const;
+
+export interface EnsureTokenBalanceArgs {
+  /** Signing client used to mint. Any funded account works — `mint` is public. */
+  walletClient: WalletClient;
+  /** Read-side client used to check balance and await the mint receipt. */
+  publicClient: PublicClient;
+  /** Mock ERC-20 to mint. */
+  tokenAddress: Address;
+  /** Wallet whose balance should reach `targetBalance`. */
+  owner: Address;
+  /** Atomic-unit balance the owner should hold after this call. */
+  targetBalance: bigint;
+}
+
+/**
+ * Ensure `owner` holds at least `targetBalance` of `tokenAddress`,
+ * minting the deficit via the mock token's public `mint(to, amount)`.
+ * Idempotent — a no-op once the wallet already holds the target.
+ */
+export async function ensureTokenBalance(args: EnsureTokenBalanceArgs): Promise<void> {
+  const balance = (await args.publicClient.readContract({
+    address: args.tokenAddress,
+    abi: ERC20_TEST_ABI,
+    functionName: "balanceOf",
+    args: [args.owner],
+  })) as bigint;
+
+  if (balance >= args.targetBalance) return;
+
+  const mintHash = await args.walletClient.writeContract({
+    address: args.tokenAddress,
+    abi: ERC20_TEST_ABI,
+    functionName: "mint",
+    args: [args.owner, args.targetBalance - balance],
+    account: args.walletClient.account!,
+    chain: args.walletClient.chain!,
+  });
+  await args.publicClient.waitForTransactionReceipt({ hash: mintHash });
+}

--- a/typescript/packages/x402-e2e/src/stack/compose.yaml
+++ b/typescript/packages/x402-e2e/src/stack/compose.yaml
@@ -133,11 +133,15 @@ services:
       - "4001:4001"
     environment:
       # ACCOUNT_2 — distinct from facilitator (ACCOUNT_8) and gateway
-      # (ACCOUNT_9). The Boson seller entity behind SELLER_ID is created
-      # at suite seed time (PR5); SELLER_ID=1 is a placeholder until
-      # then — the /resource 402 path doesn't dereference it on chain.
+      # (ACCOUNT_9). The Boson seller entity behind this key is
+      # self-seeded by the entrypoint (`src/bin/resource-server.ts`):
+      # on boot it queries the subgraph for a seller registered to
+      # this assistant address and calls `createSeller` when absent,
+      # then injects the resolved id into the app. `SELLER_ID` is
+      # therefore intentionally omitted here — pinning it statically
+      # is impossible since the on-chain id is only known after the
+      # seed transaction lands.
       - SELLER_PK=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-      - SELLER_ID=1
       - DISPUTE_RESOLVER_ID=1
       - RESOURCE_SERVER_URL=http://host.docker.internal:4001
       - RPC_NODE=http://host.docker.internal:8545

--- a/typescript/packages/x402-e2e/src/stack/compose.yaml
+++ b/typescript/packages/x402-e2e/src/stack/compose.yaml
@@ -150,6 +150,12 @@ services:
       - FACILITATOR_URL=http://host.docker.internal:8889
       - ASSET_ADDRESS=0x809d550fca64d94Bd9F66E60752A544199cfAC3D
       - AMOUNT=1000000
+      # Optional: comma-separated wallet addresses to mint payment
+      # tokens (ASSET_ADDRESS) to on boot, so a browser wallet can pay
+      # the paywall without a separate mint step. Uncomment and set to
+      # your own wallet address(es) when running the browser demo.
+      # - BUYER_WALLETS=0xYourMetaMaskAddress
+      - BUYER_WALLETS=${BUYER_WALLETS}
       - SUBGRAPH_URL=http://host.docker.internal:8000/subgraphs/name/boson/corecomponents
       - PORT=4001
       # Paywall config consumed by `examples/resource-server`'s

--- a/typescript/packages/x402-e2e/src/stack/compose.yaml
+++ b/typescript/packages/x402-e2e/src/stack/compose.yaml
@@ -148,6 +148,14 @@ services:
       - AMOUNT=1000000
       - SUBGRAPH_URL=http://host.docker.internal:8000/subgraphs/name/boson/corecomponents
       - PORT=4001
+      # Paywall config consumed by `examples/resource-server`'s
+      # `Accept: text/html` branch — turns `GET /resource` into a
+      # working browser demo when a user opens the dockerised host
+      # in a browser. Only the local-testnet flag is set; logo and
+      # WalletConnect project id are intentionally left out (testnet
+      # offers injected + Coinbase Wallet by default).
+      - PAYWALL_APP_NAME=x402B e2e paywall
+      - PAYWALL_TESTNET=1
     depends_on:
       - boson-protocol-node
       - boson-subgraph

--- a/typescript/packages/x402-e2e/src/stack/compose.yaml
+++ b/typescript/packages/x402-e2e/src/stack/compose.yaml
@@ -144,7 +144,7 @@ services:
       - CHAIN_ID=31337
       - ESCROW_ADDRESS=0xa513E6E4b8f2a923D98304ec87F64353C4D5C853
       - FACILITATOR_URL=http://host.docker.internal:8889
-      - ASSET_ADDRESS=0x70e0bA845a1A0F2DA3359C97E0285013525FFC49
+      - ASSET_ADDRESS=0x809d550fca64d94Bd9F66E60752A544199cfAC3D
       - AMOUNT=1000000
       - SUBGRAPH_URL=http://host.docker.internal:8000/subgraphs/name/boson/corecomponents
       - PORT=4001

--- a/typescript/packages/x402-e2e/test/browser/_mock-wallet.ts
+++ b/typescript/packages/x402-e2e/test/browser/_mock-wallet.ts
@@ -1,0 +1,143 @@
+// Installs an EIP-1193 `window.ethereum` shim into a Playwright
+// BrowserContext. The shim is backed by a viem private key on the
+// Node side — signing requests cross the Playwright IPC bridge via
+// `context.exposeFunction`, so the buyer's private key never leaves
+// Node. wagmi's injected connector picks the shim up as
+// `window.ethereum` and the paywall's `signerFromWalletClient`
+// adapter wires through it transparently.
+
+import type { BrowserContext } from "playwright";
+import type { Hex, TypedDataDomain } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+/**
+ * Shape of the JSON payload wagmi feeds into `eth_signTypedData_v4`.
+ * Mirrors the EIP-712 typed-data document with the
+ * `EIP712Domain` entry included in `types` (viem strips it before
+ * signing).
+ */
+interface TypedDataPayload {
+  domain: TypedDataDomain;
+  types: Record<string, ReadonlyArray<{ name: string; type: string }>>;
+  primaryType: string;
+  message: Record<string, unknown>;
+}
+
+export type MockWalletMode = "normal" | "reject-sign" | "wrong-chain";
+
+const SIGN_BRIDGE = "__x402_e2e_signTypedData";
+
+export interface InstallMockWalletArgs {
+  /**
+   * Buyer's private key. Used in-Node by viem to produce the
+   * EIP-712 signature returned to the in-browser shim.
+   */
+  privateKey: Hex;
+  /** CAIP-2 chain id without the `eip155:` prefix — e.g. `31337`. */
+  chainId: number;
+  /**
+   * Behaviour mode:
+   *   - `"normal"` — sign requests as usual, report the configured `chainId`.
+   *   - `"reject-sign"` — `eth_signTypedData_v4` throws an EIP-1193
+   *     `code: 4001` user-rejected error.
+   *   - `"wrong-chain"` — `eth_chainId` returns mainnet (`0x1`) and
+   *     `wallet_switchEthereumChain` rejects with `code: 4001`.
+   */
+  mode: MockWalletMode;
+}
+
+export async function installMockWallet(
+  context: BrowserContext,
+  args: InstallMockWalletArgs,
+): Promise<void> {
+  const account = privateKeyToAccount(args.privateKey);
+
+  await context.exposeFunction(SIGN_BRIDGE, async (typedData: TypedDataPayload) => {
+    // viem's `signTypedData` adds the `EIP712Domain` entry itself —
+    // strip it from the wallet-supplied payload to avoid a duplicate.
+    const { EIP712Domain: _ignored, ...types } = typedData.types;
+    return account.signTypedData({
+      domain: typedData.domain,
+      types,
+      primaryType: typedData.primaryType,
+      message: typedData.message,
+    });
+  });
+
+  await context.addInitScript(
+    (initArgs) => {
+      const { address, chainIdHex, mode, bridgeName } = initArgs;
+      type RpcRequest = { method: string; params?: unknown[] };
+      const listeners = new Map<string, ((...payload: unknown[]) => void)[]>();
+
+      const userRejected = (message: string) => {
+        const err = new Error(message) as Error & { code: number };
+        err.code = 4001;
+        return err;
+      };
+
+      const request = async (req: RpcRequest): Promise<unknown> => {
+        switch (req.method) {
+          case "eth_chainId":
+            return chainIdHex;
+          case "net_version":
+            return parseInt(chainIdHex, 16).toString();
+          case "eth_accounts":
+          case "eth_requestAccounts":
+            return [address];
+          case "eth_signTypedData_v4": {
+            if (mode === "reject-sign") {
+              throw userRejected("User rejected typed-data signing.");
+            }
+            const params = req.params as [string, string];
+            const typedData = JSON.parse(params[1]) as unknown;
+            const bridge = (
+              window as unknown as Record<string, (...a: unknown[]) => Promise<unknown>>
+            )[bridgeName];
+            return await bridge(typedData);
+          }
+          case "wallet_switchEthereumChain": {
+            if (mode === "wrong-chain") {
+              throw userRejected("User rejected the network switch.");
+            }
+            return null;
+          }
+          case "wallet_addEthereumChain":
+            return null;
+          default:
+            throw new Error(`mock-wallet: unsupported RPC method ${req.method}`);
+        }
+      };
+
+      const provider = {
+        isMetaMask: true,
+        request,
+        on(event: string, handler: (...payload: unknown[]) => void) {
+          const list = listeners.get(event) ?? [];
+          list.push(handler);
+          listeners.set(event, list);
+        },
+        removeListener(event: string, handler: (...payload: unknown[]) => void) {
+          const list = listeners.get(event);
+          if (!list) return;
+          listeners.set(
+            event,
+            list.filter((h) => h !== handler),
+          );
+        },
+        removeAllListeners(event?: string) {
+          if (event) listeners.delete(event);
+          else listeners.clear();
+        },
+      };
+
+      (window as unknown as Record<string, unknown>).ethereum = provider;
+    },
+    {
+      address: account.address,
+      chainIdHex: `0x${args.chainId.toString(16)}`,
+      mode: args.mode,
+      bridgeName: SIGN_BRIDGE,
+    },
+  );
+}

--- a/typescript/packages/x402-e2e/test/browser/paywall.test.ts
+++ b/typescript/packages/x402-e2e/test/browser/paywall.test.ts
@@ -1,0 +1,240 @@
+// Browser-mode E2E scenarios driving @bosonprotocol/x402-client-browser
+// and @bosonprotocol/x402-paywall end-to-end through headless chromium.
+//
+// All three scenarios live in one file (one describe → one seed-wallet
+// slot → sequential `it` blocks within the file) so they share the
+// resource-server's `FALLBACK_KEY` session slot safely. The paywall
+// doesn't stamp `X-Session-Id` today; sequencing avoids the race that
+// concurrent browser flows would otherwise trigger.
+//
+// Tag: `@p0`. Runs on every PR alongside the node scenarios; the
+// `describe.skipIf` keeps it a no-op when `E2E_DOCKER` isn't set.
+
+import { ExchangeState } from "@bosonprotocol/x402-actions";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { chromium, type Browser } from "playwright";
+import { parseEther, type Hex } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+
+import { LOCAL_31337_0 } from "../../src/config/local-31337-0.js";
+import {
+  buildPublicClient,
+  buildWalletClient,
+  readXPaymentResponse,
+} from "../../src/harness/index.js";
+import { ensureBuyerCanPay } from "../scenarios/_buyer-setup.js";
+import { SEED_WALLETS } from "../scenarios/_seed-wallets.js";
+import { createScenarioContext, type ScenarioContext } from "../scenarios/_setup.js";
+
+import { installMockWallet } from "./_mock-wallet.js";
+
+const ENABLED = process.env.E2E_DOCKER === "1";
+const SLOT = "browser" as const;
+const EXPECTED_PRICE = "1000000";
+const EXPECTED_PRICE_BIGINT = BigInt(EXPECTED_PRICE);
+const NO_COMMIT_POLL_MS = 2_000;
+
+let browser: Browser;
+let scenarioCtx: ScenarioContext;
+let buyerPk: Hex;
+let buyerAddress: `0x${string}`;
+let resourceUrl: string;
+
+describe.skipIf(!ENABLED)("@p0 browser-paywall scenarios", () => {
+  beforeAll(async () => {
+    browser = await chromium.launch({ headless: true });
+
+    // Per-file buyer EOA — generated locally rather than via
+    // `createFundedBuyer` so we keep the private key (the existing
+    // harness helper drops it on the floor since node scenarios don't
+    // need it).
+    buyerPk = generatePrivateKey();
+    const buyerAccount = privateKeyToAccount(buyerPk);
+    buyerAddress = buyerAccount.address;
+
+    const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS[SLOT].account);
+    if (funder.account === undefined || funder.chain === undefined) {
+      throw new Error("[browser/paywall] funder WalletClient missing account/chain");
+    }
+    const fundHash = await funder.sendTransaction({
+      account: funder.account,
+      chain: funder.chain,
+      to: buyerAccount.address,
+      value: parseEther("0.5"),
+    });
+    await publicClient.waitForTransactionReceipt({ hash: fundHash });
+    await ensureBuyerCanPay({
+      walletClient: buildWalletClient(buyerAccount),
+      publicClient,
+      buyerAddress,
+      assetAddress: LOCAL_31337_0.contracts.testErc20,
+      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      amount: EXPECTED_PRICE_BIGINT * 10n,
+    });
+
+    scenarioCtx = await createScenarioContext({ slot: SLOT, buyerAccount });
+    resourceUrl = `${scenarioCtx.resourceServerUrl}/resource`;
+  }, 180_000);
+
+  afterAll(async () => {
+    if (scenarioCtx !== undefined) await scenarioCtx.teardown();
+    if (browser !== undefined) await browser.close();
+  });
+
+  it("BR1 — @p0 paywall HTML 402 → connect → sign → on-chain commit", async () => {
+    const context = await browser.newContext();
+    try {
+      await installMockWallet(context, {
+        privateKey: buyerPk,
+        chainId: LOCAL_31337_0.chainId,
+        mode: "normal",
+      });
+
+      const page = await context.newPage();
+
+      // `waitForResponse` captures the paywall's X-PAYMENT retry —
+      // distinct from the initial navigation by the presence of the
+      // `x-payment` request header. Registered BEFORE `goto` so we
+      // never miss the response if the paywall fires the retry
+      // before the test reaches the `await` below.
+      const paymentResponse = page.waitForResponse(
+        (response) => {
+          if (response.url() !== resourceUrl) return false;
+          const headers = response.request().headers();
+          return headers["x-payment"] !== undefined;
+        },
+        { timeout: 90_000 },
+      );
+
+      await page.goto(resourceUrl);
+      await page.getByTestId("paywall-root").waitFor({ state: "visible" });
+
+      // Mock advertises `isMetaMask: true`, so wagmi's injected
+      // connector picks it up as `id: "injected"`.
+      await page.getByTestId("paywall-connector-injected").click();
+      await page.getByTestId("paywall-wallet-connected").waitFor({ state: "visible" });
+
+      await page.getByTestId("paywall-pay").click();
+
+      const response = await paymentResponse;
+      expect(response.status()).toBe(200);
+
+      const decoded = readXPaymentResponse(await response.allHeaders());
+      expect(decoded).not.toBeNull();
+      expect(decoded!.exchangeId).toBeTruthy();
+
+      await scenarioCtx.asserter.expect(decoded!.exchangeId!, {
+        state: ExchangeState.COMMITTED,
+        seller: scenarioCtx.suite.sellerAddress,
+        exchangeToken: LOCAL_31337_0.contracts.testErc20,
+        price: EXPECTED_PRICE,
+      });
+    } finally {
+      await context.close();
+    }
+  }, 120_000);
+
+  it("BR2 — @p0 user rejects signature → paywall error, no on-chain commit", async () => {
+    const context = await browser.newContext();
+    try {
+      await installMockWallet(context, {
+        privateKey: buyerPk,
+        chainId: LOCAL_31337_0.chainId,
+        mode: "reject-sign",
+      });
+
+      const page = await context.newPage();
+      await page.goto(resourceUrl);
+      await page.getByTestId("paywall-root").waitFor({ state: "visible" });
+
+      await page.getByTestId("paywall-connector-injected").click();
+      await page.getByTestId("paywall-wallet-connected").waitFor({ state: "visible" });
+
+      await page.getByTestId("paywall-pay").click();
+
+      // Paywall surfaces the wallet's rejection in the error panel.
+      const errorLocator = page.getByTestId("paywall-error");
+      await errorLocator.waitFor({ state: "visible" });
+      const errorText = await errorLocator.textContent();
+      expect(errorText ?? "").toMatch(/reject/i);
+
+      // No exchange should have been committed — the protocol never
+      // received an X-PAYMENT to settle. Give the subgraph a couple
+      // of seconds in case an unrelated commit slipped in (it
+      // shouldn't), then confirm the buyer's balance is still
+      // un-spent.
+      await sleep(NO_COMMIT_POLL_MS);
+      const publicClient = buildPublicClient();
+      const balance = await publicClient.readContract({
+        address: LOCAL_31337_0.contracts.testErc20,
+        abi: ERC20_BALANCE_ABI,
+        functionName: "balanceOf",
+        args: [buyerAddress],
+      });
+      // Initial mint covered 10× the price; if a commit had landed
+      // the balance would be down by EXPECTED_PRICE_BIGINT. Any reduction
+      // would be a regression.
+      expect(balance).toBeGreaterThanOrEqual(EXPECTED_PRICE_BIGINT * 10n);
+    } finally {
+      await context.close();
+    }
+  }, 120_000);
+
+  it("BR3 — @p0 wrong network → paywall surfaces switch-chain warning, no commit", async () => {
+    const context = await browser.newContext();
+    try {
+      await installMockWallet(context, {
+        privateKey: buyerPk,
+        chainId: 1, // mainnet — deliberately wrong
+        mode: "wrong-chain",
+      });
+
+      const page = await context.newPage();
+      await page.goto(resourceUrl);
+      await page.getByTestId("paywall-root").waitFor({ state: "visible" });
+
+      await page.getByTestId("paywall-connector-injected").click();
+
+      // Wagmi surfaces the connected (wrong) chain id; the paywall
+      // renders the `paywall-wrong-network` warning.
+      await page
+        .getByTestId("paywall-wrong-network")
+        .waitFor({ state: "visible", timeout: 30_000 });
+
+      // Clicking Pay triggers `switchChain`, which the mock rejects;
+      // the paywall transitions to the error state.
+      await page.getByTestId("paywall-pay").click();
+      const errorLocator = page.getByTestId("paywall-error");
+      await errorLocator.waitFor({ state: "visible" });
+      const errorText = await errorLocator.textContent();
+      expect(errorText ?? "").toMatch(/chain|switch|network/i);
+
+      await sleep(NO_COMMIT_POLL_MS);
+      const publicClient = buildPublicClient();
+      const balance = await publicClient.readContract({
+        address: LOCAL_31337_0.contracts.testErc20,
+        abi: ERC20_BALANCE_ABI,
+        functionName: "balanceOf",
+        args: [buyerAddress],
+      });
+      expect(balance).toBeGreaterThanOrEqual(EXPECTED_PRICE_BIGINT * 10n);
+    } finally {
+      await context.close();
+    }
+  }, 120_000);
+});
+
+const ERC20_BALANCE_ABI = [
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "owner", type: "address" }],
+    outputs: [{ type: "uint256" }],
+  },
+] as const;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
@@ -21,46 +21,7 @@ import {
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 import { buildWalletClient } from "../../src/harness/clients.js";
-
-const ERC20_TEST_ABI = [
-  {
-    type: "function",
-    name: "mint",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "to", type: "address" },
-      { name: "amount", type: "uint256" },
-    ],
-    outputs: [],
-  },
-  {
-    type: "function",
-    name: "balanceOf",
-    stateMutability: "view",
-    inputs: [{ name: "owner", type: "address" }],
-    outputs: [{ type: "uint256" }],
-  },
-  {
-    type: "function",
-    name: "approve",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "spender", type: "address" },
-      { name: "amount", type: "uint256" },
-    ],
-    outputs: [{ type: "bool" }],
-  },
-  {
-    type: "function",
-    name: "allowance",
-    stateMutability: "view",
-    inputs: [
-      { name: "owner", type: "address" },
-      { name: "spender", type: "address" },
-    ],
-    outputs: [{ type: "uint256" }],
-  },
-] as const;
+import { ERC20_TEST_ABI, ensureTokenBalance } from "../../src/harness/fund.js";
 
 export interface BuyerSetupArgs {
   /** Buyer's viem `WalletClient` (must hold native ETH for gas). */
@@ -83,24 +44,13 @@ export interface BuyerSetupArgs {
  * necessary so re-runs of the same scenario don't burn gas pointlessly.
  */
 export async function ensureBuyerCanPay(args: BuyerSetupArgs): Promise<void> {
-  const balance = (await args.publicClient.readContract({
-    address: args.assetAddress,
-    abi: ERC20_TEST_ABI,
-    functionName: "balanceOf",
-    args: [args.buyerAddress],
-  })) as bigint;
-
-  if (balance < args.amount) {
-    const mintHash = await args.walletClient.writeContract({
-      address: args.assetAddress,
-      abi: ERC20_TEST_ABI,
-      functionName: "mint",
-      args: [args.buyerAddress, args.amount - balance],
-      account: args.walletClient.account!,
-      chain: args.walletClient.chain!,
-    });
-    await args.publicClient.waitForTransactionReceipt({ hash: mintHash });
-  }
+  await ensureTokenBalance({
+    walletClient: args.walletClient,
+    publicClient: args.publicClient,
+    tokenAddress: args.assetAddress,
+    owner: args.buyerAddress,
+    targetBalance: args.amount,
+  });
 
   const allowance = (await args.publicClient.readContract({
     address: args.assetAddress,

--- a/typescript/packages/x402-e2e/test/scenarios/_seed-wallets.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_seed-wallets.ts
@@ -35,6 +35,7 @@ import {
   ACCOUNT_11,
   ACCOUNT_12,
   ACCOUNT_13,
+  ACCOUNT_14,
 } from "../../src/config/accounts.js";
 
 export interface SeedWalletSlot {
@@ -66,6 +67,8 @@ export const SEED_WALLETS = {
   concurrent: toSlot(ACCOUNT_13),
   /** `operational.test.ts` — F1 / F2 / F4 failure-mode scenarios. */
   operational: toSlot(ACCOUNT_10),
+  /** `browser/paywall.test.ts` — drives the in-browser paywall through Playwright. */
+  browser: toSlot(ACCOUNT_14),
   /** Spare slots for future chain-touching scenario files. */
   spareB: toSlot(ACCOUNT_11),
   spareC: toSlot(ACCOUNT_12),

--- a/typescript/packages/x402-e2e/test/setup/globalSetup.ts
+++ b/typescript/packages/x402-e2e/test/setup/globalSetup.ts
@@ -131,7 +131,11 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   }
 
   console.log("[x402-e2e/globalSetup] starting stack…");
-  await startStack({ waitForReady: true });
+  // `build: true` so workspace changes that affect the x402B service
+  // images (e.g. new transitive deps pulled in by the resource server)
+  // are picked up automatically. Warm cache adds ~5–10s; cold builds
+  // are dominated by the underlying docker pull, not the rebuild.
+  await startStack({ waitForReady: true, build: true });
 
   try {
     console.log("[x402-e2e/globalSetup] switching Hardhat to 50 ms interval mining…");


### PR DESCRIPTION
## Summary

Adds the first end-to-end browser scenarios for `@bosonprotocol/x402-client-browser` and `@bosonprotocol/x402-paywall`. Three `@p0` scenarios driving headless chromium (via the `playwright` library) through the full paywall flow:

- **BR1** — paywall HTML 402 → mock-wallet signs `eth_signTypedData_v4` → X-PAYMENT retry → `200` → on-chain `ExchangeState.COMMITTED` asserted via the subgraph reader.
- **BR2** — mock wallet rejects `eth_signTypedData_v4` (EIP-1193 `code: 4001`) → paywall surfaces the error in `[data-testid=\"paywall-error\"]`, buyer's ERC-20 balance untouched.
- **BR3** — mock wallet reports the wrong chain id and rejects `wallet_switchEthereumChain` → paywall shows the wrong-network warning, `Pay` surfaces the rejection, no commit.

All three live in one file (one seed-wallet slot, sequential within the file) so they share the resource server's `FALLBACK_KEY` session slot safely — the paywall doesn't yet stamp `X-Session-Id`.

Architectural choice worth flagging at review time: this PR drives `playwright` directly from regular vitest tests (rather than via `@vitest/browser`). Simpler, no separate config, no commands API, no cross-origin navigation quirks. The browser test uses the same **in-process resource server** pattern the existing scenarios use; chromium hits it on `127.0.0.1:<random>`.

## Supporting changes

- **`examples/resource-server`** gets a new `Accept: text/html` branch on `GET /resource` that calls `evmEscrowPaywall.generateHtml(...)`. `currentUrl` is built from the inbound request so it matches the browser's view of the origin regardless of how `RESOURCE_SERVER_URL` is configured. Non-browser callers (no Accept or `*/*`) keep getting the existing JSON 402 — no regression. Four `PAYWALL_*` env knobs added (`APP_NAME`, `APP_LOGO`, `WALLETCONNECT_PROJECT_ID`, `TESTNET`).
- **`@bosonprotocol/x402-paywall`** gets `data-testid` attributes on the root, connector list, Pay button, error paragraph, and the connected / wrong-network state paragraphs. Pure-additive; no behaviour change.
- **`x402-e2e`** gets a new `browser` slot (`ACCOUNT_14`) in `SEED_WALLETS`, `startStack` now passes `build: true` so the new paywall dep propagates through the dockerised resource-server image, and the compose service gets `PAYWALL_APP_NAME=\"x402B e2e paywall\"` + `PAYWALL_TESTNET=1` so the live demo at `http://localhost:4001/resource` returns a fully-configured paywall.

## Test plan

- [ ] `pnpm install`
- [ ] `pnpm exec playwright install chromium` (one-off ~150MB download — pnpm 10 blocks the postinstall script by default)
- [ ] `pnpm build && pnpm lint && pnpm format:check` (all green locally)
- [ ] `pnpm test` (browser file skips without `E2E_DOCKER=1` — 20 passed, 23 skipped, 26 todo locally)
- [ ] `E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e stack:up` + `curl -H \"Accept: text/html\" http://localhost:4001/resource -i` — expect a 402 with `Content-Type: text/html` and `<script>window.x402b = {...}</script>` in the body
- [ ] `curl -H \"Accept: application/json\" http://localhost:4001/resource -i` — still a 402 with `Content-Type: application/json` (existing behaviour intact)
- [ ] Open `http://localhost:4001/resource` in a real browser to eyeball the rendered paywall
- [ ] `E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test:browser` — three browser scenarios pass
- [ ] `E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test:p0` — node + browser `@p0` set passes end-to-end

## Notes for review

- Base of this PR is `add-x402-client-browser` (#77) — branch will auto-rebase onto `main` when #77 merges.
- First run of the e2e suite after this lands will rebuild `x402b-resource-server` (~30–60s) because the example picked up the new paywall workspace dep; subsequent runs use the BuildKit cache.
- CI needs to cache `PLAYWRIGHT_BROWSERS_PATH` (or set `PLAYWRIGHT_SKIP_DOWNLOAD=1` per-job) to avoid re-downloading chromium on every job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)