### PR TITLE
fix(paywall): per-flow session id for browser offer isolation

### DIFF
--- a/.changeset/paywall-session-id-isolation.md
+++ b/.changeset/paywall-session-id-isolation.md
@@ -1,0 +1,19 @@
+---
+"@bosonprotocol/x402-paywall": patch
+"@bosonprotocol/x402-core": patch
+"@bosonprotocol/x402-client-fetch": patch
+---
+
+Give the browser paywall per-flow offer isolation. Each Pay click now
+mints a fresh `X-X402-Boson-Session-Id` and stamps it on both a
+session-scoped challenge re-fetch (whose escrow requirement it signs) and
+the X-PAYMENT retry, mirroring `@bosonprotocol/x402-client-fetch`'s
+`wrapFetchWithPayment`. Previously the paywall signed the navigation-time
+requirements and retried without a session id, so sequential browser
+buyers collided on the resource server's fallback cache slot — reverting
+`OfferSoldOut` on a single-quantity offer template within the cache TTL.
+
+Adds `findEscrowAccept(body)` to `@bosonprotocol/x402-core/schemes/escrow`
+— the escrow-entry picker for a parsed 402 `accepts[]` body — and
+single-sources `@bosonprotocol/x402-client-fetch`'s entry extraction
+through it so the wrapper and the paywall select the entry identically.

--- a/typescript/packages/client-fetch/src/wrap.ts
+++ b/typescript/packages/client-fetch/src/wrap.ts
@@ -29,6 +29,7 @@
 // commits in a row.
 
 import { SESSION_ID_HEADER } from "@bosonprotocol/x402-core";
+import { findEscrowAccept } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { X402bClient } from "@bosonprotocol/x402-client";
 
 // Re-exported below so existing `@bosonprotocol/x402-client-fetch`
@@ -97,17 +98,5 @@ async function extractEscrowEntry(response: Response): Promise<unknown | undefin
   } catch {
     return undefined;
   }
-  if (typeof body !== "object" || body === null) {
-    return undefined;
-  }
-  const accepts = (body as { accepts?: unknown }).accepts;
-  if (!Array.isArray(accepts)) {
-    return undefined;
-  }
-  return accepts.find(
-    (entry) =>
-      typeof entry === "object" &&
-      entry !== null &&
-      (entry as { scheme?: unknown }).scheme === "escrow",
-  );
+  return findEscrowAccept(body);
 }

--- a/typescript/packages/core/src/schemes/escrow/accepts.ts
+++ b/typescript/packages/core/src/schemes/escrow/accepts.ts
@@ -1,0 +1,32 @@
+// Locate the `escrow` entry inside a parsed x402 402 challenge body.
+//
+// The 402 JSON envelope is `{ x402Version, accepts: [requirements...] }`
+// (see `respondWithChallenge` in `@bosonprotocol/x402-server-express`). A
+// server may advertise several schemes in `accepts[]`; this returns the
+// first entry whose `scheme === "escrow"`, or `undefined` when the body
+// isn't an object, has no `accepts[]` array, or carries only other
+// schemes.
+//
+// Single-sourced here so the buyer-side fetch wrapper
+// (`@bosonprotocol/x402-client-fetch`) and the browser paywall
+// (`@bosonprotocol/x402-paywall`) pick the entry identically. The input
+// is the already-parsed JSON body rather than a `Response` so the helper
+// stays environment-agnostic — each caller owns how it decodes the
+// response (clone-then-`json()` for the wrapper, plain `json()` for the
+// paywall).
+
+export function findEscrowAccept(body: unknown): unknown | undefined {
+  if (typeof body !== "object" || body === null) {
+    return undefined;
+  }
+  const accepts = (body as { accepts?: unknown }).accepts;
+  if (!Array.isArray(accepts)) {
+    return undefined;
+  }
+  return accepts.find(
+    (entry) =>
+      typeof entry === "object" &&
+      entry !== null &&
+      (entry as { scheme?: unknown }).scheme === "escrow",
+  );
+}

--- a/typescript/packages/core/src/schemes/escrow/index.ts
+++ b/typescript/packages/core/src/schemes/escrow/index.ts
@@ -6,6 +6,7 @@ export * from "./payment-requirements.js";
 export * from "./payment-payload.js";
 export * from "./next-actions.js";
 export * from "./validators.js";
+export * from "./accepts.js";
 
 /** Stable identifier for the scheme. Use this in place of the raw string `"escrow"` to avoid typos. */
 export const ESCROW_SCHEME = "escrow" as const;

--- a/typescript/packages/core/test/schemes/escrow/accepts.test.ts
+++ b/typescript/packages/core/test/schemes/escrow/accepts.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { findEscrowAccept } from "../../../src/schemes/escrow/index.js";
+
+describe("findEscrowAccept", () => {
+  it("returns the escrow entry from a multi-scheme accepts[]", () => {
+    const escrow = { scheme: "escrow", amount: "1000000" };
+    const body = { x402Version: 2, accepts: [{ scheme: "exact" }, escrow] };
+    expect(findEscrowAccept(body)).toBe(escrow);
+  });
+
+  it("returns undefined when no entry carries scheme 'escrow'", () => {
+    const body = { x402Version: 2, accepts: [{ scheme: "exact" }, { scheme: "upto" }] };
+    expect(findEscrowAccept(body)).toBeUndefined();
+  });
+
+  it.each([
+    ["a non-object body", "not json"],
+    ["null", null],
+    ["a body without accepts[]", { x402Version: 2 }],
+    ["a body whose accepts is not an array", { accepts: { scheme: "escrow" } }],
+  ])("returns undefined for %s", (_label, body) => {
+    expect(findEscrowAccept(body)).toBeUndefined();
+  });
+
+  it("skips non-object accepts[] entries without throwing", () => {
+    const escrow = { scheme: "escrow" };
+    const body = { accepts: [null, "x", 42, escrow] };
+    expect(findEscrowAccept(body)).toBe(escrow);
+  });
+});

--- a/typescript/packages/paywall/src/app/EvmEscrowPaywall.tsx
+++ b/typescript/packages/paywall/src/app/EvmEscrowPaywall.tsx
@@ -183,6 +183,11 @@ export function EvmEscrowPaywall({ state }: Props) {
         const challenge = await fetch(currentUrl, {
           headers: { Accept: "application/json", [SESSION_ID_HEADER]: sessionId },
         });
+        if (challenge.status !== 402) {
+          setStatus("error");
+          setErrorMessage(`Expected a 402 challenge, got status ${challenge.status}.`);
+          return;
+        }
         const escrowEntry = findEscrowAccept(await challenge.json().catch(() => undefined));
         if (!escrowEntry) {
           setStatus("error");

--- a/typescript/packages/paywall/src/app/EvmEscrowPaywall.tsx
+++ b/typescript/packages/paywall/src/app/EvmEscrowPaywall.tsx
@@ -14,9 +14,18 @@
 // produced by wagmi. The signer then drives `createX402bClient.handle402`
 // which packs the X-PAYMENT header — two EIP-712 signatures (meta-tx +
 // token authorization) happen inside that single call.
+//
+// Each Pay click mints a fresh `X-X402-Boson-Session-Id` and stamps it on
+// both the challenge re-fetch (which yields the offer we sign) and the
+// X-PAYMENT retry, mirroring `@bosonprotocol/x402-client-fetch`. This
+// scopes the resource server's signed-offer cache to the flow so distinct
+// browser buyers don't collide on its fallback cache slot — see the inline
+// note in `handlePay`.
 
-import { createX402bClient, signerFromWalletClient } from "@bosonprotocol/x402-client-browser";
+import { SESSION_ID_HEADER } from "@bosonprotocol/x402-core";
 import { fetchTokenDomain } from "@bosonprotocol/x402-core/eip712/token-auth";
+import { findEscrowAccept } from "@bosonprotocol/x402-core/schemes/escrow";
+import { createX402bClient, signerFromWalletClient } from "@bosonprotocol/x402-client-browser";
 import { useMemo, useRef, useState } from "react";
 import type { Address } from "viem";
 import {
@@ -152,11 +161,41 @@ export function EvmEscrowPaywall({ state }: Props) {
             : {}),
         });
 
-        const headerValue = await client.handle402(requirements);
+        // Mint one session id for this buyer flow and stamp it on BOTH
+        // the challenge re-fetch below and the X-PAYMENT retry, mirroring
+        // `@bosonprotocol/x402-client-fetch`'s `wrapFetchWithPayment`. The
+        // resource server scopes its signed-offer cache to this id, so the
+        // offer we sign here and the offer it re-resolves at settle are the
+        // same one — while distinct buyer flows get distinct offers, so a
+        // single-quantity offer template isn't served to two sequential
+        // commits within the server's cache TTL.
+        //
+        // We re-resolve requirements from the server under this id rather
+        // than signing the navigation-time `requirements` injected into the
+        // page: that injection was built under the server's fallback cache
+        // slot (a top-level browser navigation can't carry the header), so
+        // signing it would make the retry's session-scoped re-resolve
+        // mismatch the payload's offer (the validator deep-equals
+        // `offerRef.fullOffer` / `sellerSig`). The injected `requirements`
+        // still drive the offer summary above — every buyer-visible field
+        // is env-derived and identical across sessions.
+        const sessionId = globalThis.crypto.randomUUID();
+        const challenge = await fetch(currentUrl, {
+          headers: { Accept: "application/json", [SESSION_ID_HEADER]: sessionId },
+        });
+        const escrowEntry = findEscrowAccept(await challenge.json().catch(() => undefined));
+        if (!escrowEntry) {
+          setStatus("error");
+          setErrorMessage(
+            `Server did not return an escrow payment requirement (status ${challenge.status}).`,
+          );
+          return;
+        }
+        const headerValue = await client.handle402(escrowEntry);
 
         setStatus("submitting");
         const response = await fetch(currentUrl, {
-          headers: { [X_PAYMENT_HEADER]: headerValue },
+          headers: { [X_PAYMENT_HEADER]: headerValue, [SESSION_ID_HEADER]: sessionId },
         });
         if (response.status === 402) {
           const body = await response.text();

--- a/typescript/packages/x402-e2e/test/browser/paywall.test.ts
+++ b/typescript/packages/x402-e2e/test/browser/paywall.test.ts
@@ -2,10 +2,13 @@
 // and @bosonprotocol/x402-paywall end-to-end through headless chromium.
 //
 // All three scenarios live in one file (one describe → one seed-wallet
-// slot → sequential `it` blocks within the file) so they share the
-// resource-server's `FALLBACK_KEY` session slot safely. The paywall
-// doesn't stamp `X-Session-Id` today; sequencing avoids the race that
-// concurrent browser flows would otherwise trigger.
+// slot → sequential `it` blocks within the file) because they share one
+// buyer EOA — BR2/BR3 snapshot its balance to assert no spend, so they
+// must not race BR1's commit. The paywall now mints a fresh
+// `X-X402-Boson-Session-Id` per Pay click and stamps it on both the
+// challenge re-fetch and the X-PAYMENT retry (see EvmEscrowPaywall), so
+// the resource-server offer cache no longer forces the sequencing — each
+// flow already gets its own session-scoped offer.
 //
 // Tag: `@p0`. Runs on every PR alongside the node scenarios; the
 // `describe.skipIf` keeps it a no-op when `E2E_DOCKER` isn't set.
@@ -135,6 +138,12 @@ describe.skipIf(!ENABLED)("@p0 browser-paywall scenarios", () => {
 
       const response = await paymentResponse;
       expect(response.status()).toBe(200);
+
+      // The retry must carry the per-flow session id (lower-cased by the
+      // browser) so the resource server re-resolves the same session-scoped
+      // offer it signed at challenge time, rather than its fallback slot.
+      const retryHeaders = response.request().headers();
+      expect(retryHeaders["x-x402-boson-session-id"]).toBeTruthy();
 
       const decoded = readXPaymentResponse(await response.allHeaders());
       expect(decoded).not.toBeNull();


### PR DESCRIPTION
Closes #102.

## Problem

`client-fetch`'s `wrapFetchWithPayment` stamps `X-X402-Boson-Session-Id` on both the 402 challenge and the X-PAYMENT retry, letting the resource server scope its signed-offer cache per buyer flow. The browser paywall did neither: it signed the navigation-time injected `requirements` (built under the server's fallback cache slot, since a top-level browser navigation can't carry the header) and retried with no session id.

Consequence: sequential browser 402→retry pairs share the fallback slot. For single-quantity offer templates this reverts `OfferSoldOut` on a second commit within the cache TTL — browser flows had no per-flow offer isolation.

## Fix

Mirror `wrapFetchWithPayment` in the paywall. Each Pay click:

1. Mints a fresh `X-X402-Boson-Session-Id`.
2. Re-fetches the challenge under that id (`Accept: application/json`) and signs the **re-resolved**, session-scoped escrow requirement.
3. Stamps the same id on the X-PAYMENT retry.

Signing the re-resolved (not the navigation-injected) requirement is required so the retry's session-scoped re-resolve still byte-matches the payload — the validator deep-equals `offerRef.fullOffer` and `sellerSig` (Rules 3/4). The injected `requirements` still drive the offer summary; every buyer-visible field is env-derived and identical across sessions.

Per the issue, the consumer side in `x402b-boson-services` already reads the incoming header, so browser flows gain isolation with no change there.

## Reuse

Adds `findEscrowAccept(body)` to `@bosonprotocol/x402-core/schemes/escrow` — the escrow-entry picker for a parsed 402 `accepts[]` body — and routes `client-fetch`'s private entry extraction through it, so the wrapper and the paywall select the entry identically.

## Changes

- `core/src/schemes/escrow/accepts.ts` (new) + escrow index export
- `client-fetch/src/wrap.ts` — delegate `extractEscrowEntry` to `findEscrowAccept`
- `paywall/src/app/EvmEscrowPaywall.tsx` — session-scoped challenge + retry
- `x402-e2e/test/browser/paywall.test.ts` — BR1 asserts the retry carries the session-id header; refreshed stale comment
- `core/test/schemes/escrow/accepts.test.ts` (new) — 7 unit cases
- changeset (patch: `x402-paywall`, `x402-core`, `x402-client-fetch`)

## Verification

`pnpm build` (16/16) · `pnpm test` (32/32) · `pnpm lint` · `pnpm format:check` — all green. Docker-gated e2e (`BR1`) covers the happy path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser paywall now generates a unique session identifier per payment and includes it on both challenge requests and payment retries.
  * Paywall and payment wrapper now select the same escrow entry for consistent payment handling.

* **Bug Fixes**
  * Resolved cache-collision causing incorrect "OfferSoldOut" for single-quantity offers.

* **Tests**
  * Added unit and browser tests covering escrow selection and per-payment session isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->