### PR TITLE
test(x402-e2e): commit-time validation negatives (C1–C5, C8)

### DIFF
--- a/typescript/packages/x402-e2e/src/harness/craft-payment.ts
+++ b/typescript/packages/x402-e2e/src/harness/craft-payment.ts
@@ -1,0 +1,188 @@
+// Negative-path payload crafting for the commit-time validation suite
+// (section C of the e2e plan).
+//
+// The happy-path `BuyerActor.fetch` auto-signs and retries, hiding the
+// `X-PAYMENT` payload. These helpers expose it so a scenario can tamper a
+// single field on an otherwise-valid payload and assert the resulting
+// rejection:
+//
+//   1. `fetchEscrowChallenge` — GET /resource → the 402's escrow
+//      `accepts[]` entry (the `EscrowPaymentRequirements`).
+//   2. `client.handle402(...)` → the canonical base64 `X-PAYMENT` value.
+//   3. decode → mutate → re-encode.
+//   4. `submitPaymentHeader` — re-issue /resource with the crafted header.
+//
+// Both requests carry the SAME `X-X402-Boson-Session-Id` so the resource
+// server's offer cache hands back the same signed offer for the retry —
+// the validator deep-equals `payload.offerRef.fullOffer` against
+// `requirements.offer.fullOffer`, so a fresh offer between the two
+// requests would trip rule 3 instead of the rule under test. This mirrors
+// `wrapFetchWithPayment`.
+
+import type { X402bClient } from "@bosonprotocol/x402-client";
+import { SESSION_ID_HEADER } from "@bosonprotocol/x402-client-fetch";
+import type { EscrowPaymentPayload } from "@bosonprotocol/x402-core/schemes/escrow";
+
+const X_PAYMENT_HEADER = "X-PAYMENT";
+const RESOURCE_PATH = "/resource";
+
+function newSessionId(): string {
+  // Matches the resource server's session-id pattern (`[A-Za-z0-9_-]+`);
+  // UUIDs only contain hex + hyphens, so they pass.
+  return globalThis.crypto.randomUUID();
+}
+
+/** Wire shape of both the structured rejection body and the 200 success body. */
+export interface SubmissionBody {
+  /** Stable error code (rejections) — e.g. `CALLDATA_MISMATCH`, `FACILITATOR_REJECTED`. */
+  code?: string;
+  reason?: string;
+  details?: {
+    rule?: number;
+    field?: string;
+    expected?: unknown;
+    got?: unknown;
+    /** Inner facilitator code surfaced under a `FACILITATOR_REJECTED` envelope. */
+    facilitatorCode?: string;
+  };
+  /** Success-body fields (HTTP 200 from /resource). */
+  ok?: boolean;
+  x402b?: { exchangeId?: string; txHash?: string };
+}
+
+export interface CraftedSubmission {
+  status: number;
+  body: SubmissionBody | null;
+}
+
+/** Decode a base64 `X-PAYMENT` header value into the structured payload. */
+export function decodePaymentHeader(headerValue: string): EscrowPaymentPayload {
+  return JSON.parse(Buffer.from(headerValue, "base64").toString("utf8")) as EscrowPaymentPayload;
+}
+
+/** Re-encode a (possibly mutated) payload back into the base64 header value. */
+export function encodePaymentHeader(payload: EscrowPaymentPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
+}
+
+/**
+ * GET the 402 challenge under `sessionId` and return the escrow
+ * `accepts[]` entry (the `EscrowPaymentRequirements`). Throws if the
+ * response isn't a 402 or carries no escrow entry.
+ */
+export async function fetchEscrowChallenge(
+  resourceServerUrl: string,
+  sessionId: string,
+): Promise<Record<string, unknown>> {
+  const res = await globalThis.fetch(`${resourceServerUrl}${RESOURCE_PATH}`, {
+    headers: { [SESSION_ID_HEADER]: sessionId },
+  });
+  if (res.status !== 402) {
+    throw new Error(
+      `[x402-e2e/craft] expected a 402 challenge, got HTTP ${res.status}: ${await res.text()}`,
+    );
+  }
+  const body = (await res.json()) as { accepts?: unknown };
+  const accepts = Array.isArray(body.accepts) ? body.accepts : [];
+  const escrowEntry = accepts.find(
+    (entry) =>
+      typeof entry === "object" &&
+      entry !== null &&
+      (entry as { scheme?: unknown }).scheme === "escrow",
+  );
+  if (escrowEntry === undefined) {
+    throw new Error(
+      `[x402-e2e/craft] 402 challenge carried no escrow accepts[] entry: ${JSON.stringify(body)}`,
+    );
+  }
+  return escrowEntry as Record<string, unknown>;
+}
+
+/** Re-issue GET /resource with a crafted `X-PAYMENT` header under `sessionId`. */
+export async function submitPaymentHeader(
+  resourceServerUrl: string,
+  sessionId: string,
+  headerValue: string,
+): Promise<CraftedSubmission> {
+  const res = await globalThis.fetch(`${resourceServerUrl}${RESOURCE_PATH}`, {
+    headers: { [SESSION_ID_HEADER]: sessionId, [X_PAYMENT_HEADER]: headerValue },
+  });
+  const body = (await res.json().catch(() => null)) as SubmissionBody | null;
+  return { status: res.status, body };
+}
+
+export interface SubmitMutatedCommitArgs {
+  resourceServerUrl: string;
+  /** Typically `ctx.buyer.client`. */
+  client: X402bClient;
+  /** In-place mutation of the decoded, otherwise-valid payload. */
+  mutate: (payload: EscrowPaymentPayload) => void;
+}
+
+/**
+ * Build a valid payload from a fresh 402 challenge, apply `mutate`, and
+ * submit it. Returns the (expected-rejection) response.
+ */
+export async function submitMutatedCommit(
+  args: SubmitMutatedCommitArgs,
+): Promise<CraftedSubmission> {
+  const sessionId = newSessionId();
+  const escrowEntry = await fetchEscrowChallenge(args.resourceServerUrl, sessionId);
+  const headerValue = await args.client.handle402(escrowEntry);
+  const payload = decodePaymentHeader(headerValue);
+  args.mutate(payload);
+  return submitPaymentHeader(args.resourceServerUrl, sessionId, encodePaymentHeader(payload));
+}
+
+/**
+ * Build one valid `X-PAYMENT` header and return it together with the
+ * session id, so a caller can submit the SAME signed payload more than
+ * once (used by the nonce-replay scenario C3 — the meta-tx nonce is
+ * fixed at sign time, so re-submitting the identical header is what
+ * trips the on-chain "nonce already used" guard).
+ */
+export async function buildValidCommitHeader(
+  resourceServerUrl: string,
+  client: X402bClient,
+): Promise<{ sessionId: string; headerValue: string }> {
+  const sessionId = newSessionId();
+  const escrowEntry = await fetchEscrowChallenge(resourceServerUrl, sessionId);
+  const headerValue = await client.handle402(escrowEntry);
+  return { sessionId, headerValue };
+}
+
+export interface VerifyViaFacilitatorArgs {
+  /** Facilitator service URL (e.g. `http://127.0.0.1:8889`). */
+  facilitatorUrl: string;
+  /** CAIP-2 network id (e.g. `"eip155:31337"`). */
+  network: string;
+  payload: EscrowPaymentPayload;
+  /** Requirements to send — typically a valid set with one field tampered. */
+  requirements: unknown;
+}
+
+/**
+ * POST a `{ payload, requirements }` pair straight to the facilitator's
+ * `/verify` endpoint. Used by C8: the resource server always forwards its
+ * own (allowlisted) `escrowAddress`, so the facilitator's allowlist guard
+ * can only be exercised by submitting requirements with a non-allowlisted
+ * escrow directly. `/verify` returns HTTP 200 on `{ ok: true }`, HTTP 400
+ * on `{ ok: false, code, reason }`.
+ */
+export async function verifyViaFacilitator(
+  args: VerifyViaFacilitatorArgs,
+): Promise<CraftedSubmission> {
+  const url = new URL("/verify", args.facilitatorUrl).toString();
+  const res = await globalThis.fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      scheme: "escrow",
+      network: args.network,
+      payload: args.payload,
+      requirements: args.requirements,
+    }),
+  });
+  const body = (await res.json().catch(() => null)) as SubmissionBody | null;
+  return { status: res.status, body };
+}

--- a/typescript/packages/x402-e2e/src/harness/index.ts
+++ b/typescript/packages/x402-e2e/src/harness/index.ts
@@ -48,3 +48,17 @@ export {
   type FacilitatorOnlyActionId,
   type FacilitatorPerformResult,
 } from "./facilitator-perform-action.js";
+
+export {
+  buildValidCommitHeader,
+  decodePaymentHeader,
+  encodePaymentHeader,
+  fetchEscrowChallenge,
+  submitMutatedCommit,
+  submitPaymentHeader,
+  verifyViaFacilitator,
+  type CraftedSubmission,
+  type SubmissionBody,
+  type SubmitMutatedCommitArgs,
+  type VerifyViaFacilitatorArgs,
+} from "./craft-payment.js";

--- a/typescript/packages/x402-e2e/test/scenarios/validation-commit.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/validation-commit.test.ts
@@ -1,25 +1,242 @@
 // Commit-time validation negatives — section C of the e2e plan.
 //
-// Each scenario builds a valid `X-PAYMENT` payload then mutates a
-// single field to trip a specific server- or facilitator-side check.
-// Asserts both the HTTP status and the wire-level `code` so a future
-// rename of the error code surfaces here as a regression.
+// Each scenario builds a valid `X-PAYMENT` payload via the buyer's
+// client, then tampers a single field to trip a specific server- or
+// facilitator-side check. Asserts both the HTTP status and the
+// wire-level `code` so a future rename of an error code surfaces here
+// as a regression.
 //
-// PR 6 ships the file with `it.todo` markers so the suite enumerates
-// the planned coverage; PR 7 lands the implementations alongside the
-// post-commit lifecycle tests.
+// Where the codes diverge from the original plan text, production wins
+// (the deployed validator / facilitator are ground truth):
+//   - C1 → `CALLDATA_MISMATCH` (rule 7), not "OFFER_MISMATCH".
+//   - C8 → `INVALID_PAYLOAD` from the facilitator allowlist guard, not
+//     "ESCROW_NOT_ALLOWED" (there is no such code in the facilitator's
+//     `FacilitatorErrorCode` union).
+//
+// Two submission paths:
+//   - C1–C5 go through the resource server's `/resource` paywall (the
+//     same path the happy-path A* tests use), so they exercise the
+//     server-side validator and, for C3/C4, the facilitator via
+//     `/settle`.
+//   - C8 POSTs straight to the facilitator's `/verify`: the resource
+//     server always forwards its own (allowlisted) `escrowAddress`, so
+//     the allowlist guard can only be reached by submitting requirements
+//     with a non-allowlisted escrow directly.
 
-import { describe, it } from "vitest";
+import type { LocalAccount } from "viem";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { LOCAL_31337_0 } from "../../src/config/local-31337-0.js";
+import {
+  buildPublicClient,
+  buildWalletClient,
+  buildValidCommitHeader,
+  createChainTokenDomainResolver,
+  fetchEscrowChallenge,
+  submitMutatedCommit,
+  submitPaymentHeader,
+  verifyViaFacilitator,
+  decodePaymentHeader,
+} from "../../src/harness/index.js";
+
+import { createFundedBuyer, ensureBuyerCanPay, ensureBuyerHasBalance } from "./_buyer-setup.js";
 import { ENABLED } from "./_flags.js";
+import { SEED_WALLETS } from "./_seed-wallets.js";
+import { createScenarioContext, NONE_TOKEN_AUTH_SCENARIO, type ScenarioContext } from "./_setup.js";
 
-describe.skipIf(!ENABLED)("@p0 commit-time validations", () => {
-  it.todo("C1 — tampered `functionSignature` → 400 OFFER_MISMATCH");
-  it.todo("C2 — wrong meta-tx signature → BAD_META_TX_SIGNATURE, no on-chain submit");
-  it.todo("C3 — nonce replay → second submit fails (nonce consumed on chain)");
-  it.todo("C4 — expired offer (`validBefore < now`) → SIMULATION_REVERT or pre-flight reject");
-  it.todo(
-    "C5 — `maxTimeoutSeconds` exceeded (`validBefore > now + maxTimeoutSeconds`) → server reject pre-facilitator",
-  );
-  it.todo("C8 — wrong `escrowAddress` (not on facilitator allowlist) → ESCROW_NOT_ALLOWED");
+/** Structurally valid but never-allowlisted escrow address for C8. */
+const NON_ALLOWLISTED_ESCROW = "0x1111111111111111111111111111111111111111";
+
+describe.skipIf(!ENABLED)("@p0 commit-time validations (none strategy)", () => {
+  let ctx: ScenarioContext;
+  let buyerAccount: LocalAccount;
+
+  beforeAll(async () => {
+    const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS.validationCommit.account);
+    buyerAccount = await createFundedBuyer({ funder, publicClient });
+    ctx = await createScenarioContext({
+      slot: "validationCommit",
+      buyerAccount,
+      ...NONE_TOKEN_AUTH_SCENARIO,
+    });
+    // C3's first submit settles a real commit on-chain, so the `none`
+    // buyer needs balance + a standing escrow allowance. C1 / C2 reject
+    // at the server before settle, so the funding is a harmless no-op
+    // for them.
+    await ensureBuyerCanPay({
+      walletClient: buildWalletClient(buyerAccount),
+      publicClient,
+      buyerAddress: buyerAccount.address,
+      assetAddress: LOCAL_31337_0.contracts.testErc20,
+      escrowAddress: LOCAL_31337_0.contracts.protocolDiamond,
+      amount: 10_000_000n,
+    });
+  });
+
+  afterAll(async () => {
+    await ctx?.teardown();
+  });
+
+  it("C1 — tampered `functionSignature` → 400 CALLDATA_MISMATCH", async () => {
+    const result = await submitMutatedCommit({
+      resourceServerUrl: ctx.resourceServerUrl,
+      client: ctx.buyer.client,
+      mutate: (payload) => {
+        // Flip the final nibble — keeps the value schema-valid hex but
+        // breaks the rule-7 byte comparison against the calldata
+        // reconstructed from `offerRef`.
+        const fs = payload.payload.metaTx.functionSignature;
+        const last = fs.slice(-1);
+        payload.payload.metaTx.functionSignature = (fs.slice(0, -1) +
+          (last === "0" ? "1" : "0")) as `0x${string}`;
+      },
+    });
+
+    expect(result.status, JSON.stringify(result.body)).toBe(400);
+    expect(result.body?.code).toBe("CALLDATA_MISMATCH");
+    expect(result.body?.details?.rule).toBe(7);
+  });
+
+  it("C2 — wrong meta-tx signature (mutated nonce) → 400 BAD_META_TX_SIGNATURE", async () => {
+    const result = await submitMutatedCommit({
+      resourceServerUrl: ctx.resourceServerUrl,
+      client: ctx.buyer.client,
+      mutate: (payload) => {
+        // The meta-tx signature was produced over the original nonce.
+        // Bumping the nonce leaves `from === buyer` (rule-8's first
+        // check passes) but makes the ECDSA recovery resolve to a
+        // different address → BAD_META_TX_SIGNATURE. The server rejects
+        // pre-facilitator, so no on-chain submit happens.
+        payload.payload.metaTx.nonce = (BigInt(payload.payload.metaTx.nonce) + 1n).toString();
+      },
+    });
+
+    expect(result.status, JSON.stringify(result.body)).toBe(400);
+    expect(result.body?.code).toBe("BAD_META_TX_SIGNATURE");
+    expect(result.body?.details?.rule).toBe(8);
+  });
+
+  it("C3 — nonce replay → second submit rejected by facilitator (nonce consumed)", async () => {
+    // Build ONE signed header and submit it twice under the same
+    // session: the meta-tx nonce is fixed at sign time, so the second
+    // submit re-presents an already-consumed nonce. The server
+    // validator is stateless and passes both times; the facilitator
+    // catches the replay (duplicate-nonce revert) on the second.
+    const { sessionId, headerValue } = await buildValidCommitHeader(
+      ctx.resourceServerUrl,
+      ctx.buyer.client,
+    );
+
+    const first = await submitPaymentHeader(ctx.resourceServerUrl, sessionId, headerValue);
+    expect(first.status, JSON.stringify(first.body)).toBe(200);
+    expect(first.body?.ok).toBe(true);
+
+    const second = await submitPaymentHeader(ctx.resourceServerUrl, sessionId, headerValue);
+    expect(second.status, JSON.stringify(second.body)).toBe(502);
+    expect(second.body?.code).toBe("FACILITATOR_REJECTED");
+    // The exact inner code depends on whether the facilitator catches
+    // the consumed nonce at simulation or at on-chain submit; assert it
+    // surfaced a facilitator code rather than pinning one revert flavour.
+    expect(typeof second.body?.details?.facilitatorCode).toBe("string");
+  });
+
+  it("C8 — wrong `escrowAddress` (not on facilitator allowlist) → 400 INVALID_PAYLOAD", async () => {
+    // Build a valid payload + read back the challenge requirements, then
+    // POST to the facilitator's `/verify` with the escrow swapped for a
+    // non-allowlisted address. The allowlist guard (verify step 7) fires
+    // before signature recovery / simulation.
+    const sessionId = globalThis.crypto.randomUUID();
+    const requirements = await fetchEscrowChallenge(ctx.resourceServerUrl, sessionId);
+    const headerValue = await ctx.buyer.client.handle402(requirements);
+    const payload = decodePaymentHeader(headerValue);
+
+    const result = await verifyViaFacilitator({
+      facilitatorUrl: ctx.facilitatorUrl,
+      network: ctx.network,
+      payload,
+      requirements: { ...requirements, escrowAddress: NON_ALLOWLISTED_ESCROW },
+    });
+
+    expect(result.status, JSON.stringify(result.body)).toBe(400);
+    expect(result.body?.code).toBe("INVALID_PAYLOAD");
+  });
+});
+
+describe.skipIf(!ENABLED)("@p0 commit-time validations (erc3009 deadline)", () => {
+  let ctx: ScenarioContext;
+
+  beforeAll(async () => {
+    // Mirrors A3's ERC-3009 setup: the payload carries an `erc3009`
+    // token-auth whose `validBefore` the deadline scenarios tamper. See
+    // A3 for the 24h `maxTimeoutSeconds` chain-drift rationale.
+    const publicClient = buildPublicClient();
+    const funder = buildWalletClient(SEED_WALLETS.validationCommit.account);
+    const buyerAccount = await createFundedBuyer({ funder, publicClient });
+    ctx = await createScenarioContext({
+      slot: "validationCommit",
+      buyerAccount,
+      assetAddress: LOCAL_31337_0.contracts.testErc3009,
+      tokenAuthStrategies: ["erc3009"],
+      tokenDomainResolver: createChainTokenDomainResolver(publicClient),
+      maxTimeoutSeconds: 24 * 60 * 60,
+    });
+    await ensureBuyerHasBalance({
+      walletClient: buildWalletClient(buyerAccount),
+      publicClient,
+      buyerAddress: buyerAccount.address,
+      assetAddress: LOCAL_31337_0.contracts.testErc3009,
+      amount: 10_000_000n,
+    });
+  });
+
+  afterAll(async () => {
+    await ctx?.teardown();
+  });
+
+  it("C4 — expired authorization (`validBefore` in the past) → 502 facilitator reject", async () => {
+    // A past `validBefore` is below the server's `now + maxTimeoutSeconds`
+    // horizon, so rule 9 passes and the payload reaches the facilitator.
+    // Tampering the signed field breaks the ERC-3009 signature recovery
+    // (and would also revert on-chain), so the facilitator rejects with
+    // a 502 `FACILITATOR_REJECTED` envelope rather than the server 400.
+    const result = await submitMutatedCommit({
+      resourceServerUrl: ctx.resourceServerUrl,
+      client: ctx.buyer.client,
+      mutate: (payload) => {
+        const tokenAuth = payload.payload.tokenAuth;
+        if (tokenAuth?.kind !== "erc3009") {
+          throw new Error(`expected erc3009 tokenAuth, got ${tokenAuth?.kind ?? "none"}`);
+        }
+        // 1 second after the epoch — unambiguously expired.
+        tokenAuth.data.validBefore = 1;
+      },
+    });
+
+    expect(result.status, JSON.stringify(result.body)).toBe(502);
+    expect(result.body?.code).toBe("FACILITATOR_REJECTED");
+    expect(typeof result.body?.details?.facilitatorCode).toBe("string");
+  });
+
+  it("C5 — `maxTimeoutSeconds` exceeded → 400 TOKEN_AUTH_DEADLINE_EXCEEDED", async () => {
+    // A `validBefore` far beyond `now + maxTimeoutSeconds` trips the
+    // server's rule-9 horizon check, which reads the declared value
+    // directly — so it rejects pre-facilitator, before any signature or
+    // simulation step.
+    const farFuture = Math.floor(Date.now() / 1000) + 100 * 365 * 24 * 60 * 60;
+    const result = await submitMutatedCommit({
+      resourceServerUrl: ctx.resourceServerUrl,
+      client: ctx.buyer.client,
+      mutate: (payload) => {
+        const tokenAuth = payload.payload.tokenAuth;
+        if (tokenAuth?.kind !== "erc3009") {
+          throw new Error(`expected erc3009 tokenAuth, got ${tokenAuth?.kind ?? "none"}`);
+        }
+        tokenAuth.data.validBefore = farFuture;
+      },
+    });
+
+    expect(result.status, JSON.stringify(result.body)).toBe(400);
+    expect(result.body?.code).toBe("TOKEN_AUTH_DEADLINE_EXCEEDED");
+  });
 });


### PR DESCRIPTION
> Draft, based on `add-x402-e2e-permit-and-permit2` (PR #92). GitHub will
> auto-rebase the base to `main` once #92 merges.

## Summary

- Add `src/harness/craft-payment.ts` — replicates `wrapFetchWithPayment`
  (same session id across the 402 challenge and the `X-PAYMENT` retry) but
  exposes the decoded payload so a scenario can tamper one field and assert
  the resulting rejection. Also adds a direct facilitator `/verify` helper.
- Implement section-C commit-time validation negatives:
  - **C1** tampered `functionSignature` → 400 `CALLDATA_MISMATCH` (rule 7)
  - **C2** mutated meta-tx nonce → 400 `BAD_META_TX_SIGNATURE` (rule 8)
  - **C3** nonce replay → 2nd submit 502 `FACILITATOR_REJECTED`
  - **C4** expired `validBefore` → 502 facilitator reject
  - **C5** `validBefore` beyond horizon → 400 `TOKEN_AUTH_DEADLINE_EXCEEDED`
  - **C8** non-allowlisted escrow via facilitator `/verify` → 400 `INVALID_PAYLOAD`

## Notes / deviations from the original plan text

- Production codes win where the plan drifted: rule 7 surfaces
  `CALLDATA_MISMATCH` (not "OFFER_MISMATCH"), and the facilitator allowlist
  guard returns `INVALID_PAYLOAD` (there is no `ESCROW_NOT_ALLOWED` code).
- **C4** asserts the 502 `FACILITATOR_REJECTED` envelope + presence of a
  `facilitatorCode` rather than pinning `SIMULATION_REVERT`: tampering the
  signed `validBefore` invalidates the ERC-3009 signature, so the exact
  inner revert flavour depends on the facilitator's check order.
- **C8** submits straight to the facilitator `/verify` because the resource
  server always forwards its own allowlisted escrow.

## Test plan

- [x] `pnpm --filter @bosonprotocol/x402-e2e lint`
- [x] `tsc --noEmit`
- [x] `vitest run validation-commit` (6 tests collected, skip cleanly without `E2E_DOCKER=1`)
- [x] `pnpm format:check`
- [ ] `E2E_DOCKER=1` run against the live stack — facilitator-side assertions (C3 2nd submit, C4) and C3's first-submit 200 not yet verified end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)