### PR TITLE
test(x402-e2e): add Permit + Permit2 commit scenarios and run @p0+@p1 on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,20 @@ jobs:
 
       - run: pnpm format:check
 
-  # Runs the @p0 subset of the x402-e2e scenario suite against the real
-  # Docker stack. Always-on per PR. Cold image pulls + stack boot take
-  # 2–5 minutes; the @p0 subset itself completes in ~1–2 minutes. The
-  # full breadth (including @p1 / @p2 operational scenarios) runs in
-  # the nightly workflow.
-  e2e-p0:
-    name: e2e (@p0)
+  # Runs the @p0 + @p1 subset of the x402-e2e scenario suite against the
+  # real Docker stack. Always-on per PR. Cold image pulls + stack boot
+  # take 2–5 minutes. The `operational.test.ts` file is excluded: its F1
+  # chaos scenario kills the facilitator container mid-flight and would
+  # race the chain-touching tests in other files when run in parallel.
+  # Keeping it out lets this job stay parallel (fast); the operational
+  # tier — F1 (@p1), plus F2 / F4 (@p2) — is exercised nightly with
+  # `E2E_SEQUENTIAL=1`. The @p2 tier is also kept out here via the tag
+  # filter.
+  e2e-pr:
+    name: e2e (@p0 + @p1)
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
-    timeout-minutes: 25
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -78,16 +82,16 @@ jobs:
 
       - run: pnpm build
 
-      - name: Run @p0 e2e suite
+      - name: Run @p0 + @p1 e2e suite
         env:
           E2E_DOCKER: "1"
-        # Uses the `test:p0` script (rather than `test -- -t '@p0'`) because
-        # pnpm v10 forwards the `--` separator literally and vitest then
-        # parses `-t @p0` as positional file patterns instead of the
-        # `--testNamePattern` flag, which would re-enable the @p1/@p2
-        # operational chaos tests (they kill the facilitator container
-        # mid-flow and race the chain-touching tests in other files).
-        run: pnpm --filter @bosonprotocol/x402-e2e test:p0
+        # Uses the `test:pr` script (rather than `test -- -t '@p0|@p1'`)
+        # because pnpm v10 forwards the `--` separator literally and vitest
+        # then parses the flags as positional file patterns instead of the
+        # `--testNamePattern` / `--exclude` options. The script pins the
+        # `@p0|@p1` tag filter and excludes `operational.test.ts` so the
+        # job stays parallel-safe (no chaos tests).
+        run: pnpm --filter @bosonprotocol/x402-e2e test:pr
 
       - name: Dump docker compose logs on failure
         if: failure()
@@ -99,6 +103,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: e2e-p0-logs-${{ github.run_id }}
+          name: e2e-pr-logs-${{ github.run_id }}
           path: typescript/packages/x402-e2e/docker-compose.log
           if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: ['**']
+    branches: ["**"]
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: ['**']
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]

--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -152,15 +152,20 @@ Tests are tagged in the `describe(...)` title so vitest can filter
 with `-t '@p0'`. Priorities:
 
 - **`@p0`** — happy-path commit + post-commit lifecycle. Runs on
-  every PR in CI (see `.github/workflows/ci.yml`'s `e2e-p0` job).
-- **`@p1`** — secondary lifecycle paths + operational scenarios
-  with a tight blast radius. Runs nightly.
+  every PR in CI (see `.github/workflows/ci.yml`'s `e2e-pr` job).
+- **`@p1`** — secondary lifecycle paths (token-auth strategies,
+  retract / cancel). Runs on every PR alongside `@p0` in the `e2e-pr`
+  job. The one exception is the F1 operational chaos scenario, which
+  is excluded from the per-PR job (it kills a shared container, so it
+  can't run in parallel) and is exercised nightly instead.
 - **`@p2`** — niche failure modes (subgraph lag, buyer key
   rotation) and lower-impact transitions. Runs nightly.
 
 | Tag(s)   | Describe                                      | File                          |
 |----------|-----------------------------------------------|-------------------------------|
 | `@p0`    | commit-time scenarios (A1, A2)                | `commit.test.ts`              |
+| `@p0`    | commit-time scenarios — ERC-3009 (A3)         | `commit.test.ts`              |
+| `@p1`    | commit-time scenarios — Permit / Permit2 (A4, A5) | `commit.test.ts`          |
 | `@p0`    | concurrent commit-and-redeem (E0)             | `concurrent.test.ts`          |
 | `@p0`    | post-commit lifecycle (B1–B4)                 | `post-commit.test.ts`         |
 | `@p0`    | commit-time validations (C1–C5, C8)           | `validation-commit.test.ts`   |
@@ -173,10 +178,14 @@ with `-t '@p0'`. Priorities:
 ### Running a tag subset
 
 ```sh
-# Matches the per-PR CI job — @p0 only. Routed through the dedicated
-# `test:p0` script because pnpm v10 forwards `--` literally and vitest
-# would parse `-t @p0` as a positional file pattern (re-running the
-# full @p1 / @p2 breadth instead of filtering).
+# Matches the per-PR CI job — @p0 + @p1, with `operational.test.ts`
+# excluded so it stays parallel-safe (the F1 chaos test kills a shared
+# container). Routed through the dedicated `test:pr` script because
+# pnpm v10 forwards `--` literally and vitest would parse the flags as
+# positional file patterns instead of `--testNamePattern` / `--exclude`.
+E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test:pr
+
+# Just the @p0 subset.
 E2E_DOCKER=1 pnpm --filter @bosonprotocol/x402-e2e test:p0
 
 # Matches the nightly workflow — full breadth.
@@ -195,9 +204,12 @@ E2E_DOCKER=1 E2E_DOCKER_KEEP_STACK=1 \
 - **`.github/workflows/ci.yml`** runs on every PR + push to `main`:
   - `build-test-lint` — Node 22 / 24 matrix; `pnpm build`,
     `pnpm test`, `pnpm lint`, `pnpm format:check`.
-  - `e2e-p0` — boots the stack and runs the `@p0` scenario subset
-    via `vitest -t '@p0'`. 25-min timeout (cold image pull adds 2–5
-    min). Uploads `docker compose logs` on failure.
+  - `e2e-pr` — boots the stack and runs the `@p0 + @p1` scenario
+    subset via `test:pr` (`vitest -t '@p0|@p1' --exclude
+    '**/operational.test.ts'`). The operational file is excluded so
+    the job stays parallel; its F1 chaos scenario runs nightly
+    instead. 30-min timeout (cold image pull adds 2–5 min). Uploads
+    `docker compose logs` on failure.
 - **`.github/workflows/nightly.yml`** runs daily at 03:00 UTC and on
   manual `workflow_dispatch`:
   - `e2e-full` — same stack boot, no tag filter — runs every

--- a/typescript/packages/x402-e2e/package.json
+++ b/typescript/packages/x402-e2e/package.json
@@ -9,6 +9,7 @@
     "build": "tsc --noEmit",
     "test": "vitest run",
     "test:p0": "vitest run -t @p0",
+    "test:pr": "vitest run -t '@p0|@p1' --exclude '**/operational.test.ts'",
     "lint": "eslint src test scripts --max-warnings 0",
     "stack:up": "tsx scripts/stack-up.ts",
     "stack:down": "tsx scripts/stack-down.ts",

--- a/typescript/packages/x402-e2e/src/harness/craft-payment.ts
+++ b/typescript/packages/x402-e2e/src/harness/craft-payment.ts
@@ -1,0 +1,188 @@
+// Negative-path payload crafting for the commit-time validation suite
+// (section C of the e2e plan).
+//
+// The happy-path `BuyerActor.fetch` auto-signs and retries, hiding the
+// `X-PAYMENT` payload. These helpers expose it so a scenario can tamper a
+// single field on an otherwise-valid payload and assert the resulting
+// rejection:
+//
+//   1. `fetchEscrowChallenge` — GET /resource → the 402's escrow
+//      `accepts[]` entry (the `EscrowPaymentRequirements`).
+//   2. `client.handle402(...)` → the canonical base64 `X-PAYMENT` value.
+//   3. decode → mutate → re-encode.
+//   4. `submitPaymentHeader` — re-issue /resource with the crafted header.
+//
+// Both requests carry the SAME `X-X402-Boson-Session-Id` so the resource
+// server's offer cache hands back the same signed offer for the retry —
+// the validator deep-equals `payload.offerRef.fullOffer` against
+// `requirements.offer.fullOffer`, so a fresh offer between the two
+// requests would trip rule 3 instead of the rule under test. This mirrors
+// `wrapFetchWithPayment`.
+
+import type { X402bClient } from "@bosonprotocol/x402-client";
+import { SESSION_ID_HEADER } from "@bosonprotocol/x402-client-fetch";
+import type { EscrowPaymentPayload } from "@bosonprotocol/x402-core/schemes/escrow";
+
+const X_PAYMENT_HEADER = "X-PAYMENT";
+const RESOURCE_PATH = "/resource";
+
+function newSessionId(): string {
+  // Matches the resource server's session-id pattern (`[A-Za-z0-9_-]+`);
+  // UUIDs only contain hex + hyphens, so they pass.
+  return globalThis.crypto.randomUUID();
+}
+
+/** Wire shape of both the structured rejection body and the 200 success body. */
+export interface SubmissionBody {
+  /** Stable error code (rejections) — e.g. `CALLDATA_MISMATCH`, `FACILITATOR_REJECTED`. */
+  code?: string;
+  reason?: string;
+  details?: {
+    rule?: number;
+    field?: string;
+    expected?: unknown;
+    got?: unknown;
+    /** Inner facilitator code surfaced under a `FACILITATOR_REJECTED` envelope. */
+    facilitatorCode?: string;
+  };
+  /** Success-body fields (HTTP 200 from /resource). */
+  ok?: boolean;
+  x402b?: { exchangeId?: string; txHash?: string };
+}
+
+export interface CraftedSubmission {
+  status: number;
+  body: SubmissionBody | null;
+}
+
+/** Decode a base64 `X-PAYMENT` header value into the structured payload. */
+export function decodePaymentHeader(headerValue: string): EscrowPaymentPayload {
+  return JSON.parse(Buffer.from(headerValue, "base64").toString("utf8")) as EscrowPaymentPayload;
+}
+
+/** Re-encode a (possibly mutated) payload back into the base64 header value. */
+export function encodePaymentHeader(payload: EscrowPaymentPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
+}
+
+/**
+ * GET the 402 challenge under `sessionId` and return the escrow
+ * `accepts[]` entry (the `EscrowPaymentRequirements`). Throws if the
+ * response isn't a 402 or carries no escrow entry.
+ */
+export async function fetchEscrowChallenge(
+  resourceServerUrl: string,
+  sessionId: string,
+): Promise<Record<string, unknown>> {
+  const res = await globalThis.fetch(`${resourceServerUrl}${RESOURCE_PATH}`, {
+    headers: { [SESSION_ID_HEADER]: sessionId },
+  });
+  if (res.status !== 402) {
+    throw new Error(
+      `[x402-e2e/craft] expected a 402 challenge, got HTTP ${res.status}: ${await res.text()}`,
+    );
+  }
+  const body = (await res.json()) as { accepts?: unknown };
+  const accepts = Array.isArray(body.accepts) ? body.accepts : [];
+  const escrowEntry = accepts.find(
+    (entry) =>
+      typeof entry === "object" &&
+      entry !== null &&
+      (entry as { scheme?: unknown }).scheme === "escrow",
+  );
+  if (escrowEntry === undefined) {
+    throw new Error(
+      `[x402-e2e/craft] 402 challenge carried no escrow accepts[] entry: ${JSON.stringify(body)}`,
+    );
+  }
+  return escrowEntry as Record<string, unknown>;
+}
+
+/** Re-issue GET /resource with a crafted `X-PAYMENT` header under `sessionId`. */
+export async function submitPaymentHeader(
+  resourceServerUrl: string,
+  sessionId: string,
+  headerValue: string,
+): Promise<CraftedSubmission> {
+  const res = await globalThis.fetch(`${resourceServerUrl}${RESOURCE_PATH}`, {
+    headers: { [SESSION_ID_HEADER]: sessionId, [X_PAYMENT_HEADER]: headerValue },
+  });
+  const body = (await res.json().catch(() => null)) as SubmissionBody | null;
+  return { status: res.status, body };
+}
+
+export interface SubmitMutatedCommitArgs {
+  resourceServerUrl: string;
+  /** Typically `ctx.buyer.client`. */
+  client: X402bClient;
+  /** In-place mutation of the decoded, otherwise-valid payload. */
+  mutate: (payload: EscrowPaymentPayload) => void;
+}
+
+/**
+ * Build a valid payload from a fresh 402 challenge, apply `mutate`, and
+ * submit it. Returns the (expected-rejection) response.
+ */
+export async function submitMutatedCommit(
+  args: SubmitMutatedCommitArgs,
+): Promise<CraftedSubmission> {
+  const sessionId = newSessionId();
+  const escrowEntry = await fetchEscrowChallenge(args.resourceServerUrl, sessionId);
+  const headerValue = await args.client.handle402(escrowEntry);
+  const payload = decodePaymentHeader(headerValue);
+  args.mutate(payload);
+  return submitPaymentHeader(args.resourceServerUrl, sessionId, encodePaymentHeader(payload));
+}
+
+/**
+ * Build one valid `X-PAYMENT` header and return it together with the
+ * session id, so a caller can submit the SAME signed payload more than
+ * once (used by the nonce-replay scenario C3 — the meta-tx nonce is
+ * fixed at sign time, so re-submitting the identical header is what
+ * trips the on-chain "nonce already used" guard).
+ */
+export async function buildValidCommitHeader(
+  resourceServerUrl: string,
+  client: X402bClient,
+): Promise<{ sessionId: string; headerValue: string }> {
+  const sessionId = newSessionId();
+  const escrowEntry = await fetchEscrowChallenge(resourceServerUrl, sessionId);
+  const headerValue = await client.handle402(escrowEntry);
+  return { sessionId, headerValue };
+}
+
+export interface VerifyViaFacilitatorArgs {
+  /** Facilitator service URL (e.g. `http://127.0.0.1:8889`). */
+  facilitatorUrl: string;
+  /** CAIP-2 network id (e.g. `"eip155:31337"`). */
+  network: string;
+  payload: EscrowPaymentPayload;
+  /** Requirements to send — typically a valid set with one field tampered. */
+  requirements: unknown;
+}
+
+/**
+ * POST a `{ payload, requirements }` pair straight to the facilitator's
+ * `/verify` endpoint. Used by C8: the resource server always forwards its
+ * own (allowlisted) `escrowAddress`, so the facilitator's allowlist guard
+ * can only be exercised by submitting requirements with a non-allowlisted
+ * escrow directly. `/verify` returns HTTP 200 on `{ ok: true }`, HTTP 400
+ * on `{ ok: false, code, reason }`.
+ */
+export async function verifyViaFacilitator(
+  args: VerifyViaFacilitatorArgs,
+): Promise<CraftedSubmission> {
+  const url = new URL("/verify", args.facilitatorUrl).toString();
+  const res = await globalThis.fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      scheme: "escrow",
+      network: args.network,
+      payload: args.payload,
+      requirements: args.requirements,
+    }),
+  });
+  const body = (await res.json().catch(() => null)) as SubmissionBody | null;
+  return { status: res.status, body };
+}

--- a/typescript/packages/x402-e2e/src/harness/index.ts
+++ b/typescript/packages/x402-e2e/src/harness/index.ts
@@ -48,3 +48,17 @@ export {
   type FacilitatorOnlyActionId,
   type FacilitatorPerformResult,
 } from "./facilitator-perform-action.js";
+
+export {
+  buildValidCommitHeader,
+  decodePaymentHeader,
+  encodePaymentHeader,
+  fetchEscrowChallenge,
+  submitMutatedCommit,
+  submitPaymentHeader,
+  verifyViaFacilitator,
+  type CraftedSubmission,
+  type SubmissionBody,
+  type SubmitMutatedCommitArgs,
+  type VerifyViaFacilitatorArgs,
+} from "./craft-payment.js";

--- a/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
@@ -3,9 +3,12 @@
 // Two flavours, picked by the scenario based on its `tokenAuthStrategy`:
 //
 //   - `ensureBuyerHasBalance` — mint payment tokens to the buyer if
-//     the balance falls short. ERC-3009, Permit, and Permit2 carry
-//     their own authorisation in the X-PAYMENT payload, so no
-//     allowance is needed; balance alone gates the settle.
+//     the balance falls short. ERC-3009 and Permit (EIP-2612) carry a
+//     full transfer authorisation in the X-PAYMENT payload, so no
+//     ERC-20 allowance is needed; balance alone gates the settle.
+//     (Permit2 is different — its payload authorises the transfer but
+//     the canonical Permit2 contract still needs a standing ERC-20
+//     allowance, so `permit2` routes through `ensureBuyerCanPay` below.)
 //   - `ensureBuyerCanPay` — calls `ensureBuyerHasBalance`, then ensures
 //     a spender has a generous ERC-20 allowance. Required for the
 //     `none` strategy (settle calls `transferFrom` against the escrow

--- a/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_buyer-setup.ts
@@ -7,9 +7,11 @@
 //     their own authorisation in the X-PAYMENT payload, so no
 //     allowance is needed; balance alone gates the settle.
 //   - `ensureBuyerCanPay` — calls `ensureBuyerHasBalance`, then ensures
-//     the escrow has a generous ERC-20 allowance. Required only for
-//     the `none` strategy, where settle just calls `transferFrom` and
-//     reverts on insufficient allowance.
+//     a spender has a generous ERC-20 allowance. Required for the
+//     `none` strategy (settle calls `transferFrom` against the escrow
+//     and reverts on insufficient allowance) and for `permit2` (the
+//     canonical Permit2 contract must hold a standing allowance to pull
+//     from the buyer).
 //
 // The local Boson stack's test ERC-20 mocks (`Foreign20`,
 // `MockERC3009Token`, `MockERC2612Token`) all expose a public
@@ -80,8 +82,12 @@ export interface EnsureBuyerHasBalanceArgs {
 }
 
 export interface BuyerSetupArgs extends EnsureBuyerHasBalanceArgs {
-  /** Escrow address — the `spender` the buyer approves for the `none` strategy. */
-  escrowAddress: Address;
+  /**
+   * The `spender` the buyer grants an ERC-20 allowance to. The escrow
+   * for the `none` strategy; the canonical Permit2 contract for the
+   * `permit2` strategy.
+   */
+  spenderAddress: Address;
 }
 
 /**
@@ -127,10 +133,12 @@ export async function ensureBuyerHasBalance(args: EnsureBuyerHasBalanceArgs): Pr
 
 /**
  * Ensure the buyer has at least `amount` balance + allowance against
- * the escrow. Used by the `none` token-auth strategy, where settle
- * calls `transferFrom` and reverts on insufficient allowance. Both
- * the mint and the approve are no-ops when re-run with sufficient
- * balance / allowance.
+ * `spenderAddress`. Used by the `none` token-auth strategy (spender =
+ * escrow, where settle calls `transferFrom` and reverts on insufficient
+ * allowance) and by `permit2` (spender = the canonical Permit2 contract,
+ * which needs a standing allowance to pull from the buyer). Both the
+ * mint and the approve are no-ops when re-run with sufficient balance /
+ * allowance.
  */
 export async function ensureBuyerCanPay(args: BuyerSetupArgs): Promise<void> {
   await ensureBuyerHasBalance(args);
@@ -148,7 +156,7 @@ export async function ensureBuyerCanPay(args: BuyerSetupArgs): Promise<void> {
     address: args.assetAddress,
     abi: ERC20_TEST_ABI,
     functionName: "allowance",
-    args: [args.buyerAddress, args.escrowAddress],
+    args: [args.buyerAddress, args.spenderAddress],
   })) as bigint;
 
   if (allowance < args.amount) {
@@ -158,7 +166,7 @@ export async function ensureBuyerCanPay(args: BuyerSetupArgs): Promise<void> {
       functionName: "approve",
       // Approve a generous cap so subsequent scenarios on the same
       // chain state don't need to re-approve; refunds untouched.
-      args: [args.escrowAddress, args.amount * 1000n],
+      args: [args.spenderAddress, args.amount * 1000n],
       account: walletAccount,
       chain: walletChain,
     });
@@ -190,8 +198,8 @@ export interface CreateFundedBuyerArgs {
 export interface RotateBuyerArgs extends CreateFundedBuyerArgs {
   /** Payment-asset address (typically `LOCAL_31337_0.contracts.testErc20`). */
   assetAddress: Address;
-  /** Escrow address — the `spender` the rotated buyer approves. */
-  escrowAddress: Address;
+  /** The `spender` the rotated buyer grants an ERC-20 allowance to. */
+  spenderAddress: Address;
   /** Amount the rotated buyer must be able to pay (atomic units). */
   amount: bigint;
 }
@@ -199,7 +207,7 @@ export interface RotateBuyerArgs extends CreateFundedBuyerArgs {
 /**
  * Generate a fresh buyer EOA, fund it with native ETH from `funder`,
  * and ensure it has at least `amount` of the payment asset both
- * minted and approved against `escrowAddress`. Used by F4 (buyer
+ * minted and approved against `spenderAddress`. Used by F4 (buyer
  * key rotation) where the test needs a SECOND buyer key — fully
  * funded and approved — to attempt a redeem against an exchange
  * committed by the FIRST buyer key.
@@ -215,7 +223,7 @@ export async function rotateBuyer(args: RotateBuyerArgs): Promise<LocalAccount> 
     publicClient: args.publicClient,
     buyerAddress: account.address,
     assetAddress: args.assetAddress,
-    escrowAddress: args.escrowAddress,
+    spenderAddress: args.spenderAddress,
     amount: args.amount,
   });
   return account;

--- a/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
@@ -63,7 +63,7 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
       publicClient,
       buyerAddress: buyerAccount.address,
       assetAddress: LOCAL_31337_0.contracts.testErc20,
-      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      spenderAddress: LOCAL_31337_0.contracts.protocolDiamond,
       amount: 10_000_000n,
     });
   });
@@ -316,7 +316,7 @@ describe.skipIf(!ENABLED)("@p1 commit-time scenarios (Permit2)", () => {
       publicClient,
       buyerAddress: buyerAccount.address,
       assetAddress: LOCAL_31337_0.contracts.testErc20,
-      escrowAddress: LOCAL_31337_0.contracts.permit2,
+      spenderAddress: LOCAL_31337_0.contracts.permit2,
       amount: 10_000_000n,
     });
   });

--- a/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/commit.test.ts
@@ -10,9 +10,10 @@
 // fetches the resource, the middleware emits a 402, the buyer's
 // `wrapFetchWithPayment` signs and retries with X-PAYMENT, settle
 // commits on-chain, and the response carries `X-PAYMENT-RESPONSE`
-// with the new `exchangeId`. A2–A5 cover the other commit-time
-// dimensions (atomic / token-auth strategies); they're `it.todo`
-// in this PR and land in PR 7.
+// with the new `exchangeId`. A2 covers atomic commit-and-redeem;
+// A3/A4/A5 cover the token-auth strategies (ERC-3009 / EIP-2612
+// Permit / Permit2), each in its own describe that pins the
+// advertised strategy so the client dispatcher can't fall back.
 
 import { ExchangeState } from "@bosonprotocol/x402-actions";
 import type { LocalAccount } from "viem";
@@ -142,12 +143,6 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios", () => {
       price: EXPECTED_PRICE,
     });
   });
-
-  // Token-auth strategies. Each describe below pins
-  // `tokenAuthStrategies` to a single value so the client dispatcher
-  // can't fall back to a different strategy.
-  it.todo("A4 — commit with `permit` token-auth (testErc2612)");
-  it.todo("A5 — commit with `permit2` token-auth");
 });
 
 describe.skipIf(!ENABLED)("@p0 commit-time scenarios (ERC-3009)", () => {
@@ -216,6 +211,140 @@ describe.skipIf(!ENABLED)("@p0 commit-time scenarios (ERC-3009)", () => {
       state: ExchangeState.COMMITTED,
       seller: ctx.seller.address,
       exchangeToken: LOCAL_31337_0.contracts.testErc3009,
+      price: EXPECTED_PRICE,
+    });
+  });
+});
+
+describe.skipIf(!ENABLED)("@p1 commit-time scenarios (Permit / EIP-2612)", () => {
+  let ctx: ScenarioContext;
+
+  beforeAll(async () => {
+    // Distinct buyer + describe-scoped context so the resource server
+    // advertises ONLY `permit` and the BuyerActor signs an EIP-2612
+    // Permit against the testErc2612 token's domain. Shares the file's
+    // `commit` seed slot with the describes above — vitest serialises
+    // describes within a file, so the slot's seller handles them
+    // back-to-back.
+    const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS.commit.account);
+    const buyerAccount = await createFundedBuyer({ funder, publicClient });
+    ctx = await createScenarioContext({
+      slot: "commit",
+      buyerAccount,
+      assetAddress: LOCAL_31337_0.contracts.testErc2612,
+      tokenAuthStrategies: ["permit"],
+      tokenDomainResolver: createChainTokenDomainResolver(publicClient),
+      // EIP-2612 `deadline` is enforced against `block.timestamp`. The
+      // local stack mines at ~20× wall-clock, so a 1-hour window can
+      // already be in the past by the time settle simulates. Stretch to
+      // the protocol max — see A3 for the full chain-drift rationale.
+      maxTimeoutSeconds: 24 * 60 * 60,
+    });
+    // EIP-2612 Permit carries the spend approval inline (settle calls
+    // `permit()` then `transferFrom`), so the buyer needs a balance but
+    // no standing escrow allowance.
+    await ensureBuyerHasBalance({
+      walletClient: buildWalletClient(buyerAccount),
+      publicClient,
+      buyerAddress: buyerAccount.address,
+      assetAddress: LOCAL_31337_0.contracts.testErc2612,
+      amount: 10_000_000n,
+    });
+  });
+
+  afterAll(async () => {
+    await ctx?.teardown();
+  });
+
+  it("A4 — commit with `permit` token-auth (testErc2612)", async () => {
+    const res = await ctx.buyer.fetch(`${ctx.resourceServerUrl}/resource`);
+    expect(res.status, await res.clone().text()).toBe(200);
+
+    const body = (await res.json()) as {
+      ok?: boolean;
+      x402b?: { exchangeId?: string; txHash?: `0x${string}` };
+    };
+    expect(body.ok).toBe(true);
+    expect(typeof body.x402b?.exchangeId).toBe("string");
+
+    const decoded = readXPaymentResponse(res.headers);
+    expect(decoded?.exchangeId).toBe(body.x402b?.exchangeId);
+    expect(decoded?.txHash).toMatch(TX_HASH_REGEX);
+
+    const exchangeId = body.x402b!.exchangeId!;
+    await ctx.asserter.expect(exchangeId, {
+      state: ExchangeState.COMMITTED,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc2612,
+      price: EXPECTED_PRICE,
+    });
+  });
+});
+
+describe.skipIf(!ENABLED)("@p1 commit-time scenarios (Permit2)", () => {
+  let ctx: ScenarioContext;
+
+  beforeAll(async () => {
+    // Permit2 works with any standard ERC-20 (no token-side EIP-2612 /
+    // EIP-3009 support needed), so this describe pays with the generic
+    // `testErc20`. The client signs a Permit2 `PermitTransferFrom`
+    // against the canonical Permit2 domain — no `tokenDomainResolver`
+    // required. Shares the file's `commit` seed slot with the describes
+    // above; vitest serialises describes within a file.
+    const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS.commit.account);
+    const buyerAccount = await createFundedBuyer({ funder, publicClient });
+    ctx = await createScenarioContext({
+      slot: "commit",
+      buyerAccount,
+      assetAddress: LOCAL_31337_0.contracts.testErc20,
+      tokenAuthStrategies: ["permit2"],
+      // Permit2's SignatureTransfer `deadline` is enforced against
+      // `block.timestamp`; stretch the window to the protocol max for
+      // the same chain-time-drift reason as A3 / A4.
+      maxTimeoutSeconds: 24 * 60 * 60,
+    });
+    // Permit2 pulls funds through the canonical Permit2 contract, which
+    // the buyer must have approved once on the ERC-20. Reuse
+    // `ensureBuyerCanPay` but with the Permit2 contract as the approved
+    // spender (not the escrow) — the signed SignatureTransfer names the
+    // escrow as recipient at settle time, while Permit2 itself needs the
+    // standing allowance to pull from the buyer.
+    await ensureBuyerCanPay({
+      walletClient: buildWalletClient(buyerAccount),
+      publicClient,
+      buyerAddress: buyerAccount.address,
+      assetAddress: LOCAL_31337_0.contracts.testErc20,
+      escrowAddress: LOCAL_31337_0.contracts.permit2,
+      amount: 10_000_000n,
+    });
+  });
+
+  afterAll(async () => {
+    await ctx?.teardown();
+  });
+
+  it("A5 — commit with `permit2` token-auth (testErc20)", async () => {
+    const res = await ctx.buyer.fetch(`${ctx.resourceServerUrl}/resource`);
+    expect(res.status, await res.clone().text()).toBe(200);
+
+    const body = (await res.json()) as {
+      ok?: boolean;
+      x402b?: { exchangeId?: string; txHash?: `0x${string}` };
+    };
+    expect(body.ok).toBe(true);
+    expect(typeof body.x402b?.exchangeId).toBe("string");
+
+    const decoded = readXPaymentResponse(res.headers);
+    expect(decoded?.exchangeId).toBe(body.x402b?.exchangeId);
+    expect(decoded?.txHash).toMatch(TX_HASH_REGEX);
+
+    const exchangeId = body.x402b!.exchangeId!;
+    await ctx.asserter.expect(exchangeId, {
+      state: ExchangeState.COMMITTED,
+      seller: ctx.seller.address,
+      exchangeToken: LOCAL_31337_0.contracts.testErc20,
       price: EXPECTED_PRICE,
     });
   });

--- a/typescript/packages/x402-e2e/test/scenarios/concurrent.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/concurrent.test.ts
@@ -69,7 +69,7 @@ describe.skipIf(!ENABLED)("@p0 concurrent commit-and-redeem scenarios", () => {
           publicClient,
           buyerAddress: account.address,
           assetAddress: LOCAL_31337_0.contracts.testErc20,
-          escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+          spenderAddress: LOCAL_31337_0.contracts.protocolDiamond,
           amount: PER_COMMIT_AMOUNT,
         }),
       ),

--- a/typescript/packages/x402-e2e/test/scenarios/operational.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/operational.test.ts
@@ -112,7 +112,7 @@ describe.skipIf(!ENABLED)("@p1 operational scenarios", () => {
       publicClient,
       buyerAddress: buyerAccount.address,
       assetAddress: LOCAL_31337_0.contracts.testErc20,
-      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      spenderAddress: LOCAL_31337_0.contracts.protocolDiamond,
       amount: 10_000_000n,
     });
   });
@@ -216,7 +216,7 @@ describe.skipIf(!ENABLED)("@p2 operational scenarios", () => {
       publicClient,
       buyerAddress: buyerAccount.address,
       assetAddress: LOCAL_31337_0.contracts.testErc20,
-      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      spenderAddress: LOCAL_31337_0.contracts.protocolDiamond,
       amount: 10_000_000n,
     });
   });
@@ -317,7 +317,7 @@ describe.skipIf(!ENABLED)("@p2 operational scenarios", () => {
       funder: buildWalletClient(SEED_WALLETS.operational.account),
       publicClient,
       assetAddress: LOCAL_31337_0.contracts.testErc20,
-      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      spenderAddress: LOCAL_31337_0.contracts.protocolDiamond,
       amount: 10_000_000n,
       fundEth: "0.5",
     });

--- a/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/post-commit.test.ts
@@ -97,7 +97,7 @@ describe.skipIf(!ENABLED)("@p0 post-commit lifecycle scenarios", () => {
       publicClient,
       buyerAddress: buyerAccount.address,
       assetAddress: LOCAL_31337_0.contracts.testErc20,
-      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      spenderAddress: LOCAL_31337_0.contracts.protocolDiamond,
       amount: 10_000_000n,
     });
   });
@@ -261,7 +261,7 @@ describe.skipIf(!ENABLED)("@p1 post-commit lifecycle scenarios", () => {
       publicClient,
       buyerAddress: buyerAccount.address,
       assetAddress: LOCAL_31337_0.contracts.testErc20,
-      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      spenderAddress: LOCAL_31337_0.contracts.protocolDiamond,
       amount: 10_000_000n,
     });
   });

--- a/typescript/packages/x402-e2e/test/scenarios/validation-commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/validation-commit.test.ts
@@ -69,7 +69,7 @@ describe.skipIf(!ENABLED)("@p0 commit-time validations (none strategy)", () => {
       publicClient,
       buyerAddress: buyerAccount.address,
       assetAddress: LOCAL_31337_0.contracts.testErc20,
-      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      spenderAddress: LOCAL_31337_0.contracts.protocolDiamond,
       amount: 10_000_000n,
     });
   });

--- a/typescript/packages/x402-e2e/test/scenarios/validation-commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/validation-commit.test.ts
@@ -1,25 +1,242 @@
 // Commit-time validation negatives — section C of the e2e plan.
 //
-// Each scenario builds a valid `X-PAYMENT` payload then mutates a
-// single field to trip a specific server- or facilitator-side check.
-// Asserts both the HTTP status and the wire-level `code` so a future
-// rename of the error code surfaces here as a regression.
+// Each scenario builds a valid `X-PAYMENT` payload via the buyer's
+// client, then tampers a single field to trip a specific server- or
+// facilitator-side check. Asserts both the HTTP status and the
+// wire-level `code` so a future rename of an error code surfaces here
+// as a regression.
 //
-// PR 6 ships the file with `it.todo` markers so the suite enumerates
-// the planned coverage; PR 7 lands the implementations alongside the
-// post-commit lifecycle tests.
+// Where the codes diverge from the original plan text, production wins
+// (the deployed validator / facilitator are ground truth):
+//   - C1 → `CALLDATA_MISMATCH` (rule 7), not "OFFER_MISMATCH".
+//   - C8 → `INVALID_PAYLOAD` from the facilitator allowlist guard, not
+//     "ESCROW_NOT_ALLOWED" (there is no such code in the facilitator's
+//     `FacilitatorErrorCode` union).
+//
+// Two submission paths:
+//   - C1–C5 go through the resource server's `/resource` paywall (the
+//     same path the happy-path A* tests use), so they exercise the
+//     server-side validator and, for C3/C4, the facilitator via
+//     `/settle`.
+//   - C8 POSTs straight to the facilitator's `/verify`: the resource
+//     server always forwards its own (allowlisted) `escrowAddress`, so
+//     the allowlist guard can only be reached by submitting requirements
+//     with a non-allowlisted escrow directly.
 
-import { describe, it } from "vitest";
+import type { LocalAccount } from "viem";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { LOCAL_31337_0 } from "../../src/config/local-31337-0.js";
+import {
+  buildPublicClient,
+  buildWalletClient,
+  buildValidCommitHeader,
+  createChainTokenDomainResolver,
+  fetchEscrowChallenge,
+  submitMutatedCommit,
+  submitPaymentHeader,
+  verifyViaFacilitator,
+  decodePaymentHeader,
+} from "../../src/harness/index.js";
+
+import { createFundedBuyer, ensureBuyerCanPay, ensureBuyerHasBalance } from "./_buyer-setup.js";
 import { ENABLED } from "./_flags.js";
+import { SEED_WALLETS } from "./_seed-wallets.js";
+import { createScenarioContext, NONE_TOKEN_AUTH_SCENARIO, type ScenarioContext } from "./_setup.js";
 
-describe.skipIf(!ENABLED)("@p0 commit-time validations", () => {
-  it.todo("C1 — tampered `functionSignature` → 400 OFFER_MISMATCH");
-  it.todo("C2 — wrong meta-tx signature → BAD_META_TX_SIGNATURE, no on-chain submit");
-  it.todo("C3 — nonce replay → second submit fails (nonce consumed on chain)");
-  it.todo("C4 — expired offer (`validBefore < now`) → SIMULATION_REVERT or pre-flight reject");
-  it.todo(
-    "C5 — `maxTimeoutSeconds` exceeded (`validBefore > now + maxTimeoutSeconds`) → server reject pre-facilitator",
-  );
-  it.todo("C8 — wrong `escrowAddress` (not on facilitator allowlist) → ESCROW_NOT_ALLOWED");
+/** Structurally valid but never-allowlisted escrow address for C8. */
+const NON_ALLOWLISTED_ESCROW = "0x1111111111111111111111111111111111111111";
+
+describe.skipIf(!ENABLED)("@p0 commit-time validations (none strategy)", () => {
+  let ctx: ScenarioContext;
+  let buyerAccount: LocalAccount;
+
+  beforeAll(async () => {
+    const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS.validationCommit.account);
+    buyerAccount = await createFundedBuyer({ funder, publicClient });
+    ctx = await createScenarioContext({
+      slot: "validationCommit",
+      buyerAccount,
+      ...NONE_TOKEN_AUTH_SCENARIO,
+    });
+    // C3's first submit settles a real commit on-chain, so the `none`
+    // buyer needs balance + a standing escrow allowance. C1 / C2 reject
+    // at the server before settle, so the funding is a harmless no-op
+    // for them.
+    await ensureBuyerCanPay({
+      walletClient: buildWalletClient(buyerAccount),
+      publicClient,
+      buyerAddress: buyerAccount.address,
+      assetAddress: LOCAL_31337_0.contracts.testErc20,
+      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      amount: 10_000_000n,
+    });
+  });
+
+  afterAll(async () => {
+    await ctx?.teardown();
+  });
+
+  it("C1 — tampered `functionSignature` → 400 CALLDATA_MISMATCH", async () => {
+    const result = await submitMutatedCommit({
+      resourceServerUrl: ctx.resourceServerUrl,
+      client: ctx.buyer.client,
+      mutate: (payload) => {
+        // Flip the final nibble — keeps the value schema-valid hex but
+        // breaks the rule-7 byte comparison against the calldata
+        // reconstructed from `offerRef`.
+        const fs = payload.payload.metaTx.functionSignature;
+        const last = fs.slice(-1);
+        payload.payload.metaTx.functionSignature = (fs.slice(0, -1) +
+          (last === "0" ? "1" : "0")) as `0x${string}`;
+      },
+    });
+
+    expect(result.status, JSON.stringify(result.body)).toBe(400);
+    expect(result.body?.code).toBe("CALLDATA_MISMATCH");
+    expect(result.body?.details?.rule).toBe(7);
+  });
+
+  it("C2 — wrong meta-tx signature (mutated nonce) → 400 BAD_META_TX_SIGNATURE", async () => {
+    const result = await submitMutatedCommit({
+      resourceServerUrl: ctx.resourceServerUrl,
+      client: ctx.buyer.client,
+      mutate: (payload) => {
+        // The meta-tx signature was produced over the original nonce.
+        // Bumping the nonce leaves `from === buyer` (rule-8's first
+        // check passes) but makes the ECDSA recovery resolve to a
+        // different address → BAD_META_TX_SIGNATURE. The server rejects
+        // pre-facilitator, so no on-chain submit happens.
+        payload.payload.metaTx.nonce = (BigInt(payload.payload.metaTx.nonce) + 1n).toString();
+      },
+    });
+
+    expect(result.status, JSON.stringify(result.body)).toBe(400);
+    expect(result.body?.code).toBe("BAD_META_TX_SIGNATURE");
+    expect(result.body?.details?.rule).toBe(8);
+  });
+
+  it("C3 — nonce replay → second submit rejected by facilitator (nonce consumed)", async () => {
+    // Build ONE signed header and submit it twice under the same
+    // session: the meta-tx nonce is fixed at sign time, so the second
+    // submit re-presents an already-consumed nonce. The server
+    // validator is stateless and passes both times; the facilitator
+    // catches the replay (duplicate-nonce revert) on the second.
+    const { sessionId, headerValue } = await buildValidCommitHeader(
+      ctx.resourceServerUrl,
+      ctx.buyer.client,
+    );
+
+    const first = await submitPaymentHeader(ctx.resourceServerUrl, sessionId, headerValue);
+    expect(first.status, JSON.stringify(first.body)).toBe(200);
+    expect(first.body?.ok).toBe(true);
+
+    const second = await submitPaymentHeader(ctx.resourceServerUrl, sessionId, headerValue);
+    expect(second.status, JSON.stringify(second.body)).toBe(502);
+    expect(second.body?.code).toBe("FACILITATOR_REJECTED");
+    // The exact inner code depends on whether the facilitator catches
+    // the consumed nonce at simulation or at on-chain submit; assert it
+    // surfaced a facilitator code rather than pinning one revert flavour.
+    expect(typeof second.body?.details?.facilitatorCode).toBe("string");
+  });
+
+  it("C8 — wrong `escrowAddress` (not on facilitator allowlist) → 400 INVALID_PAYLOAD", async () => {
+    // Build a valid payload + read back the challenge requirements, then
+    // POST to the facilitator's `/verify` with the escrow swapped for a
+    // non-allowlisted address. The allowlist guard (verify step 7) fires
+    // before signature recovery / simulation.
+    const sessionId = globalThis.crypto.randomUUID();
+    const requirements = await fetchEscrowChallenge(ctx.resourceServerUrl, sessionId);
+    const headerValue = await ctx.buyer.client.handle402(requirements);
+    const payload = decodePaymentHeader(headerValue);
+
+    const result = await verifyViaFacilitator({
+      facilitatorUrl: ctx.facilitatorUrl,
+      network: ctx.network,
+      payload,
+      requirements: { ...requirements, escrowAddress: NON_ALLOWLISTED_ESCROW },
+    });
+
+    expect(result.status, JSON.stringify(result.body)).toBe(400);
+    expect(result.body?.code).toBe("INVALID_PAYLOAD");
+  });
+});
+
+describe.skipIf(!ENABLED)("@p0 commit-time validations (erc3009 deadline)", () => {
+  let ctx: ScenarioContext;
+
+  beforeAll(async () => {
+    // Mirrors A3's ERC-3009 setup: the payload carries an `erc3009`
+    // token-auth whose `validBefore` the deadline scenarios tamper. See
+    // A3 for the 24h `maxTimeoutSeconds` chain-drift rationale.
+    const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS.validationCommit.account);
+    const buyerAccount = await createFundedBuyer({ funder, publicClient });
+    ctx = await createScenarioContext({
+      slot: "validationCommit",
+      buyerAccount,
+      assetAddress: LOCAL_31337_0.contracts.testErc3009,
+      tokenAuthStrategies: ["erc3009"],
+      tokenDomainResolver: createChainTokenDomainResolver(publicClient),
+      maxTimeoutSeconds: 24 * 60 * 60,
+    });
+    await ensureBuyerHasBalance({
+      walletClient: buildWalletClient(buyerAccount),
+      publicClient,
+      buyerAddress: buyerAccount.address,
+      assetAddress: LOCAL_31337_0.contracts.testErc3009,
+      amount: 10_000_000n,
+    });
+  });
+
+  afterAll(async () => {
+    await ctx?.teardown();
+  });
+
+  it("C4 — expired authorization (`validBefore` in the past) → 502 facilitator reject", async () => {
+    // A past `validBefore` is below the server's `now + maxTimeoutSeconds`
+    // horizon, so rule 9 passes and the payload reaches the facilitator.
+    // Tampering the signed field breaks the ERC-3009 signature recovery
+    // (and would also revert on-chain), so the facilitator rejects with
+    // a 502 `FACILITATOR_REJECTED` envelope rather than the server 400.
+    const result = await submitMutatedCommit({
+      resourceServerUrl: ctx.resourceServerUrl,
+      client: ctx.buyer.client,
+      mutate: (payload) => {
+        const tokenAuth = payload.payload.tokenAuth;
+        if (tokenAuth?.kind !== "erc3009") {
+          throw new Error(`expected erc3009 tokenAuth, got ${tokenAuth?.kind ?? "none"}`);
+        }
+        // 1 second after the epoch — unambiguously expired.
+        tokenAuth.data.validBefore = 1;
+      },
+    });
+
+    expect(result.status, JSON.stringify(result.body)).toBe(502);
+    expect(result.body?.code).toBe("FACILITATOR_REJECTED");
+    expect(typeof result.body?.details?.facilitatorCode).toBe("string");
+  });
+
+  it("C5 — `maxTimeoutSeconds` exceeded → 400 TOKEN_AUTH_DEADLINE_EXCEEDED", async () => {
+    // A `validBefore` far beyond `now + maxTimeoutSeconds` trips the
+    // server's rule-9 horizon check, which reads the declared value
+    // directly — so it rejects pre-facilitator, before any signature or
+    // simulation step.
+    const farFuture = Math.floor(Date.now() / 1000) + 100 * 365 * 24 * 60 * 60;
+    const result = await submitMutatedCommit({
+      resourceServerUrl: ctx.resourceServerUrl,
+      client: ctx.buyer.client,
+      mutate: (payload) => {
+        const tokenAuth = payload.payload.tokenAuth;
+        if (tokenAuth?.kind !== "erc3009") {
+          throw new Error(`expected erc3009 tokenAuth, got ${tokenAuth?.kind ?? "none"}`);
+        }
+        tokenAuth.data.validBefore = farFuture;
+      },
+    });
+
+    expect(result.status, JSON.stringify(result.body)).toBe(400);
+    expect(result.body?.code).toBe("TOKEN_AUTH_DEADLINE_EXCEEDED");
+  });
 });


### PR DESCRIPTION
## Summary

- Implement the **A4 (`permit` / EIP-2612)** and **A5 (`permit2`)** commit-time
  e2e scenarios in `commit.test.ts`, each in its own `@p1` describe that pins
  the advertised token-auth strategy so the client dispatcher can't fall back.
  - A4 pays with `testErc2612`, wires a chain token-domain resolver, and needs
    only a buyer balance (the EIP-2612 permit carries the spend approval inline).
  - A5 pays with the generic `testErc20`, needs no domain resolver, and approves
    the canonical Permit2 contract once so Permit2 can pull at settle.
  - Both stretch `maxTimeoutSeconds` to the protocol max for the same
    `block.timestamp` chain-drift reason as A3.
  - No harness changes needed — the client already implements `signPermit` /
    `signPermit2`.
- Widen the per-PR e2e CI job from `@p0`-only to **`@p0 + @p1`** via a dedicated
  `test:pr` script (`vitest -t '@p0|@p1' --exclude '**/operational.test.ts'`), so
  the new scenarios run on every PR. `operational.test.ts` is excluded to keep
  the job parallel (its F1 chaos test kills a shared container); F1 still runs
  nightly.

> Note: the e2e status check is now reported as `e2e (@p0 + @p1)` (renamed from
> `e2e (@p0)`) — update branch-protection required checks accordingly.

## Test plan

- [x] `pnpm --filter @bosonprotocol/x402-e2e lint`
- [x] `tsc --noEmit` + offline `vitest run` (scenarios skip cleanly without `E2E_DOCKER=1`)
- [x] `test:pr` collects the right files (excludes `operational.test.ts`)
- [x] `pnpm format:check`
- [ ] `e2e-pr` job green against the live Docker stack (first real run is this PR's CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage with added token-auth scenarios (EIP-2612 and Permit2) and updated concurrent/post-commit flows.
  * Per-PR E2E now runs a broader `@p0` + `@p1` subset.

* **Documentation**
  * Updated README guidance for running per-PR and commit-time E2E subsets and CI behavior.

* **Chores**
  * CI E2E job and artifacts adjusted; PR runs use an updated test flow and longer timeout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->