### PR TITLE
feat(client): add server→facilitator channel fallback for buyer flows

### DIFF
--- a/.changeset/client-channel-fallback.md
+++ b/.changeset/client-channel-fallback.md
@@ -1,0 +1,40 @@
+---
+"@bosonprotocol/x402-client": minor
+"@bosonprotocol/x402-client-fetch": minor
+---
+
+Add channel-aware fallback so buyer flows survive a brief resource-server
+outage. Post-commit actions and (opt-in) commit-time payments now walk
+the seller's advertised channel list, intersected with `["server",
+"facilitator"]`, instead of being pinned to the first endpoint.
+
+`@bosonprotocol/x402-client`
+
+- New `submitAction(args)` method on `X402bClient` and a low-level
+  `submitAction()` helper from the package root. Signs the meta-tx via
+  `signAction`, looks up the matching entry in
+  `priorNextActions.next[]`, and POSTs to the first responsive channel
+  in `channels[]`. Falls back to the next channel on 5xx, network
+  error, or timeout; stops and throws on 4xx (a buyer-side payload bug
+  fallback can't fix). `NoCompatibleChannelError` covers actions
+  advertising only non-HTTP channels; `AllChannelsFailedError` carries
+  the per-channel attempt log. The server-channel response surfaces
+  the full `nextActions` envelope; the facilitator's
+  `/perform-action` returns the new state only.
+
+`@bosonprotocol/x402-client-fetch`
+
+- New `commitFallback: "off" | "auto"` option on `wrapFetchWithPayment`
+  (default `"off"`). When `"auto"`, a resource-server 5xx / network
+  error / timeout on the X-PAYMENT retry triggers a direct POST to the
+  facilitator's `/settle` endpoint advertised in the 402's
+  `actions.next[*].endpoints.facilitator`. On settle success the
+  wrapper returns a synthesized `200` with `X-PAYMENT-RESPONSE`
+  populated, a `X-X402-Boson-Commit-Channel: facilitator` marker so
+  the caller can detect that fallback was taken, and an empty body —
+  the resource itself stays the responsibility of the resource server.
+  On any fallback failure the original upstream error is surfaced
+  unchanged.
+
+`onchain`, `mcp`, and `xmtp` channels remain out of scope for both
+surfaces and will land separately when the underlying primitives ship.

--- a/typescript/packages/client-fetch/src/index.ts
+++ b/typescript/packages/client-fetch/src/index.ts
@@ -4,5 +4,5 @@
 // installing just this package gets `createX402bClient`, error classes,
 // types, and the fetch wrapper in one import path.
 
-export { wrapFetchWithPayment, SESSION_ID_HEADER } from "./wrap.js";
+export { wrapFetchWithPayment, SESSION_ID_HEADER, type WrapFetchOptions } from "./wrap.js";
 export * from "@bosonprotocol/x402-client";

--- a/typescript/packages/client-fetch/src/wrap.ts
+++ b/typescript/packages/client-fetch/src/wrap.ts
@@ -61,7 +61,10 @@ import {
   type EscrowPaymentPayload,
   type NextAction,
 } from "@bosonprotocol/x402-core/schemes/escrow";
+import { ACTION_POST_STATE } from "@bosonprotocol/x402-core/state-machine";
 import type { X402bClient } from "@bosonprotocol/x402-client";
+
+type CommitActionId = "boson-createOfferAndCommit" | "boson-createOfferCommitAndRedeem";
 
 // Re-exported below so existing `@bosonprotocol/x402-client-fetch`
 // importers keep working without having to add a direct dep on
@@ -173,6 +176,7 @@ export function wrapFetchWithPayment(
     }
     return synthesizeCommitFallbackResponse({
       body: fallback,
+      actionId: fallback.actionId,
       serverErrorMarker:
         networkErrorMessage !== undefined
           ? `network:${networkErrorMessage}`
@@ -207,7 +211,9 @@ async function tryFacilitatorFallback(input: {
   headerValue: string;
   facilitatorTimeoutMs: number;
   originalFetch: typeof fetch;
-}): Promise<{ ok: true; exchangeId: string; txHash: string } | undefined> {
+}): Promise<
+  { ok: true; actionId: CommitActionId; exchangeId: string; txHash: string } | undefined
+> {
   const requirements = input.escrowEntry as {
     scheme?: unknown;
     network?: unknown;
@@ -222,7 +228,7 @@ async function tryFacilitatorFallback(input: {
   }
 
   const commitEntry = (requirements.actions.next as NextAction[]).find(
-    (e) =>
+    (e): e is NextAction & { id: CommitActionId } =>
       (e.id === "boson-createOfferAndCommit" || e.id === "boson-createOfferCommitAndRedeem") &&
       e.channels.includes("facilitator") &&
       typeof e.endpoints?.facilitator === "string",
@@ -263,7 +269,12 @@ async function tryFacilitatorFallback(input: {
   if (typeof ok.exchangeId !== "string" || typeof ok.txHash !== "string") {
     return undefined;
   }
-  return { ok: true, exchangeId: ok.exchangeId, txHash: ok.txHash };
+  return {
+    ok: true,
+    actionId: commitEntry.id,
+    exchangeId: ok.exchangeId,
+    txHash: ok.txHash,
+  };
 }
 
 /**
@@ -274,12 +285,13 @@ async function tryFacilitatorFallback(input: {
  */
 function synthesizeCommitFallbackResponse(input: {
   body: { ok: true; exchangeId: string; txHash: string };
+  actionId: CommitActionId;
   serverErrorMarker: string;
 }): Response {
   const xPaymentResponseBody = {
     exchangeId: input.body.exchangeId,
     txHash: input.body.txHash,
-    nextActions: { exchangeState: "COMMITTED" },
+    nextActions: { exchangeState: ACTION_POST_STATE[input.actionId].exchange },
   };
   const headers = new Headers();
   headers.set(X_PAYMENT_RESPONSE_HEADER, encodeBase64(JSON.stringify(xPaymentResponseBody)));

--- a/typescript/packages/client-fetch/src/wrap.ts
+++ b/typescript/packages/client-fetch/src/wrap.ts
@@ -151,13 +151,16 @@ export function wrapFetchWithPayment(
       }
       networkErrorMessage = e instanceof Error ? e.message : String(e);
       // Synthesize a 599 sentinel so the network-error path joins the
-      // 5xx branch below (`status < 500` skips the fallback). 599 is
-      // never returned to the caller — on a successful fallback we
-      // emit a synthesized 200; on a failed fallback we surface this
-      // placeholder as the original error, which is acceptable
-      // because the real error message is preserved on the
-      // `X-X402-Boson-Server-Error` header (`network:<message>`).
-      retryResponse = new Response(null, { status: 599 });
+      // 5xx branch below (`status < 500` skips the fallback). On a
+      // successful fallback this 599 is replaced by a synthesized 200;
+      // on a failed fallback it surfaces to the caller — and stamping
+      // the original `network:<message>` on `X-X402-Boson-Server-Error`
+      // here ensures the underlying failure isn't lost behind the
+      // placeholder status.
+      retryResponse = new Response(null, {
+        status: 599,
+        headers: { [SERVER_ERROR_HEADER]: `network:${networkErrorMessage}` },
+      });
     }
 
     if (commitFallback !== "auto" || retryResponse.status < 500) {

--- a/typescript/packages/client-fetch/src/wrap.ts
+++ b/typescript/packages/client-fetch/src/wrap.ts
@@ -62,7 +62,7 @@ import {
   type NextAction,
 } from "@bosonprotocol/x402-core/schemes/escrow";
 import { ACTION_POST_STATE } from "@bosonprotocol/x402-core/state-machine";
-import type { X402bClient } from "@bosonprotocol/x402-client";
+import { decodeBase64, encodeBase64, type X402bClient } from "@bosonprotocol/x402-client";
 
 type CommitActionId = "boson-createOfferAndCommit" | "boson-createOfferCommitAndRedeem";
 
@@ -325,28 +325,4 @@ async function fetchWithTimeout(
   } finally {
     clearTimeout(timer);
   }
-}
-
-function decodeBase64(value: string): string {
-  if (typeof Buffer !== "undefined") {
-    return Buffer.from(value, "base64").toString("utf8");
-  }
-  const binary = atob(value);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return new TextDecoder().decode(bytes);
-}
-
-function encodeBase64(value: string): string {
-  if (typeof Buffer !== "undefined") {
-    return Buffer.from(value, "utf8").toString("base64");
-  }
-  const bytes = new TextEncoder().encode(value);
-  let binary = "";
-  for (const b of bytes) {
-    binary += String.fromCharCode(b);
-  }
-  return btoa(binary);
 }

--- a/typescript/packages/client-fetch/src/wrap.ts
+++ b/typescript/packages/client-fetch/src/wrap.ts
@@ -150,6 +150,13 @@ export function wrapFetchWithPayment(
         throw e;
       }
       networkErrorMessage = e instanceof Error ? e.message : String(e);
+      // Synthesize a 599 sentinel so the network-error path joins the
+      // 5xx branch below (`status < 500` skips the fallback). 599 is
+      // never returned to the caller — on a successful fallback we
+      // emit a synthesized 200; on a failed fallback we surface this
+      // placeholder as the original error, which is acceptable
+      // because the real error message is preserved on the
+      // `X-X402-Boson-Server-Error` header (`network:<message>`).
       retryResponse = new Response(null, { status: 599 });
     }
 

--- a/typescript/packages/client-fetch/src/wrap.ts
+++ b/typescript/packages/client-fetch/src/wrap.ts
@@ -27,9 +27,40 @@
 // against `requirements.offer.fullOffer`), while distinct buyer flows
 // see distinct offers so a single-quantity offer isn't served to two
 // commits in a row.
+//
+// ### Commit fallback (opt-in)
+//
+// When `commitFallback: "auto"` is set, a resource-server 5xx / network
+// error / timeout on step 5 no longer fails the call. Instead, the
+// wrapper recovers the structured `EscrowPaymentPayload` from the
+// X-PAYMENT base64, looks up `requirements.actions.next[*]
+// .endpoints.facilitator` for the chosen commit action, and POSTs
+// `{ scheme, network, payload, requirements }` directly to the
+// facilitator's `/settle` route. On success the commit lands on-chain
+// via the facilitator and the wrapper returns a **synthesized 200**
+// with:
+//
+//   - `X-PAYMENT-RESPONSE: <base64-of-the-success-body>` so
+//     `client.parsePaymentResponse(...)` continues to work,
+//   - `X-X402-Boson-Commit-Channel: facilitator` so the caller can
+//     detect that fallback was used,
+//   - `X-X402-Boson-Server-Error: <status-or-message>` for diagnostics,
+//   - an empty body — the resource itself comes from the resource
+//     server, which by definition is unreachable; callers that need
+//     the resource must come back later (re-GET when the server is up,
+//     or rely on the seller's asynchronous fulfillment channel).
+//
+// Default is `commitFallback: "off"` — the behaviour above is opt-in so
+// that existing callers don't get a different response shape from a
+// brief upstream blip.
 
 import { SESSION_ID_HEADER } from "@bosonprotocol/x402-core";
-import { findEscrowAccept } from "@bosonprotocol/x402-core/schemes/escrow";
+import {
+  findEscrowAccept,
+  parseEscrowPaymentPayload,
+  type EscrowPaymentPayload,
+  type NextAction,
+} from "@bosonprotocol/x402-core/schemes/escrow";
 import type { X402bClient } from "@bosonprotocol/x402-client";
 
 // Re-exported below so existing `@bosonprotocol/x402-client-fetch`
@@ -38,6 +69,28 @@ import type { X402bClient } from "@bosonprotocol/x402-client";
 export { SESSION_ID_HEADER };
 
 const X_PAYMENT_HEADER = "X-PAYMENT";
+const X_PAYMENT_RESPONSE_HEADER = "X-PAYMENT-RESPONSE";
+const COMMIT_CHANNEL_HEADER = "X-X402-Boson-Commit-Channel";
+const SERVER_ERROR_HEADER = "X-X402-Boson-Server-Error";
+
+/** Per-wrapper configuration knobs. */
+export interface WrapFetchOptions {
+  /**
+   * When `"auto"`, retry-with-X-PAYMENT failures (5xx / network error /
+   * timeout against the resource server) are recovered by POSTing the
+   * payload directly to the facilitator's `/settle` endpoint advertised
+   * in the prior 402's `actions.next[*].endpoints.facilitator`. The
+   * wrapper synthesizes a 200 response carrying the
+   * `X-PAYMENT-RESPONSE` header and a `X-X402-Boson-Commit-Channel:
+   * facilitator` marker so callers can detect the fallback path.
+   *
+   * Default `"off"` — callers must opt in to the synthesized-response
+   * shape.
+   */
+  commitFallback?: "off" | "auto";
+  /** Per-attempt timeout in milliseconds, applied to the facilitator fallback POST. Default 10000. */
+  facilitatorTimeoutMs?: number;
+}
 
 function newSessionId(): string {
   // `globalThis.crypto.randomUUID()` works in modern browsers and Node 19+
@@ -54,7 +107,11 @@ function newSessionId(): string {
 export function wrapFetchWithPayment(
   originalFetch: typeof fetch,
   client: X402bClient,
+  options: WrapFetchOptions = {},
 ): typeof fetch {
+  const commitFallback = options.commitFallback ?? "off";
+  const facilitatorTimeoutMs = options.facilitatorTimeoutMs ?? 10_000;
+
   return async function fetchWithPayment(input, init) {
     const initialRequest = new Request(input, init);
     // Stamp a fresh session id on this buyer flow's headers so the
@@ -81,7 +138,46 @@ export function wrapFetchWithPayment(
     headers.set(X_PAYMENT_HEADER, headerValue);
     const retryRequest = new Request(retryBase, { headers });
 
-    return originalFetch(retryRequest);
+    let retryResponse: Response;
+    let networkErrorMessage: string | undefined;
+    try {
+      retryResponse = await originalFetch(retryRequest);
+    } catch (e) {
+      if (commitFallback !== "auto") {
+        throw e;
+      }
+      networkErrorMessage = e instanceof Error ? e.message : String(e);
+      retryResponse = new Response(null, { status: 599 });
+    }
+
+    if (commitFallback !== "auto" || retryResponse.status < 500) {
+      return retryResponse;
+    }
+
+    // Resource server failed (5xx / network). Try the facilitator-direct
+    // path. On *any* recoverable hand-off failure (no facilitator
+    // endpoint advertised, facilitator also failing, …) we surface the
+    // original 5xx — the buyer-facing contract is "fallback is
+    // best-effort; on failure the upstream error wins".
+    const fallback = await tryFacilitatorFallback({
+      escrowEntry,
+      headerValue,
+      facilitatorTimeoutMs,
+      originalFetch,
+    });
+    if (fallback === undefined) {
+      // Couldn't fall back. Surface the original retry response —
+      // either the resource server's 5xx body, or, when the call
+      // failed at the network level, the synthesized 599 placeholder.
+      return retryResponse;
+    }
+    return synthesizeCommitFallbackResponse({
+      body: fallback,
+      serverErrorMarker:
+        networkErrorMessage !== undefined
+          ? `network:${networkErrorMessage}`
+          : String(retryResponse.status),
+    });
   };
 }
 
@@ -99,4 +195,139 @@ async function extractEscrowEntry(response: Response): Promise<unknown | undefin
     return undefined;
   }
   return findEscrowAccept(body);
+}
+
+/**
+ * Try to land the commit via the facilitator's `/settle` route. Returns
+ * the parsed success body on a 2xx, or `undefined` on any failure
+ * (caller surfaces the original 5xx).
+ */
+async function tryFacilitatorFallback(input: {
+  escrowEntry: unknown;
+  headerValue: string;
+  facilitatorTimeoutMs: number;
+  originalFetch: typeof fetch;
+}): Promise<{ ok: true; exchangeId: string; txHash: string } | undefined> {
+  const requirements = input.escrowEntry as {
+    scheme?: unknown;
+    network?: unknown;
+    actions?: { next?: unknown };
+  };
+  if (
+    requirements.scheme !== "escrow" ||
+    typeof requirements.network !== "string" ||
+    !Array.isArray(requirements.actions?.next)
+  ) {
+    return undefined;
+  }
+
+  const commitEntry = (requirements.actions.next as NextAction[]).find(
+    (e) =>
+      (e.id === "boson-createOfferAndCommit" || e.id === "boson-createOfferCommitAndRedeem") &&
+      e.channels.includes("facilitator") &&
+      typeof e.endpoints?.facilitator === "string",
+  );
+  if (commitEntry === undefined) {
+    return undefined;
+  }
+
+  let payload: EscrowPaymentPayload;
+  try {
+    payload = parseEscrowPaymentPayload(JSON.parse(decodeBase64(input.headerValue)));
+  } catch {
+    return undefined;
+  }
+
+  const settleUrl = commitEntry.endpoints!.facilitator!;
+  const body = JSON.stringify({
+    scheme: "escrow",
+    network: requirements.network,
+    payload,
+    requirements,
+  });
+
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(input.originalFetch, settleUrl, body, input.facilitatorTimeoutMs);
+  } catch {
+    return undefined;
+  }
+
+  if (!res.ok) return undefined;
+
+  const parsed = (await res.json().catch(() => null)) as unknown;
+  if (parsed === null || typeof parsed !== "object" || (parsed as { ok?: unknown }).ok !== true) {
+    return undefined;
+  }
+  const ok = parsed as { ok: true; exchangeId?: unknown; txHash?: unknown };
+  if (typeof ok.exchangeId !== "string" || typeof ok.txHash !== "string") {
+    return undefined;
+  }
+  return { ok: true, exchangeId: ok.exchangeId, txHash: ok.txHash };
+}
+
+/**
+ * Build the synthesized fallback `Response` returned to the caller when
+ * the facilitator settled the commit successfully. Status 200 keeps
+ * existing `response.ok` checks happy; the channel header lets callers
+ * detect that the resource body wasn't delivered.
+ */
+function synthesizeCommitFallbackResponse(input: {
+  body: { ok: true; exchangeId: string; txHash: string };
+  serverErrorMarker: string;
+}): Response {
+  const xPaymentResponseBody = {
+    exchangeId: input.body.exchangeId,
+    txHash: input.body.txHash,
+    nextActions: { exchangeState: "COMMITTED" },
+  };
+  const headers = new Headers();
+  headers.set(X_PAYMENT_RESPONSE_HEADER, encodeBase64(JSON.stringify(xPaymentResponseBody)));
+  headers.set(COMMIT_CHANNEL_HEADER, "facilitator");
+  headers.set(SERVER_ERROR_HEADER, input.serverErrorMarker);
+  return new Response(null, { status: 200, headers });
+}
+
+async function fetchWithTimeout(
+  fetcher: typeof fetch,
+  url: string,
+  body: string,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetcher(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function decodeBase64(value: string): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value, "base64").toString("utf8");
+  }
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function encodeBase64(value: string): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value, "utf8").toString("base64");
+  }
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary);
 }

--- a/typescript/packages/client-fetch/test/wrap.test.ts
+++ b/typescript/packages/client-fetch/test/wrap.test.ts
@@ -395,6 +395,26 @@ describe("wrapFetchWithPayment — commit fallback (opt-in)", () => {
     expect(await res.text()).toBe("server down");
   });
 
+  it("commitFallback='auto': network error + facilitator also fails → 599 carries network: marker", async () => {
+    const client = makeClient(VALID_PAYLOAD_BASE64);
+    const fakeFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("https://example/resource")) {
+        if (fakeFetch.mock.calls.length === 1) {
+          return jsonResponse(escrow402Body({ withFacilitatorEndpoint: true }), { status: 402 });
+        }
+        throw new TypeError("connect ECONNREFUSED");
+      }
+      return new Response("facilitator down", { status: 503 });
+    });
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client, { commitFallback: "auto" });
+    const res = await wrapped("https://example/resource");
+
+    expect(res.status).toBe(599);
+    expect(res.headers.get("X-X402-Boson-Server-Error")).toBe("network:connect ECONNREFUSED");
+  });
+
   it("commitFallback='auto': resource-server 4xx does NOT trigger fallback (only 5xx)", async () => {
     const client = makeClient(VALID_PAYLOAD_BASE64);
     const fakeFetch = vi.fn(async (input: RequestInfo | URL) => {

--- a/typescript/packages/client-fetch/test/wrap.test.ts
+++ b/typescript/packages/client-fetch/test/wrap.test.ts
@@ -11,6 +11,37 @@ import type { X402bClient } from "@bosonprotocol/x402-client";
 
 import { wrapFetchWithPayment } from "../src/wrap.js";
 
+// Minimal but schema-valid `EscrowPaymentPayload` JSON, base64-encoded
+// so the commit-fallback path can decode it through
+// `parseEscrowPaymentPayload`. Shape mirrors
+// `core/test/schemes/escrow/fixtures.ts:validPayloadNone`.
+const VALID_PAYLOAD_JSON = {
+  x402Version: 2,
+  scheme: "escrow",
+  network: "eip155:8453",
+  payload: {
+    action: "boson-createOfferAndCommit",
+    tokenAuthStrategy: "none",
+    offerRef: {
+      fullOffer: { id: "0", price: "1000000" },
+      sellerSig: "0xdeadbeef",
+    },
+    buyer: "0x2222222222222222222222222222222222222222",
+    metaTx: {
+      from: "0x2222222222222222222222222222222222222222",
+      nonce: "0",
+      functionName: "createOfferAndCommit(...)",
+      functionSignature: "0xabcd1234",
+      sig: { v: 27, r: `0x${"11".repeat(32)}`, s: `0x${"22".repeat(32)}` },
+    },
+  },
+  fulfillment: { option: "inline" },
+};
+
+const VALID_PAYLOAD_BASE64 = Buffer.from(JSON.stringify(VALID_PAYLOAD_JSON), "utf8").toString(
+  "base64",
+);
+
 function makeClient(headerValue = "base64-encoded-payment"): X402bClient & {
   handle402: Mock;
   parsePaymentResponse: Mock;
@@ -23,7 +54,14 @@ function makeClient(headerValue = "base64-encoded-payment"): X402bClient & {
   };
 }
 
-function escrow402Body() {
+function escrow402Body(options: { withFacilitatorEndpoint?: boolean } = {}) {
+  const channels: string[] = options.withFacilitatorEndpoint
+    ? ["server", "facilitator"]
+    : ["server"];
+  const endpoints: Record<string, string> = { server: "https://example/resource" };
+  if (options.withFacilitatorEndpoint) {
+    endpoints.facilitator = "https://facilitator.example/settle";
+  }
   return {
     x402Version: 2,
     accepts: [
@@ -41,7 +79,9 @@ function escrow402Body() {
           creator: "0x1111111111111111111111111111111111111111",
         },
         tokenAuthStrategies: ["erc3009"],
-        actions: { next: [{ id: "boson-createOfferAndCommit", channels: ["server"] }] },
+        actions: {
+          next: [{ id: "boson-createOfferAndCommit", channels, endpoints }],
+        },
       },
     ],
   };
@@ -181,5 +221,181 @@ describe("wrapFetchWithPayment", () => {
     // initial + 1 retry = 2, never more
     expect(fakeFetch).toHaveBeenCalledTimes(2);
     expect(client.handle402).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("wrapFetchWithPayment — commit fallback (opt-in)", () => {
+  function settleOkBody(): { ok: true; exchangeId: string; txHash: string } {
+    return { ok: true, exchangeId: "42", txHash: "0xdeadbeef" };
+  }
+
+  it("default (commitFallback off): resource-server 5xx after X-PAYMENT bubbles up unchanged", async () => {
+    const client = makeClient(VALID_PAYLOAD_BASE64);
+    const fakeFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(escrow402Body({ withFacilitatorEndpoint: true }), { status: 402 }),
+      )
+      .mockResolvedValueOnce(new Response("boom", { status: 502 }));
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client);
+    const res = await wrapped("https://example/resource");
+
+    expect(res.status).toBe(502);
+    expect(fakeFetch).toHaveBeenCalledTimes(2);
+    // No call to the facilitator URL.
+    expect(
+      fakeFetch.mock.calls.some(
+        (c) => String(c[0] as Request | URL | string) === "https://facilitator.example/settle",
+      ),
+    ).toBe(false);
+  });
+
+  it("commitFallback='auto': resource-server 5xx triggers facilitator settle, returns synthesized 200", async () => {
+    const client = makeClient(VALID_PAYLOAD_BASE64);
+    const fakeFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("https://example/resource")) {
+        if (fakeFetch.mock.calls.length === 1) {
+          return jsonResponse(escrow402Body({ withFacilitatorEndpoint: true }), { status: 402 });
+        }
+        return new Response("boom", { status: 502 });
+      }
+      if (url.startsWith("https://facilitator.example/settle")) {
+        return jsonResponse(settleOkBody(), { status: 200 });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client, { commitFallback: "auto" });
+    const res = await wrapped("https://example/resource");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-X402-Boson-Commit-Channel")).toBe("facilitator");
+    expect(res.headers.get("X-X402-Boson-Server-Error")).toBe("502");
+    expect(res.headers.get("X-PAYMENT-RESPONSE")).toBeTruthy();
+    expect(await res.text()).toBe("");
+
+    // initial 402 + X-PAYMENT retry (502) + facilitator settle (200) = 3
+    expect(fakeFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("commitFallback='auto': X-PAYMENT-RESPONSE header decodes to {exchangeId, txHash, nextActions.exchangeState}", async () => {
+    const client = makeClient(VALID_PAYLOAD_BASE64);
+    const fakeFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("https://example/resource")) {
+        if (fakeFetch.mock.calls.length === 1) {
+          return jsonResponse(escrow402Body({ withFacilitatorEndpoint: true }), { status: 402 });
+        }
+        return new Response("boom", { status: 502 });
+      }
+      return jsonResponse(settleOkBody(), { status: 200 });
+    });
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client, { commitFallback: "auto" });
+    const res = await wrapped("https://example/resource");
+
+    const headerValue = res.headers.get("X-PAYMENT-RESPONSE")!;
+    const decoded = JSON.parse(Buffer.from(headerValue, "base64").toString("utf8"));
+    expect(decoded).toEqual({
+      exchangeId: "42",
+      txHash: "0xdeadbeef",
+      nextActions: { exchangeState: "COMMITTED" },
+    });
+  });
+
+  it("commitFallback='auto': network error on retry triggers fallback, marker carries network: prefix", async () => {
+    const client = makeClient(VALID_PAYLOAD_BASE64);
+    const fakeFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("https://example/resource")) {
+        if (fakeFetch.mock.calls.length === 1) {
+          return jsonResponse(escrow402Body({ withFacilitatorEndpoint: true }), { status: 402 });
+        }
+        throw new TypeError("connect ECONNREFUSED");
+      }
+      return jsonResponse(settleOkBody(), { status: 200 });
+    });
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client, { commitFallback: "auto" });
+    const res = await wrapped("https://example/resource");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-X402-Boson-Commit-Channel")).toBe("facilitator");
+    expect(res.headers.get("X-X402-Boson-Server-Error")).toContain("network:");
+  });
+
+  it("commitFallback='auto' but no facilitator endpoint advertised: surfaces the original 5xx unchanged", async () => {
+    const client = makeClient(VALID_PAYLOAD_BASE64);
+    const fakeFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(escrow402Body(), { status: 402 }))
+      .mockResolvedValueOnce(new Response("boom", { status: 502 }));
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client, { commitFallback: "auto" });
+    const res = await wrapped("https://example/resource");
+
+    expect(res.status).toBe(502);
+    expect(fakeFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("commitFallback='auto': facilitator also fails → original 5xx surfaces", async () => {
+    const client = makeClient(VALID_PAYLOAD_BASE64);
+    const fakeFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("https://example/resource")) {
+        if (fakeFetch.mock.calls.length === 1) {
+          return jsonResponse(escrow402Body({ withFacilitatorEndpoint: true }), { status: 402 });
+        }
+        return new Response("server down", { status: 502 });
+      }
+      return new Response("facilitator down", { status: 503 });
+    });
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client, { commitFallback: "auto" });
+    const res = await wrapped("https://example/resource");
+
+    expect(res.status).toBe(502);
+    expect(await res.text()).toBe("server down");
+  });
+
+  it("commitFallback='auto': resource-server 4xx does NOT trigger fallback (only 5xx)", async () => {
+    const client = makeClient(VALID_PAYLOAD_BASE64);
+    const fakeFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("https://example/resource")) {
+        if (fakeFetch.mock.calls.length === 1) {
+          return jsonResponse(escrow402Body({ withFacilitatorEndpoint: true }), { status: 402 });
+        }
+        return new Response("bad payload", { status: 400 });
+      }
+      return jsonResponse(settleOkBody(), { status: 200 });
+    });
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client, { commitFallback: "auto" });
+    const res = await wrapped("https://example/resource");
+
+    expect(res.status).toBe(400);
+    // initial + retry = 2; no facilitator call.
+    expect(fakeFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("commitFallback='auto': retry success (200) is returned untouched — no fallback path", async () => {
+    const client = makeClient(VALID_PAYLOAD_BASE64);
+    const fakeFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(escrow402Body({ withFacilitatorEndpoint: true }), { status: 402 }),
+      )
+      .mockResolvedValueOnce(new Response("resource-body", { status: 200 }));
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client, { commitFallback: "auto" });
+    const res = await wrapped("https://example/resource");
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("resource-body");
+    expect(res.headers.get("X-X402-Boson-Commit-Channel")).toBeNull();
+    expect(fakeFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/typescript/packages/client-fetch/test/wrap.test.ts
+++ b/typescript/packages/client-fetch/test/wrap.test.ts
@@ -54,7 +54,13 @@ function makeClient(headerValue = "base64-encoded-payment"): X402bClient & {
   };
 }
 
-function escrow402Body(options: { withFacilitatorEndpoint?: boolean } = {}) {
+function escrow402Body(
+  options: {
+    withFacilitatorEndpoint?: boolean;
+    actionId?: "boson-createOfferAndCommit" | "boson-createOfferCommitAndRedeem";
+  } = {},
+) {
+  const actionId = options.actionId ?? "boson-createOfferAndCommit";
   const channels: string[] = options.withFacilitatorEndpoint
     ? ["server", "facilitator"]
     : ["server"];
@@ -80,7 +86,7 @@ function escrow402Body(options: { withFacilitatorEndpoint?: boolean } = {}) {
         },
         tokenAuthStrategies: ["erc3009"],
         actions: {
-          next: [{ id: "boson-createOfferAndCommit", channels, endpoints }],
+          next: [{ id: actionId, channels, endpoints }],
         },
       },
     ],
@@ -303,6 +309,35 @@ describe("wrapFetchWithPayment — commit fallback (opt-in)", () => {
       txHash: "0xdeadbeef",
       nextActions: { exchangeState: "COMMITTED" },
     });
+  });
+
+  it("commitFallback='auto': createOfferCommitAndRedeem fallback reports exchangeState=REDEEMED", async () => {
+    // The atomic commit-and-redeem flow lands the exchange in REDEEMED, not
+    // COMMITTED — the synthesized X-PAYMENT-RESPONSE must reflect that.
+    const client = makeClient(VALID_PAYLOAD_BASE64);
+    const fakeFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("https://example/resource")) {
+        if (fakeFetch.mock.calls.length === 1) {
+          return jsonResponse(
+            escrow402Body({
+              withFacilitatorEndpoint: true,
+              actionId: "boson-createOfferCommitAndRedeem",
+            }),
+            { status: 402 },
+          );
+        }
+        return new Response("boom", { status: 502 });
+      }
+      return jsonResponse(settleOkBody(), { status: 200 });
+    });
+
+    const wrapped = wrapFetchWithPayment(fakeFetch, client, { commitFallback: "auto" });
+    const res = await wrapped("https://example/resource");
+
+    const headerValue = res.headers.get("X-PAYMENT-RESPONSE")!;
+    const decoded = JSON.parse(Buffer.from(headerValue, "base64").toString("utf8"));
+    expect(decoded.nextActions).toEqual({ exchangeState: "REDEEMED" });
   });
 
   it("commitFallback='auto': network error on retry triggers fallback, marker carries network: prefix", async () => {

--- a/typescript/packages/client/src/base64.ts
+++ b/typescript/packages/client/src/base64.ts
@@ -1,0 +1,35 @@
+// Isomorphic base64 helpers used by the X-PAYMENT / X-PAYMENT-RESPONSE
+// header pipeline. Picks `Buffer` on Node and `atob` / `btoa` on
+// browsers — tsup builds both formats, so the runtime branch matters.
+//
+// Browser-side encode goes UTF-8 → binary-string → `btoa` because
+// `btoa` accepts only code units 0–255 and throws
+// `InvalidCharacterError` on any character above U+00FF, while wire
+// payloads can carry free-form fulfillment data populated by the
+// buyer (emails, addresses, notes). Decode does the inverse.
+
+/** Decode a base64-encoded string to UTF-8. */
+export function decodeBase64(value: string): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value, "base64").toString("utf8");
+  }
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+/** Encode a UTF-8 string as base64. */
+export function encodeBase64(value: string): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value, "utf8").toString("base64");
+  }
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary);
+}

--- a/typescript/packages/client/src/client.ts
+++ b/typescript/packages/client/src/client.ts
@@ -28,6 +28,11 @@ import {
 } from "./post-commit.js";
 import { parsePaymentResponse } from "./response.js";
 import {
+  submitAction as submitActionInner,
+  type FulfillmentRequest,
+  type SubmitResult,
+} from "./submit.js";
+import {
   signWithdrawAllAvailableFunds,
   signWithdrawFunds,
   type SignWithdrawAllAvailableFundsArgs,
@@ -37,6 +42,29 @@ import {
 import { buildAndSignTokenAuth } from "./token-auth/index.js";
 import { MaxAmountExceededError, UnsupportedTokenAuthError } from "./errors.js";
 import type { ExchangeSummary, X402bClientConfig } from "./types.js";
+import type { EscrowNextActions } from "@bosonprotocol/x402-core/schemes/escrow";
+
+/**
+ * Args for `client.submitAction`. Layered over `SignActionArgs`: the
+ * client signs the meta-tx, then resolves the matching `NextAction`
+ * entry on `priorNextActions` and walks its `channels[]` (server →
+ * facilitator) until the first 2xx. See `submit.ts` for the channel
+ * walk semantics; see `signAction` for the signing args.
+ */
+export type SubmitActionArgs = SignActionArgs & {
+  /**
+   * The `nextActions` envelope returned by the prior server response.
+   * Used to read `channels[]` + `endpoints[channel]` for the entry
+   * matching `actionId`.
+   */
+  priorNextActions: EscrowNextActions;
+  /** Redeem-only fulfillment payload — forwarded to the `server` channel body. */
+  fulfillment?: FulfillmentRequest;
+  /** Override the default `globalThis.fetch`. Useful for tests / custom transports. */
+  fetch?: typeof globalThis.fetch;
+  /** Per-channel timeout in milliseconds. Default 10000. */
+  timeoutMs?: number;
+};
 
 export interface X402bClient {
   /**
@@ -62,6 +90,26 @@ export interface X402bClient {
    * of MVP.
    */
   signAction(args: SignActionArgs): Promise<SignedPostCommitAction>;
+
+  /**
+   * Sign a buyer post-commit action via {@link X402bClient.signAction} and
+   * submit it through the first responsive HTTP channel the seller
+   * advertised on the matching `nextActions.next[]` entry. Order is taken
+   * from `priorNextActions` (the envelope from the prior server response);
+   * the walk is intersected with `["server", "facilitator"]` — `onchain` /
+   * `mcp` / `xmtp` channels are out of scope for this method.
+   *
+   * Falls back to the next channel on **5xx / network error / timeout**.
+   * Stops and throws on **4xx** (a buyer-side payload error fallback
+   * can't fix — masking it would hide bugs). Throws
+   * `NoCompatibleChannelError` when the matching entry advertises only
+   * non-HTTP channels, and `AllChannelsFailedError` when every attempt
+   * failed.
+   *
+   * Pre-existing callers that prefer to keep submission outside the SDK
+   * can still use `signAction` + their own dispatch.
+   */
+  submitAction(args: SubmitActionArgs): Promise<SubmitResult>;
 
   /**
    * Sign a `withdrawFunds(entityId, tokenList, tokenAmounts)` meta-tx.
@@ -183,6 +231,27 @@ export function createX402bClient(config: X402bClientConfig): X402bClient {
 
     signAction(args) {
       return signPostCommitAction(args, { buildCoreSdk, getBuyerAddress });
+    },
+
+    async submitAction(args) {
+      const signed = await signPostCommitAction(args, { buildCoreSdk, getBuyerAddress });
+      const action = args.priorNextActions.next.find((entry) => entry.id === args.actionId);
+      if (action === undefined) {
+        throw new Error(
+          `x402-client/submitAction: actionId '${args.actionId}' is not present in priorNextActions.next[]`,
+        );
+      }
+      const submitArgs = {
+        action,
+        signed,
+        exchangeId: String(args.exchangeId),
+        network: args.network,
+        escrowAddress: args.escrowAddress,
+        fulfillment: args.fulfillment,
+        fetch: args.fetch,
+        timeoutMs: args.timeoutMs,
+      };
+      return submitActionInner(submitArgs);
     },
 
     signWithdrawFunds(args) {

--- a/typescript/packages/client/src/index.ts
+++ b/typescript/packages/client/src/index.ts
@@ -27,6 +27,7 @@ export {
 } from "./errors.js";
 
 export { pickAction } from "./action.js";
+export { decodeBase64, encodeBase64 } from "./base64.js";
 export { resolveFulfillment, type ResolvedFulfillment } from "./fulfillment.js";
 export { parseChainId } from "./core-sdk-factory.js";
 export { parsePaymentResponse } from "./response.js";

--- a/typescript/packages/client/src/index.ts
+++ b/typescript/packages/client/src/index.ts
@@ -30,13 +30,24 @@ export { pickAction } from "./action.js";
 export { resolveFulfillment, type ResolvedFulfillment } from "./fulfillment.js";
 export { parseChainId } from "./core-sdk-factory.js";
 export { parsePaymentResponse } from "./response.js";
-export { createX402bClient, type X402bClient } from "./client.js";
+export { createX402bClient, type SubmitActionArgs, type X402bClient } from "./client.js";
 export type {
   ResolveDisputeArgs,
   SignActionArgs,
   SignedPostCommitAction,
   SimplePostCommitArgs,
 } from "./post-commit.js";
+export {
+  AllChannelsFailedError,
+  NoCompatibleChannelError,
+  submitAction,
+  type ChannelAttempt,
+  type ChannelFailureReason,
+  type FulfillmentRequest,
+  type SubmitArgs,
+  type SubmitChannel,
+  type SubmitResult,
+} from "./submit.js";
 export type {
   SignWithdrawAllAvailableFundsArgs,
   SignWithdrawFundsArgs,

--- a/typescript/packages/client/src/payload.ts
+++ b/typescript/packages/client/src/payload.ts
@@ -3,8 +3,9 @@
 // Defense-in-depth: the assembled `EscrowPaymentPayload` is re-validated
 // through `parseEscrowPaymentPayload` from `@bosonprotocol/x402-core`
 // before serialization, so shape bugs surface here instead of at the
-// server. Base64 encoding picks `Buffer` on Node and `btoa` on browser
-// targets — tsup builds both, so the runtime branch matters.
+// server. Base64 encoding goes through the isomorphic `encodeBase64`
+// helper from `./base64.js` — `Buffer` on Node, UTF-8-aware
+// `btoa` on browsers.
 
 import {
   parseEscrowPaymentPayload,
@@ -16,6 +17,7 @@ import {
 } from "@bosonprotocol/x402-core/schemes/escrow";
 import type { Address } from "viem";
 
+import { encodeBase64 } from "./base64.js";
 import type { ResolvedFulfillment } from "./fulfillment.js";
 
 /** Current x402 protocol version embedded in the payload envelope. */
@@ -79,21 +81,5 @@ export function assemblePayload({
 /** Build, validate, and base64-encode the payload for the `X-PAYMENT` header. */
 export function assembleAndEncodePayload(args: AssembleArgs): string {
   const payload = assemblePayload(args);
-  const json = JSON.stringify(payload);
-  if (typeof Buffer !== "undefined") {
-    return Buffer.from(json, "utf8").toString("base64");
-  }
-  // Browser fallback. Wire payloads mostly carry hex/numeric strings,
-  // but atomic Flow B's `fulfillment.data` is a `Record<string, unknown>`
-  // the buyer populates — emails, addresses, free-form notes. `btoa`
-  // accepts only a binary string (code units 0–255) and throws
-  // `InvalidCharacterError` on any character above U+00FF. UTF-8 encode
-  // the JSON first, then map the bytes into the binary-string form
-  // `btoa` expects.
-  const bytes = new TextEncoder().encode(json);
-  let binary = "";
-  for (const b of bytes) {
-    binary += String.fromCharCode(b);
-  }
-  return btoa(binary);
+  return encodeBase64(JSON.stringify(payload));
 }

--- a/typescript/packages/client/src/response.ts
+++ b/typescript/packages/client/src/response.ts
@@ -7,6 +7,7 @@
 // the common property paths an x402B server might use. Callers who need
 // stronger guarantees can read `raw` directly.
 
+import { decodeBase64 } from "./base64.js";
 import type { ExchangeSummary } from "./types.js";
 
 const HEADER_NAME = "X-PAYMENT-RESPONSE";
@@ -99,18 +100,6 @@ function isClientStateShape(v: unknown): v is NonNullable<ExchangeSummary["state
     return false;
   }
   return true;
-}
-
-function decodeBase64(value: string): string {
-  if (typeof Buffer !== "undefined") {
-    return Buffer.from(value, "base64").toString("utf8");
-  }
-  const binary = atob(value);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return new TextDecoder().decode(bytes);
 }
 
 function pickString(obj: Record<string, unknown>, keys: string[]): string | undefined {

--- a/typescript/packages/client/src/submit.ts
+++ b/typescript/packages/client/src/submit.ts
@@ -39,9 +39,18 @@ const SUBMIT_CHANNELS: readonly SubmitChannel[] = ["server", "facilitator"];
  * configuration gap (channel advertised, but no URL listed under
  * `action.endpoints`) — distinct from a real transport-level
  * `"network"` failure so callers branching on `reason` can tell the
- * two apart.
+ * two apart. `"invalid-response"` covers 2xx replies whose body
+ * doesn't match the channel's expected shape — the server replied
+ * but with something we can't make sense of, treated as a
+ * recoverable failure (the next channel is tried).
  */
-export type ChannelFailureReason = "5xx" | "4xx" | "network" | "timeout" | "no-endpoint";
+export type ChannelFailureReason =
+  | "5xx"
+  | "4xx"
+  | "network"
+  | "timeout"
+  | "no-endpoint"
+  | "invalid-response";
 
 /** Per-channel attempt record — every walk-step appended to `attempts[]`. */
 export type ChannelAttempt =
@@ -224,9 +233,20 @@ async function attemptChannel(input: {
       attempt: { channel, ok: false, reason: "5xx", status: res.status },
     };
   }
-  if (!res.ok || parsed === null || typeof parsed !== "object") {
+  if (!res.ok) {
     return {
       attempt: { channel, ok: false, reason: "4xx", status: res.status },
+    };
+  }
+  if (parsed === null || typeof parsed !== "object") {
+    return {
+      attempt: {
+        channel,
+        ok: false,
+        reason: "invalid-response",
+        status: res.status,
+        message: "response body is not a JSON object",
+      },
     };
   }
 
@@ -237,12 +257,19 @@ async function attemptChannel(input: {
       attempt: { channel, ok: true, status: res.status },
       result: { ...result, channelUsed: channel },
     };
-  } catch {
-    // Body parsed as JSON but doesn't match the expected shape — treat
-    // as a 4xx (the channel responded with a 200 we can't make sense of;
-    // falling back wouldn't help because the issue is upstream).
+  } catch (e) {
+    // 2xx body parsed as JSON but doesn't match the expected shape — the
+    // server replied with something we can't make sense of. Treat as
+    // recoverable so the next channel gets a chance (vs. a 4xx, which
+    // is terminal because no other channel can fix the buyer's payload).
     return {
-      attempt: { channel, ok: false, reason: "4xx", status: res.status },
+      attempt: {
+        channel,
+        ok: false,
+        reason: "invalid-response",
+        status: res.status,
+        message: e instanceof Error ? e.message : String(e),
+      },
     };
   }
 }

--- a/typescript/packages/client/src/submit.ts
+++ b/typescript/packages/client/src/submit.ts
@@ -1,0 +1,368 @@
+// Channel-aware submitter for buyer-driven post-commit actions.
+//
+// Given a `NextAction` entry (from a prior server response's
+// `nextActions.next[]`) and a signed payload, walk the action's
+// advertised `channels` in order, intersected with the channels this
+// submitter knows how to drive over HTTP (`server`, `facilitator`).
+// Stop at the first 2xx and return the normalized result; treat 5xx /
+// network errors / timeouts as a signal to fall back; treat 4xx as
+// terminal (a buyer-side payload error fallback can't fix — masking it
+// would hide bugs).
+//
+// `onchain` / `mcp` / `xmtp` channels stay out of this module: the
+// onchain submitter needs a wallet client plumbed through client config
+// and tx-receipt waiting; the agentic channels need a separate
+// `@bosonprotocol/x402-agent` package that isn't shipped. Callers whose
+// `action.channels` only list those will hit `NoCompatibleChannelError`.
+//
+// The server channel returns the rich `{ txHash, nextActions, fulfillment? }`
+// envelope; the facilitator's `/perform-action` returns only
+// `{ ok: true, txHash, newExchangeState, newDisputeState? }`. The result
+// is normalized to the intersection — `nextActions` is surfaced when
+// the server channel handled the action, omitted when the facilitator
+// did (callers that need a fresh envelope after a facilitator fallback
+// can re-derive it server-side or read it from the next response).
+
+import type { EscrowNextActions, NextAction } from "@bosonprotocol/x402-core/schemes/escrow";
+import { DisputeState, ExchangeState, type ActionId } from "@bosonprotocol/x402-core/state-machine";
+import type { Address, Hex } from "viem";
+
+import type { SignedPostCommitAction } from "./post-commit.js";
+
+/** Channels this submitter drives over HTTP. */
+export type SubmitChannel = "server" | "facilitator";
+
+const SUBMIT_CHANNELS: readonly SubmitChannel[] = ["server", "facilitator"];
+
+/** Why a channel attempt didn't yield a 2xx. */
+export type ChannelFailureReason = "5xx" | "4xx" | "network" | "timeout";
+
+/** Per-channel attempt record — every walk-step appended to `attempts[]`. */
+export type ChannelAttempt =
+  | { channel: SubmitChannel; ok: true; status: number }
+  | {
+      channel: SubmitChannel;
+      ok: false;
+      reason: ChannelFailureReason;
+      status?: number;
+      message?: string;
+    };
+
+/** Caller passes `{ option, data }` for the redeem-only fulfillment payload. */
+export interface FulfillmentRequest {
+  option: string;
+  data: Record<string, unknown> | null;
+}
+
+export interface SubmitArgs {
+  action: NextAction;
+  signed: SignedPostCommitAction;
+  exchangeId: string;
+  /** CAIP-2 (e.g. `"eip155:31337"`). Required by the facilitator route. */
+  network: string;
+  /** Boson Diamond address. Required by the facilitator route. */
+  escrowAddress: Address;
+  /** Redeem-only — forwarded to the `server` channel body; ignored by `facilitator`. */
+  fulfillment?: FulfillmentRequest;
+  /** Defaults to `globalThis.fetch`. */
+  fetch?: typeof globalThis.fetch;
+  /** Per-channel timeout in milliseconds. Defaults to 10000. */
+  timeoutMs?: number;
+}
+
+export interface SubmitResult {
+  txHash: Hex;
+  newExchangeState: ExchangeState;
+  newDisputeState?: DisputeState;
+  /** Present only when the `server` channel handled the action. */
+  nextActions?: EscrowNextActions;
+  channelUsed: SubmitChannel;
+  attempts: readonly ChannelAttempt[];
+}
+
+/** Thrown when no advertised channel matches one this submitter can drive. */
+export class NoCompatibleChannelError extends Error {
+  readonly actionId: string;
+  readonly advertisedChannels: readonly string[];
+  constructor(actionId: string, advertisedChannels: readonly string[]) {
+    super(
+      `x402-client: action '${actionId}' advertises channels [${advertisedChannels.join(", ")}] but none are submittable over HTTP (server / facilitator).`,
+    );
+    this.name = "NoCompatibleChannelError";
+    this.actionId = actionId;
+    this.advertisedChannels = advertisedChannels;
+  }
+}
+
+/**
+ * Thrown when every attempted channel failed. Carries the per-channel
+ * attempt log so callers can branch on the final cause (e.g. 4xx from
+ * the server → buyer payload bug; 5xx from both → outage).
+ */
+export class AllChannelsFailedError extends Error {
+  readonly attempts: readonly ChannelAttempt[];
+  constructor(actionId: string, attempts: readonly ChannelAttempt[]) {
+    super(
+      `x402-client: action '${actionId}' failed on every attempted channel — ${attempts
+        .map((a) => formatAttempt(a))
+        .join("; ")}`,
+    );
+    this.name = "AllChannelsFailedError";
+    this.attempts = attempts;
+  }
+}
+
+function formatAttempt(a: ChannelAttempt): string {
+  if (a.ok) return `${a.channel}=ok(${a.status})`;
+  const tail = a.status !== undefined ? `(${a.status})` : "";
+  return `${a.channel}=${a.reason}${tail}`;
+}
+
+/**
+ * Submit a signed post-commit action through the first responsive HTTP
+ * channel advertised on `action.channels`. Returns the normalized result
+ * on first 2xx; throws `NoCompatibleChannelError` when no submittable
+ * channel is advertised, or `AllChannelsFailedError` when every attempt
+ * failed.
+ */
+export async function submitAction(args: SubmitArgs): Promise<SubmitResult> {
+  const fetcher = args.fetch ?? globalThis.fetch.bind(globalThis);
+  const timeoutMs = args.timeoutMs ?? 10_000;
+
+  const ordered = orderedChannels(args.action);
+  if (ordered.length === 0) {
+    throw new NoCompatibleChannelError(args.action.id, args.action.channels);
+  }
+
+  const attempts: ChannelAttempt[] = [];
+  for (const channel of ordered) {
+    const endpoint = args.action.endpoints?.[channel];
+    if (endpoint === undefined) {
+      attempts.push({
+        channel,
+        ok: false,
+        reason: "network",
+        message: `no endpoint advertised for channel '${channel}'`,
+      });
+      continue;
+    }
+
+    const outcome = await attemptChannel({
+      channel,
+      endpoint,
+      args,
+      fetcher,
+      timeoutMs,
+    });
+    attempts.push(outcome.attempt);
+
+    if (outcome.attempt.ok && outcome.result !== undefined) {
+      return { ...outcome.result, attempts };
+    }
+    if (!outcome.attempt.ok && outcome.attempt.reason === "4xx") {
+      // 4xx is a buyer-payload error — no fallback can fix it; surface it.
+      throw new AllChannelsFailedError(args.action.id, attempts);
+    }
+  }
+
+  throw new AllChannelsFailedError(args.action.id, attempts);
+}
+
+function orderedChannels(action: NextAction): SubmitChannel[] {
+  const seen = new Set<SubmitChannel>();
+  const out: SubmitChannel[] = [];
+  for (const c of action.channels) {
+    if ((SUBMIT_CHANNELS as readonly string[]).includes(c) && !seen.has(c as SubmitChannel)) {
+      seen.add(c as SubmitChannel);
+      out.push(c as SubmitChannel);
+    }
+  }
+  return out;
+}
+
+interface AttemptOutcome {
+  attempt: ChannelAttempt;
+  /** Set when `attempt.ok === true`. */
+  result?: Omit<SubmitResult, "attempts">;
+}
+
+async function attemptChannel(input: {
+  channel: SubmitChannel;
+  endpoint: string;
+  args: SubmitArgs;
+  fetcher: typeof globalThis.fetch;
+  timeoutMs: number;
+}): Promise<AttemptOutcome> {
+  const { channel, endpoint, args, fetcher, timeoutMs } = input;
+
+  const body = channel === "server" ? buildServerBody(args) : buildFacilitatorBody(args);
+
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(fetcher, endpoint, body, timeoutMs);
+  } catch (e) {
+    const reason = isTimeout(e) ? "timeout" : "network";
+    return {
+      attempt: {
+        channel,
+        ok: false,
+        reason,
+        message: e instanceof Error ? e.message : String(e),
+      },
+    };
+  }
+
+  const parsed = (await res.json().catch(() => null)) as unknown;
+  if (res.status >= 500) {
+    return {
+      attempt: { channel, ok: false, reason: "5xx", status: res.status },
+    };
+  }
+  if (!res.ok || parsed === null || typeof parsed !== "object") {
+    return {
+      attempt: { channel, ok: false, reason: "4xx", status: res.status },
+    };
+  }
+
+  try {
+    const result =
+      channel === "server" ? parseServerResult(parsed) : parseFacilitatorResult(parsed);
+    return {
+      attempt: { channel, ok: true, status: res.status },
+      result: { ...result, channelUsed: channel },
+    };
+  } catch {
+    // Body parsed as JSON but doesn't match the expected shape — treat
+    // as a 4xx (the channel responded with a 200 we can't make sense of;
+    // falling back wouldn't help because the issue is upstream).
+    return {
+      attempt: { channel, ok: false, reason: "4xx", status: res.status },
+    };
+  }
+}
+
+function buildServerBody(args: SubmitArgs): unknown {
+  const body: Record<string, unknown> = {
+    exchangeId: args.exchangeId,
+    signedPayload: args.signed.signedPayload,
+  };
+  if (args.action.id === "boson-redeem" && args.fulfillment !== undefined) {
+    body.fulfillment = args.fulfillment;
+  }
+  return body;
+}
+
+function buildFacilitatorBody(args: SubmitArgs): unknown {
+  return {
+    action: args.action.id as ActionId,
+    exchangeId: args.exchangeId,
+    network: args.network,
+    escrowAddress: args.escrowAddress,
+    signedPayload: args.signed.signedPayload,
+  };
+}
+
+async function fetchWithTimeout(
+  fetcher: typeof globalThis.fetch,
+  endpoint: string,
+  body: unknown,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new TimeoutError(timeoutMs)), timeoutMs);
+  try {
+    return await fetcher(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+class TimeoutError extends Error {
+  readonly isTimeout = true as const;
+  constructor(timeoutMs: number) {
+    super(`x402-client/submit: channel attempt timed out after ${timeoutMs}ms`);
+    this.name = "TimeoutError";
+  }
+}
+
+function isTimeout(e: unknown): boolean {
+  if (e instanceof TimeoutError) return true;
+  if (typeof e !== "object" || e === null) return false;
+  const obj = e as { name?: unknown; isTimeout?: unknown; cause?: unknown };
+  if (obj.isTimeout === true) return true;
+  if (obj.name === "AbortError" || obj.name === "TimeoutError") return true;
+  // `AbortController.abort(reason)` surfaces the reason on `.cause` for
+  // fetch implementations that wrap it; check one level deep.
+  if (typeof obj.cause === "object" && obj.cause !== null) {
+    const cause = obj.cause as { isTimeout?: unknown; name?: unknown };
+    if (cause.isTimeout === true) return true;
+    if (cause.name === "TimeoutError") return true;
+  }
+  return false;
+}
+
+function parseServerResult(body: unknown): Omit<SubmitResult, "attempts" | "channelUsed"> {
+  if (typeof body !== "object" || body === null) {
+    throw new Error("server response body is not an object");
+  }
+  const raw = body as {
+    txHash?: unknown;
+    nextActions?: {
+      exchangeState?: unknown;
+      disputeState?: unknown;
+      next?: unknown;
+      exchangeId?: unknown;
+      fallback?: unknown;
+    };
+  };
+  const txHash = raw.txHash;
+  const exchangeState = raw.nextActions?.exchangeState;
+  if (typeof txHash !== "string" || !isExchangeState(exchangeState)) {
+    throw new Error("server response missing txHash or nextActions.exchangeState");
+  }
+  const out: Omit<SubmitResult, "attempts" | "channelUsed"> = {
+    txHash: txHash as Hex,
+    newExchangeState: exchangeState,
+    nextActions: raw.nextActions as EscrowNextActions,
+  };
+  if (isDisputeState(raw.nextActions?.disputeState)) {
+    out.newDisputeState = raw.nextActions.disputeState;
+  }
+  return out;
+}
+
+function parseFacilitatorResult(body: unknown): Omit<SubmitResult, "attempts" | "channelUsed"> {
+  if (typeof body !== "object" || body === null) {
+    throw new Error("facilitator response body is not an object");
+  }
+  const raw = body as {
+    ok?: unknown;
+    txHash?: unknown;
+    newExchangeState?: unknown;
+    newDisputeState?: unknown;
+  };
+  if (raw.ok !== true || typeof raw.txHash !== "string" || !isExchangeState(raw.newExchangeState)) {
+    throw new Error("facilitator response missing ok/txHash/newExchangeState");
+  }
+  const out: Omit<SubmitResult, "attempts" | "channelUsed"> = {
+    txHash: raw.txHash as Hex,
+    newExchangeState: raw.newExchangeState,
+  };
+  if (isDisputeState(raw.newDisputeState)) {
+    out.newDisputeState = raw.newDisputeState;
+  }
+  return out;
+}
+
+function isExchangeState(v: unknown): v is ExchangeState {
+  return typeof v === "string" && (Object.values(ExchangeState) as string[]).includes(v);
+}
+
+function isDisputeState(v: unknown): v is DisputeState {
+  return typeof v === "string" && (Object.values(DisputeState) as string[]).includes(v);
+}

--- a/typescript/packages/client/src/submit.ts
+++ b/typescript/packages/client/src/submit.ts
@@ -355,11 +355,11 @@ function parseServerResult(body: unknown): Omit<SubmitResult, "attempts" | "chan
   };
   const txHash = raw.txHash;
   const exchangeState = raw.nextActions?.exchangeState;
-  if (typeof txHash !== "string" || !isExchangeState(exchangeState)) {
+  if (!isHexHash(txHash) || !isExchangeState(exchangeState)) {
     throw new Error("server response missing txHash or nextActions.exchangeState");
   }
   const out: Omit<SubmitResult, "attempts" | "channelUsed"> = {
-    txHash: txHash as Hex,
+    txHash,
     newExchangeState: exchangeState,
     nextActions: raw.nextActions as EscrowNextActions,
   };
@@ -379,17 +379,27 @@ function parseFacilitatorResult(body: unknown): Omit<SubmitResult, "attempts" | 
     newExchangeState?: unknown;
     newDisputeState?: unknown;
   };
-  if (raw.ok !== true || typeof raw.txHash !== "string" || !isExchangeState(raw.newExchangeState)) {
+  if (raw.ok !== true || !isHexHash(raw.txHash) || !isExchangeState(raw.newExchangeState)) {
     throw new Error("facilitator response missing ok/txHash/newExchangeState");
   }
   const out: Omit<SubmitResult, "attempts" | "channelUsed"> = {
-    txHash: raw.txHash as Hex,
+    txHash: raw.txHash,
     newExchangeState: raw.newExchangeState,
   };
   if (isDisputeState(raw.newDisputeState)) {
     out.newDisputeState = raw.newDisputeState;
   }
   return out;
+}
+
+// Standard EVM tx-hash shape: `0x` + 64 hex chars (32 bytes). Validating
+// here ensures invalid hashes (e.g. test placeholders, garbled
+// payloads) don't slip through as typed-success results that break
+// downstream consumers expecting a real `Hex`.
+const TX_HASH_RE = /^0x[0-9a-fA-F]{64}$/;
+
+function isHexHash(v: unknown): v is Hex {
+  return typeof v === "string" && TX_HASH_RE.test(v);
 }
 
 function isExchangeState(v: unknown): v is ExchangeState {

--- a/typescript/packages/client/src/submit.ts
+++ b/typescript/packages/client/src/submit.ts
@@ -34,8 +34,14 @@ export type SubmitChannel = "server" | "facilitator";
 
 const SUBMIT_CHANNELS: readonly SubmitChannel[] = ["server", "facilitator"];
 
-/** Why a channel attempt didn't yield a 2xx. */
-export type ChannelFailureReason = "5xx" | "4xx" | "network" | "timeout";
+/**
+ * Why a channel attempt didn't yield a 2xx. `"no-endpoint"` is a
+ * configuration gap (channel advertised, but no URL listed under
+ * `action.endpoints`) — distinct from a real transport-level
+ * `"network"` failure so callers branching on `reason` can tell the
+ * two apart.
+ */
+export type ChannelFailureReason = "5xx" | "4xx" | "network" | "timeout" | "no-endpoint";
 
 /** Per-channel attempt record — every walk-step appended to `attempts[]`. */
 export type ChannelAttempt =
@@ -141,7 +147,7 @@ export async function submitAction(args: SubmitArgs): Promise<SubmitResult> {
       attempts.push({
         channel,
         ok: false,
-        reason: "network",
+        reason: "no-endpoint",
         message: `no endpoint advertised for channel '${channel}'`,
       });
       continue;

--- a/typescript/packages/client/src/submit.ts
+++ b/typescript/packages/client/src/submit.ts
@@ -75,7 +75,7 @@ export interface SubmitArgs {
   exchangeId: string;
   /** CAIP-2 (e.g. `"eip155:31337"`). Required by the facilitator route. */
   network: string;
-  /** Boson Diamond address. Required by the facilitator route. */
+  /** Escrow contract address. Required by the facilitator route. */
   escrowAddress: Address;
   /** Redeem-only — forwarded to the `server` channel body; ignored by `facilitator`. */
   fulfillment?: FulfillmentRequest;

--- a/typescript/packages/client/test/submit.test.ts
+++ b/typescript/packages/client/test/submit.test.ts
@@ -1,0 +1,241 @@
+// Unit tests for the channel-aware post-commit submitter.
+//
+// Drives `submitAction` against a vi-mocked fetch and verifies:
+//   - server-channel happy path (single attempt, full envelope surfaced),
+//   - 5xx on server triggers facilitator fallback,
+//   - 4xx on server is terminal (no fallback),
+//   - timeout / network error triggers fallback,
+//   - no-compatible-channel + all-channels-failed errors,
+//   - body shape per channel (server expects { exchangeId, signedPayload };
+//     facilitator expects the envelope with `action` + `network` + …),
+//   - redeem-only fulfillment payload only goes on the server-channel body.
+
+import type { NextAction } from "@bosonprotocol/x402-core/schemes/escrow";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SignedPostCommitAction } from "../src/post-commit.js";
+import {
+  AllChannelsFailedError,
+  NoCompatibleChannelError,
+  submitAction,
+  type SubmitArgs,
+} from "../src/submit.js";
+
+const ESCROW = "0xdddddddddddddddddddddddddddddddddddddddd" as const;
+const NETWORK = "eip155:31337";
+const EXCHANGE_ID = "42";
+
+const SERVER_URL = "https://server.example/x402B/redeem";
+const FACILITATOR_URL = "https://facilitator.example/perform-action?action=boson-redeem";
+
+const SIGNED: SignedPostCommitAction = {
+  metaTx: {
+    from: "0x2222222222222222222222222222222222222222",
+    nonce: "1",
+    functionName: "redeemVoucher(uint256)",
+    functionSignature: "0xdeadbeef",
+    sig: { v: 27, r: `0x${"01".repeat(32)}`, s: `0x${"02".repeat(32)}` },
+  },
+  signedPayload: `0x${"cd".repeat(64)}`,
+};
+
+function makeAction(overrides: Partial<NextAction> = {}): NextAction {
+  return {
+    id: "boson-redeem",
+    channels: ["server", "facilitator"],
+    endpoints: { server: SERVER_URL, facilitator: FACILITATOR_URL },
+    ...overrides,
+  };
+}
+
+function makeArgs(overrides: Partial<SubmitArgs> = {}): SubmitArgs {
+  return {
+    action: makeAction(),
+    signed: SIGNED,
+    exchangeId: EXCHANGE_ID,
+    network: NETWORK,
+    escrowAddress: ESCROW,
+    ...overrides,
+  };
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const SERVER_OK_BODY = {
+  txHash: "0xredeemtx",
+  nextActions: {
+    exchangeId: EXCHANGE_ID,
+    exchangeState: "REDEEMED",
+    next: [{ id: "boson-completeExchange", channels: ["server"] }],
+  },
+};
+
+const FACILITATOR_OK_BODY = {
+  ok: true,
+  txHash: "0xredeemtx",
+  newExchangeState: "REDEEMED",
+};
+
+describe("submitAction", () => {
+  it("server channel 2xx → returns normalized result with nextActions and channelUsed='server'", async () => {
+    const fetcher = vi.fn(async () => jsonResponse(200, SERVER_OK_BODY));
+    const result = await submitAction(makeArgs({ fetch: fetcher as unknown as typeof fetch }));
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher.mock.calls[0]?.[0]).toBe(SERVER_URL);
+    expect(result.channelUsed).toBe("server");
+    expect(result.txHash).toBe("0xredeemtx");
+    expect(result.newExchangeState).toBe("REDEEMED");
+    expect(result.nextActions).toBeDefined();
+    expect(result.attempts).toEqual([{ channel: "server", ok: true, status: 200 }]);
+  });
+
+  it("server channel 5xx → falls back to facilitator and surfaces facilitator result", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo) => {
+      if (String(input) === SERVER_URL) return jsonResponse(502, { code: "BAD_GATEWAY" });
+      return jsonResponse(200, FACILITATOR_OK_BODY);
+    });
+    const result = await submitAction(makeArgs({ fetch: fetcher as unknown as typeof fetch }));
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(result.channelUsed).toBe("facilitator");
+    expect(result.txHash).toBe("0xredeemtx");
+    expect(result.newExchangeState).toBe("REDEEMED");
+    // Facilitator route doesn't emit nextActions; result.nextActions stays unset.
+    expect(result.nextActions).toBeUndefined();
+    expect(result.attempts).toEqual([
+      { channel: "server", ok: false, reason: "5xx", status: 502 },
+      { channel: "facilitator", ok: true, status: 200 },
+    ]);
+  });
+
+  it("server channel 4xx → terminal (no fallback), throws AllChannelsFailedError", async () => {
+    const fetcher = vi.fn(async () => jsonResponse(400, { code: "BAD_PAYLOAD" }));
+    await expect(
+      submitAction(makeArgs({ fetch: fetcher as unknown as typeof fetch })),
+    ).rejects.toBeInstanceOf(AllChannelsFailedError);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("server channel network error → falls back to facilitator", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo) => {
+      if (String(input) === SERVER_URL) {
+        throw new TypeError("fetch failed");
+      }
+      return jsonResponse(200, FACILITATOR_OK_BODY);
+    });
+    const result = await submitAction(makeArgs({ fetch: fetcher as unknown as typeof fetch }));
+    expect(result.channelUsed).toBe("facilitator");
+    expect(result.attempts[0]).toMatchObject({
+      channel: "server",
+      ok: false,
+      reason: "network",
+    });
+  });
+
+  it("both channels 5xx → throws AllChannelsFailedError with both attempt records", async () => {
+    const fetcher = vi.fn(async () => jsonResponse(503, { code: "DOWN" }));
+    await expect(
+      submitAction(makeArgs({ fetch: fetcher as unknown as typeof fetch })),
+    ).rejects.toBeInstanceOf(AllChannelsFailedError);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("action advertises only non-HTTP channels → throws NoCompatibleChannelError without calling fetch", async () => {
+    const fetcher = vi.fn();
+    await expect(
+      submitAction(
+        makeArgs({
+          action: makeAction({ channels: ["mcp", "onchain"] }),
+          fetch: fetcher as unknown as typeof fetch,
+        }),
+      ),
+    ).rejects.toBeInstanceOf(NoCompatibleChannelError);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("channel advertised without an endpoint → skipped, attempt logged, fallback proceeds", async () => {
+    const fetcher = vi.fn(async () => jsonResponse(200, FACILITATOR_OK_BODY));
+    const result = await submitAction(
+      makeArgs({
+        action: makeAction({ endpoints: { facilitator: FACILITATOR_URL } }),
+        fetch: fetcher as unknown as typeof fetch,
+      }),
+    );
+    expect(result.channelUsed).toBe("facilitator");
+    expect(result.attempts[0]).toMatchObject({ channel: "server", ok: false, reason: "network" });
+  });
+
+  it("server channel body contains exchangeId + signedPayload (and fulfillment when provided)", async () => {
+    const fetcher = vi.fn(async () => jsonResponse(200, SERVER_OK_BODY));
+    await submitAction(
+      makeArgs({
+        fulfillment: { option: "inline", data: { foo: "bar" } },
+        fetch: fetcher as unknown as typeof fetch,
+      }),
+    );
+    const req = fetcher.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(req.body))).toEqual({
+      exchangeId: EXCHANGE_ID,
+      signedPayload: SIGNED.signedPayload,
+      fulfillment: { option: "inline", data: { foo: "bar" } },
+    });
+  });
+
+  it("facilitator channel body contains action + network + escrowAddress + signedPayload (no fulfillment)", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo) => {
+      if (String(input) === SERVER_URL) return jsonResponse(500, {});
+      return jsonResponse(200, FACILITATOR_OK_BODY);
+    });
+    await submitAction(
+      makeArgs({
+        fulfillment: { option: "inline", data: { foo: "bar" } },
+        fetch: fetcher as unknown as typeof fetch,
+      }),
+    );
+    const facilitatorCall = fetcher.mock.calls.find((c) => String(c[0]) === FACILITATOR_URL);
+    expect(facilitatorCall).toBeDefined();
+    const req = facilitatorCall![1] as RequestInit;
+    expect(JSON.parse(String(req.body))).toEqual({
+      action: "boson-redeem",
+      exchangeId: EXCHANGE_ID,
+      network: NETWORK,
+      escrowAddress: ESCROW,
+      signedPayload: SIGNED.signedPayload,
+    });
+  });
+
+  it("DISPUTED post-commit response surfaces newDisputeState", async () => {
+    const body = {
+      txHash: "0xdispute",
+      nextActions: {
+        exchangeId: EXCHANGE_ID,
+        exchangeState: "DISPUTED",
+        disputeState: "RESOLVING",
+        next: [{ id: "boson-retractDispute", channels: ["server"] }],
+      },
+    };
+    const fetcher = vi.fn(async () => jsonResponse(200, body));
+    const result = await submitAction(makeArgs({ fetch: fetcher as unknown as typeof fetch }));
+    expect(result.newExchangeState).toBe("DISPUTED");
+    expect(result.newDisputeState).toBe("RESOLVING");
+  });
+
+  it("respects the seller's advertised channel order (facilitator first, then server)", async () => {
+    const calls: string[] = [];
+    const fetcher = vi.fn(async (input: RequestInfo) => {
+      calls.push(String(input));
+      return jsonResponse(200, FACILITATOR_OK_BODY);
+    });
+    await submitAction(
+      makeArgs({
+        action: makeAction({ channels: ["facilitator", "server"] }),
+        fetch: fetcher as unknown as typeof fetch,
+      }),
+    );
+    expect(calls[0]).toBe(FACILITATOR_URL);
+  });
+});

--- a/typescript/packages/client/test/submit.test.ts
+++ b/typescript/packages/client/test/submit.test.ts
@@ -67,7 +67,7 @@ function jsonResponse(status: number, body: unknown): Response {
 }
 
 const SERVER_OK_BODY = {
-  txHash: "0xredeemtx",
+  txHash: `0x${"ab".repeat(32)}`,
   nextActions: {
     exchangeId: EXCHANGE_ID,
     exchangeState: "REDEEMED",
@@ -77,7 +77,7 @@ const SERVER_OK_BODY = {
 
 const FACILITATOR_OK_BODY = {
   ok: true,
-  txHash: "0xredeemtx",
+  txHash: `0x${"ab".repeat(32)}`,
   newExchangeState: "REDEEMED",
 };
 
@@ -88,7 +88,7 @@ describe("submitAction", () => {
     expect(fetcher).toHaveBeenCalledTimes(1);
     expect(fetcher.mock.calls[0]?.[0]).toBe(SERVER_URL);
     expect(result.channelUsed).toBe("server");
-    expect(result.txHash).toBe("0xredeemtx");
+    expect(result.txHash).toBe(`0x${"ab".repeat(32)}`);
     expect(result.newExchangeState).toBe("REDEEMED");
     expect(result.nextActions).toBeDefined();
     expect(result.attempts).toEqual([{ channel: "server", ok: true, status: 200 }]);
@@ -102,7 +102,7 @@ describe("submitAction", () => {
     const result = await submitAction(makeArgs({ fetch: fetcher as unknown as typeof fetch }));
     expect(fetcher).toHaveBeenCalledTimes(2);
     expect(result.channelUsed).toBe("facilitator");
-    expect(result.txHash).toBe("0xredeemtx");
+    expect(result.txHash).toBe(`0x${"ab".repeat(32)}`);
     expect(result.newExchangeState).toBe("REDEEMED");
     // Facilitator route doesn't emit nextActions; result.nextActions stays unset.
     expect(result.nextActions).toBeUndefined();
@@ -214,7 +214,7 @@ describe("submitAction", () => {
 
   it("DISPUTED post-commit response surfaces newDisputeState", async () => {
     const body = {
-      txHash: "0xdispute",
+      txHash: `0x${"cd".repeat(32)}`,
       nextActions: {
         exchangeId: EXCHANGE_ID,
         exchangeState: "DISPUTED",
@@ -233,6 +233,30 @@ describe("submitAction", () => {
       if (String(input) === SERVER_URL) {
         // 200 with a JSON object that's missing txHash + nextActions.
         return jsonResponse(200, { unexpected: true });
+      }
+      return jsonResponse(200, FACILITATOR_OK_BODY);
+    });
+    const result = await submitAction(makeArgs({ fetch: fetcher as unknown as typeof fetch }));
+    expect(result.channelUsed).toBe("facilitator");
+    expect(result.attempts[0]).toMatchObject({
+      channel: "server",
+      ok: false,
+      reason: "invalid-response",
+      status: 200,
+    });
+  });
+
+  it("server 2xx with non-hex txHash → reason='invalid-response', falls back to facilitator", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo) => {
+      if (String(input) === SERVER_URL) {
+        return jsonResponse(200, {
+          txHash: "not-a-hex-hash",
+          nextActions: {
+            exchangeId: EXCHANGE_ID,
+            exchangeState: "REDEEMED",
+            next: [],
+          },
+        });
       }
       return jsonResponse(200, FACILITATOR_OK_BODY);
     });

--- a/typescript/packages/client/test/submit.test.ts
+++ b/typescript/packages/client/test/submit.test.ts
@@ -228,6 +228,44 @@ describe("submitAction", () => {
     expect(result.newDisputeState).toBe("RESOLVING");
   });
 
+  it("server 2xx with body of wrong shape → reason='invalid-response', falls back to facilitator", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo) => {
+      if (String(input) === SERVER_URL) {
+        // 200 with a JSON object that's missing txHash + nextActions.
+        return jsonResponse(200, { unexpected: true });
+      }
+      return jsonResponse(200, FACILITATOR_OK_BODY);
+    });
+    const result = await submitAction(makeArgs({ fetch: fetcher as unknown as typeof fetch }));
+    expect(result.channelUsed).toBe("facilitator");
+    expect(result.attempts[0]).toMatchObject({
+      channel: "server",
+      ok: false,
+      reason: "invalid-response",
+      status: 200,
+    });
+  });
+
+  it("server 2xx with non-object body → reason='invalid-response', falls back to facilitator", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo) => {
+      if (String(input) === SERVER_URL) {
+        return new Response('"a-string"', {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return jsonResponse(200, FACILITATOR_OK_BODY);
+    });
+    const result = await submitAction(makeArgs({ fetch: fetcher as unknown as typeof fetch }));
+    expect(result.channelUsed).toBe("facilitator");
+    expect(result.attempts[0]).toMatchObject({
+      channel: "server",
+      ok: false,
+      reason: "invalid-response",
+      status: 200,
+    });
+  });
+
   it("respects the seller's advertised channel order (facilitator first, then server)", async () => {
     const calls: string[] = [];
     const fetcher = vi.fn(async (input: RequestInfo) => {

--- a/typescript/packages/client/test/submit.test.ts
+++ b/typescript/packages/client/test/submit.test.ts
@@ -166,7 +166,11 @@ describe("submitAction", () => {
       }),
     );
     expect(result.channelUsed).toBe("facilitator");
-    expect(result.attempts[0]).toMatchObject({ channel: "server", ok: false, reason: "network" });
+    expect(result.attempts[0]).toMatchObject({
+      channel: "server",
+      ok: false,
+      reason: "no-endpoint",
+    });
   });
 
   it("server channel body contains exchangeId + signedPayload (and fulfillment when provided)", async () => {

--- a/typescript/packages/x402-e2e/test/scenarios/_skeletons.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/_skeletons.test.ts
@@ -33,12 +33,12 @@ describe.skipIf(!ENABLED)("@p2 commit-time validations — PR 7", () => {
 });
 
 describe.skipIf(!ENABLED)("@p0/@p1 nextActions / channel routing — PR 7", () => {
-  // D1, D2 moved to `next-actions.test.ts` as runnable scenarios.
-  // D3 stays a todo: the client-side channel fallback chain
-  // (server → facilitator → onchain on 5xx / network error) isn't
-  // implemented today in `x402-client` / `x402-client-fetch`. The
-  // test will land alongside the feature work in its own PR.
-  it.todo("D3 — server/facilitator/onchain channel fallback chain (kill facilitator)");
+  // D1, D2, and D3 (server→facilitator) moved to `next-actions.test.ts`
+  // as runnable scenarios. The remaining todos extend D3's fallback
+  // chain once the matching submitters land: `onchain` needs a
+  // wallet-driven submitter wired into `client.submitAction`, and
+  // `mcp` ships with `@bosonprotocol/x402-agent`.
+  it.todo("D5 — extend D3 fallback chain to `onchain` once the wallet submitter lands");
   it.todo(
     "D4 — `mcp` channel for buyer-side action — skipped until `@bosonprotocol/x402-agent` lands",
   );

--- a/typescript/packages/x402-e2e/test/scenarios/next-actions.test.ts
+++ b/typescript/packages/x402-e2e/test/scenarios/next-actions.test.ts
@@ -18,6 +18,7 @@
 // envelope rides the `/x402B/redeem` response body.
 
 import { ExchangeState } from "@bosonprotocol/x402-actions";
+import type { EscrowNextActions } from "@bosonprotocol/x402-core/schemes/escrow";
 import { clientLegalActions } from "@bosonprotocol/x402-core/state-machine";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -111,5 +112,58 @@ describe.skipIf(!ENABLED)("@p0 nextActions derivation", () => {
     expect(sortedIds(redeemed.nextActionIds)).toEqual(
       sortedIds(clientLegalActions({ exchange: ExchangeState.REDEEMED })),
     );
+  });
+
+  it("D3 — submitAction falls back from server to facilitator on a dead server endpoint", async () => {
+    // Doubles as the canonical example of `client.submitAction` usage:
+    // commit, read the post-commit envelope, hand the
+    // `boson-redeem` entry back to `submitAction` for a transparent
+    // channel walk. We patch `endpoints.server` to a closed port
+    // (`http://127.0.0.1:1` → connect-refused → `ChannelFailureReason
+    // "network"`) while leaving the server-stamped
+    // `endpoints.facilitator` URL intact — so the walk fails on
+    // server, then succeeds on facilitator.
+    const commitRes = await ctx.buyer.fetch(`${ctx.resourceServerUrl}/resource`);
+    expect(commitRes.status, await commitRes.clone().text()).toBe(200);
+    const exchangeId = ((await commitRes.json()) as { x402b?: { exchangeId?: string } }).x402b
+      ?.exchangeId;
+    if (typeof exchangeId !== "string") {
+      throw new Error(
+        `Expected commit response x402b.exchangeId to be a string, got ${typeof exchangeId}`,
+      );
+    }
+
+    const decoded = readXPaymentResponse(commitRes.headers);
+    const original = decoded?.nextActions?.next?.find((entry) => entry.id === "boson-redeem");
+    expect(original, "post-COMMITTED envelope must advertise boson-redeem").toBeDefined();
+
+    const priorNextActions = {
+      ...decoded!.nextActions!,
+      next: decoded!.nextActions!.next!.map((entry) =>
+        entry.id === "boson-redeem"
+          ? {
+              ...entry,
+              endpoints: { ...(entry.endpoints ?? {}), server: "http://127.0.0.1:1" },
+            }
+          : entry,
+      ),
+    } as unknown as EscrowNextActions;
+
+    const result = await ctx.buyer.client.submitAction({
+      actionId: "boson-redeem",
+      exchangeId,
+      network: ctx.network,
+      escrowAddress: ctx.escrowAddress,
+      priorNextActions,
+    });
+
+    expect(result.channelUsed).toBe("facilitator");
+    expect(result.newExchangeState).toBe(ExchangeState.REDEEMED);
+    const firstAttempt = result.attempts[0];
+    expect(firstAttempt?.channel).toBe("server");
+    expect(firstAttempt?.ok).toBe(false);
+    if (firstAttempt !== undefined && !firstAttempt.ok) {
+      expect(firstAttempt.reason).toBe("network");
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **`@bosonprotocol/x402-client`** — new `submitAction(args)` on `X402bClient` (plus a low-level `submitAction()` helper). Signs the meta-tx, then walks `priorNextActions.next[i].channels[]` intersected with `["server", "facilitator"]` until the first 2xx. Falls back on **5xx / network / timeout**; stops on **4xx** (no fallback can fix a buyer-payload bug). Surfaces `NoCompatibleChannelError` (no submittable channel advertised) and `AllChannelsFailedError` with a per-channel attempt log.
- **`@bosonprotocol/x402-client-fetch`** — new `commitFallback: "off" | "auto"` option on `wrapFetchWithPayment` (default `"off"`). On `"auto"`, when the resource server 5xx's the X-PAYMENT retry the wrapper POSTs `{ scheme, network, payload, requirements }` directly to `actions.next[*].endpoints.facilitator` and synthesizes a `200` carrying `X-PAYMENT-RESPONSE` + `X-X402-Boson-Commit-Channel: facilitator` + `X-X402-Boson-Server-Error: <status|network:msg>` and an empty body. Fallback failures surface the original 5xx unchanged.
- Closes the feature gap behind **D3** (channel-fallback chain) from the e2e plan. The kill-facilitator e2e test stays `it.todo` in `_skeletons.test.ts` and will land in the follow-up that also switches the harness to `client.submitAction`. `onchain` / `mcp` / `xmtp` channels remain out of scope here.

## Why now

Pre-launch audit found this as the only client-side **feature gap** (vs. test gap) blocking buyer resilience: the SDK was pinned to the first advertised endpoint with no recovery on 5xx, so a brief resource-server blip could fail an otherwise-valid post-commit action or strand a buyer who had already signed an X-PAYMENT.

## What this PR does *not* change

- No `onchain` channel submitter — would need a `WalletClient` plumbed through `X402bClientConfig` and a simulate/broadcast/receipt path.
- No e2e harness change — the existing post-commit scenarios still POST through the harness's hard-coded resource-server URL. The natural place to switch them to `client.submitAction` is alongside the D3 test.
- `wrapFetchWithPayment`'s default is `commitFallback: "off"` — pre-existing callers see zero behavior change.

## Test plan

- [x] `pnpm --filter x402-client --filter x402-client-fetch test` — **79 + 15 passed**, including:
  - 11 new submit-channel tests (server/facilitator happy paths, 5xx fallback, 4xx terminal, network/timeout, no-compatible-channel, body-shape per channel)
  - 8 new commit-fallback tests (default-off, auto + 5xx → synth 200, X-PAYMENT-RESPONSE header decode, network-error path, no facilitator endpoint, facilitator-also-fails, 4xx-no-fallback, retry-200-untouched)
- [x] `pnpm --filter x402-client --filter x402-client-fetch lint` — clean
- [x] `pnpm --filter x402-client --filter x402-client-fetch build` — clean
- [x] `pnpm format:check` — clean
- [ ] D3 kill-facilitator e2e test — deferred to follow-up PR (intentionally not in scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel-aware fallback for buyer submissions that retries across server → facilitator on 5xx/network/timeouts.
  * New submitAction() API for resilient post-commit submissions with structured results and attempt logging.
  * Opt-in payment commit fallback: automatic facilitator settle attempt when payment retry fails (configurable).

* **Bug Fixes / Error Handling**
  * Clear error types for no-compatible-channel and multi-channel failure scenarios.

* **Tests**
  * Comprehensive unit and e2e tests covering fallback, success, and failure paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->