### PR TITLE
ci: run build/test/lint on draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
   build-test-lint:
     name: build / test / lint (node ${{ matrix.node }})
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Remove the draft guard (`if: ${{ !github.event.pull_request.draft }}`) from the `build-test-lint` job so it runs on draft PRs.

## Why

Draft PRs (used here as the base for dependent staged PRs) previously skipped CI entirely until marked ready for review, so build/test/lint feedback only arrived late. With this change the fast job runs on `opened` / `synchronize` for drafts too.

The heavier `e2e-pr` job keeps its draft guard and still only runs once the PR is marked ready for review, so draft pushes stay cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)