### PR TITLE
docs(x402-e2e): flow-based scenario walkthroughs (A/B/C/D)

### DIFF
--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -176,6 +176,14 @@ with `-t '@p0'`. Priorities:
 | `@p1/@p2`| commit-time fulfillment (A6–A8)               | `_skeletons.test.ts`          |
 | `it.todo`| follow-up scenarios (B5, B8–9, C6–C10, D1–D4, E1–E3) | `_skeletons.test.ts`   |
 
+### Scenario walkthroughs
+
+Prose + sequence-diagram docs that explain how the protocol behaves,
+flow by flow, mapping each step back to the harness / SDK / facilitator /
+Diamond method that runs it — see [`docs/scenarios/`](./docs/scenarios/README.md).
+Pilot coverage: [Flow A — deferred commit](./docs/scenarios/flow-a-deferred-commit.md)
+and [Flow C — dispute path](./docs/scenarios/flow-c-dispute.md).
+
 ### Running a tag subset
 
 ```sh

--- a/typescript/packages/x402-e2e/README.md
+++ b/typescript/packages/x402-e2e/README.md
@@ -181,8 +181,11 @@ with `-t '@p0'`. Priorities:
 Prose + sequence-diagram docs that explain how the protocol behaves,
 flow by flow, mapping each step back to the harness / SDK / facilitator /
 Diamond method that runs it — see [`docs/scenarios/`](./docs/scenarios/README.md).
-Pilot coverage: [Flow A — deferred commit](./docs/scenarios/flow-a-deferred-commit.md)
-and [Flow C — dispute path](./docs/scenarios/flow-c-dispute.md).
+One doc per protocol flow:
+[A — deferred commit](./docs/scenarios/flow-a-deferred-commit.md),
+[B — atomic commit-and-redeem](./docs/scenarios/flow-b-atomic-commit-redeem.md),
+[C — dispute path](./docs/scenarios/flow-c-dispute.md),
+[D — channels & nextActions](./docs/scenarios/flow-d-channels-nextactions.md).
 
 ### Running a tag subset
 

--- a/typescript/packages/x402-e2e/docs/scenarios/README.md
+++ b/typescript/packages/x402-e2e/docs/scenarios/README.md
@@ -42,12 +42,13 @@ under whichever flow they exercise:
 | Flow doc | Protocol flow | e2e scenarios |
 |---|---|---|
 | [`flow-a-deferred-commit.md`](./flow-a-deferred-commit.md) | Deferred commit, redeem later | A1/A3/A4/A5 commit, B1 redeem, A6 fulfillment, B7 cancel |
-| `flow-b-atomic-commit-redeem.md` _(planned)_ | Atomic commit-and-redeem | A2, B2 completeExchange |
+| [`flow-b-atomic-commit-redeem.md`](./flow-b-atomic-commit-redeem.md) | Atomic commit-and-redeem | A2, B2 completeExchange |
 | [`flow-c-dispute.md`](./flow-c-dispute.md) | Dispute path | B3 raise, B4 resolve (50/50), B6 retract, E3 dual-sig |
-| `flow-d-channels-nextactions.md` _(planned)_ | Channel fallback + `nextActions` | B7 via facilitator, D1/D2 |
+| [`flow-d-channels-nextactions.md`](./flow-d-channels-nextactions.md) | Channels + `nextActions` | D1/D2, B7 via facilitator |
 
-> **Status:** pilot. `flow-a` and `flow-c` are written; `flow-b` and
-> `flow-d` follow once the format is settled.
+> All four protocol flows are documented. Deferred scenarios (escalation
+> B5/B9, channel-fallback-on-failure D3, MCP D4) are noted inline in the
+> relevant flow doc until their harness support lands.
 
 ## Sources of truth
 

--- a/typescript/packages/x402-e2e/docs/scenarios/README.md
+++ b/typescript/packages/x402-e2e/docs/scenarios/README.md
@@ -1,0 +1,61 @@
+# x402B scenario walkthroughs
+
+These docs explain **how x402B actually behaves**, using the end-to-end
+test suite as the worked example. Where the spec docs in the repo-root
+[`docs/`](../../../../../docs/boson-impl-00-overview.md) describe the
+protocol in the abstract, each file here narrates a concrete protocol
+**flow** as a timeline — who talks to whom, in what order, with what
+payloads — and maps every step back to the **real method** in the
+harness, the SDK, the server/facilitator, and the Boson Diamond, so you
+can jump from "what happens" to "where it's coded".
+
+The suite itself lives one level up under
+[`test/scenarios/`](../../test/scenarios/); the buyer/seller/asserter
+personas it drives live under [`src/harness/`](../../src/harness/).
+
+## How to read these
+
+Every flow doc follows the same structure:
+
+1. **Overview & context** — what the flow is for, and the e2e scenarios
+   that exercise it (with links to the exact `test:line`).
+2. **Actors** — the participants, each mapped to the code object that
+   plays it in the suite.
+3. **Sequence diagram** — a Mermaid `sequenceDiagram` annotated with the
+   real method on each arrow.
+4. **Step-by-step walkthrough** — per step: the method called, the
+   request/response **payload** on the wire, and the **assertion** the
+   test makes there.
+5. **Payload appendix** — concrete example bodies (402
+   `PaymentRequirements`, decoded `X-PAYMENT`, `X-PAYMENT-RESPONSE`,
+   post-commit request/response, `nextActions`).
+6. **Code map** — a table: logical step → harness → SDK/server/
+   facilitator → Boson Diamond facet method.
+7. **Failure modes** — the negative (C-series) / operational (F-series)
+   scenarios that probe this flow's guards.
+
+The four protocol flows are the same A/B/C/D used in
+[`docs/boson-impl-02-flows.md`](../../../../../docs/boson-impl-02-flows.md).
+The e2e suite's letter-numbered scenarios (A1, B4, C2, …) are grouped
+under whichever flow they exercise:
+
+| Flow doc | Protocol flow | e2e scenarios |
+|---|---|---|
+| [`flow-a-deferred-commit.md`](./flow-a-deferred-commit.md) | Deferred commit, redeem later | A1/A3/A4/A5 commit, B1 redeem, A6 fulfillment, B7 cancel |
+| `flow-b-atomic-commit-redeem.md` _(planned)_ | Atomic commit-and-redeem | A2, B2 completeExchange |
+| [`flow-c-dispute.md`](./flow-c-dispute.md) | Dispute path | B3 raise, B4 resolve (50/50), B6 retract, E3 dual-sig |
+| `flow-d-channels-nextactions.md` _(planned)_ | Channel fallback + `nextActions` | B7 via facilitator, D1/D2 |
+
+> **Status:** pilot. `flow-a` and `flow-c` are written; `flow-b` and
+> `flow-d` follow once the format is settled.
+
+## Sources of truth
+
+These docs paraphrase wire shapes from the packages that own them; when
+they diverge, the code wins. The canonical definitions are:
+
+- **402 `PaymentRequirements`** — [`core/src/schemes/escrow/payment-requirements.ts`](../../../core/src/schemes/escrow/payment-requirements.ts)
+- **`X-PAYMENT` payload** — [`core/src/schemes/escrow/payment-payload.ts`](../../../core/src/schemes/escrow/payment-payload.ts)
+- **`nextActions` envelope + action IDs** — [`docs/boson-impl-04-state-machine-and-next-actions.md`](../../../../../docs/boson-impl-04-state-machine-and-next-actions.md), backed by `@bosonprotocol/x402-core/state-machine`
+- **Server convenience routes** — [`server-express/src/mount.ts`](../../../server-express/src/mount.ts)
+- **Facilitator perform-action** — [`facilitator/src/perform-action/index.ts`](../../../facilitator/src/perform-action/index.ts)

--- a/typescript/packages/x402-e2e/docs/scenarios/flow-a-deferred-commit.md
+++ b/typescript/packages/x402-e2e/docs/scenarios/flow-a-deferred-commit.md
@@ -1,0 +1,350 @@
+# Flow A — Deferred commit (commit now, redeem later)
+
+> Walkthrough of the canonical x402B happy path as exercised by the e2e
+> suite. Spec counterpart:
+> [`docs/boson-impl-02-flows.md` § Flow A](../../../../../docs/boson-impl-02-flows.md).
+
+## Overview & context
+
+Flow A is the two-step purchase: the buyer first **commits** to a
+freshly-signed offer (escrowing the price and minting an ERC-721
+voucher → `COMMITTED`), then **redeems** the voucher in a separate
+transaction (`REDEEMED`), and finally either completes or disputes. The
+commit and redeem legs are independent on-chain transactions, so the
+voucher is transferable in between and delivery data is attached at
+redeem time, not commit time.
+
+The first leg rides the standard x402 handshake: an unpaid `GET` returns
+`402`, the client signs and retries with an `X-PAYMENT` header, and the
+retry settles on-chain and returns `200` with an `X-PAYMENT-RESPONSE`.
+What x402B adds is *what* gets signed (a Boson meta-transaction plus an
+optional token-transfer authorization) and *where the money goes* (Boson
+Diamond escrow, not the seller).
+
+### Scenarios on this flow
+
+| ID | What it pins | Test |
+|---|---|---|
+| **A1** | Deferred commit, `none` token-auth → `COMMITTED` | [`commit.test.ts:75`](../../test/scenarios/commit.test.ts#L75) |
+| **A3** | Commit with ERC-3009 `ReceiveWithAuthorization` | [`commit.test.ts:191`](../../test/scenarios/commit.test.ts#L191) |
+| **A4** | Commit with EIP-2612 `Permit` | [`commit.test.ts:260`](../../test/scenarios/commit.test.ts#L260) |
+| **A5** | Commit with Permit2 `PermitTransferFrom` | [`commit.test.ts:328`](../../test/scenarios/commit.test.ts#L328) |
+| **B1** | Redeem after deferred commit → `REDEEMED` | [`post-commit.test.ts:109`](../../test/scenarios/post-commit.test.ts#L109) |
+| **B7** | Cancel voucher before redeem → `CANCELLED` (via facilitator) | [`post-commit.test.ts:311`](../../test/scenarios/post-commit.test.ts#L311) |
+
+A2 (atomic commit-and-redeem) collapses both legs into one tx and is
+documented under Flow B.
+
+## Actors
+
+| Actor | Played by | Defined in |
+|---|---|---|
+| **Buyer / client** | `BuyerActor` — wraps `X402bClient` (`createX402bClient`) and `wrapFetchWithPayment` | [`src/harness/buyer-actor.ts`](../../src/harness/buyer-actor.ts) |
+| **Seller / resource server** | In-process Express app from `createResourceServerApp`; offers signed by `SellerActor` (`signFullOffer`) | [`examples/resource-server/src/app.ts`](../../../../../examples/resource-server/src/app.ts), [`src/harness/seller-actor.ts`](../../src/harness/seller-actor.ts) |
+| **Facilitator** | The compose-service relayer at `:8889`; reached directly for `cancelVoucher` via `performCancelVoucher` | [`facilitator/src/perform-action/index.ts`](../../../facilitator/src/perform-action/index.ts), [`src/harness/facilitator-perform-action.ts`](../../src/harness/facilitator-perform-action.ts) |
+| **Boson Diamond (escrow)** | The local-chain protocol Diamond at `LOCAL_31337_0.contracts.protocolDiamond` | — |
+| **Subgraph** | Asserted through `OnchainAsserter` (retries on indexer lag) | [`src/harness/onchain-asserter.ts`](../../src/harness/onchain-asserter.ts) |
+
+The whole `ScenarioContext` (server URL, actors, asserter, escrow
+address, network) is assembled per test in
+[`_setup.ts`](../../test/scenarios/_setup.ts).
+
+## Sequence diagram
+
+The commit leg (A1) and the redeem leg (B1):
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as BuyerActor (X402bClient)
+    participant S as Resource Server
+    participant F as Facilitator
+    participant D as Boson Diamond
+    participant G as Subgraph
+
+    Note over B,S: ── Commit leg (A1) ──
+    B->>S: GET /resource  (no X-PAYMENT)
+    S->>S: resolveRequirements() → buildPaymentRequirements()<br/>signFullOffer() (seller key)
+    S-->>B: 402 { x402Version, accepts: [EscrowPaymentRequirements] }
+
+    Note over B: wrapFetchWithPayment → client.handle402(requirements)
+    B->>B: pickAction() → "boson-createOfferAndCommit"<br/>sign BosonMetaTx + token-auth (skipped for "none")<br/>→ base64 X-PAYMENT
+    B->>S: GET /resource + X-PAYMENT (+ X-SESSION-ID)
+    S->>S: validate payload (offerRef deep-equals cached requirements)
+    S->>F: POST /verify, POST /settle
+    F->>D: executeMetaTransaction[WithTokenTransferAuthorization](metaTx, …)
+    D->>D: createOfferAndCommit → transferFundsIn → mint voucher<br/>state = COMMITTED
+    D-->>F: exchangeId, txHash
+    F-->>S: { exchangeId, txHash }
+    S->>G: read exchange → verifyExchangeSnapshot()
+    S-->>B: 200 { ok, x402b:{exchangeId,txHash}, resource }<br/>X-PAYMENT-RESPONSE: base64{ exchangeId, txHash, nextActions }
+    B->>G: asserter.expect(state=COMMITTED, seller, token, price)
+
+    Note over B,S: ── Redeem leg (B1) ──
+    B->>B: client.signAction({ actionId:"boson-redeem", … }) → signedPayload
+    B->>S: POST /x402B/redeem { exchangeId, signedPayload }
+    S->>F: POST /perform-action
+    F->>D: executeMetaTransaction(metaTx) → redeemVoucher
+    D->>D: state = REDEEMED
+    D-->>F: txHash
+    F-->>S: { ok, txHash, newExchangeState:"REDEEMED" }
+    S-->>B: 200 { txHash, nextActions:{ exchangeState:"REDEEMED", next:[…] } }
+    B->>G: asserter.expect(state=REDEEMED, …)
+```
+
+## Step-by-step walkthrough
+
+### Commit leg
+
+**1–3 · The 402 challenge.** `ctx.buyer.fetch(".../resource")`
+([`commit.test.ts:80`](../../test/scenarios/commit.test.ts#L80)) issues a
+plain `GET`. The server's `/resource` route runs
+`expressMiddleware(server, { resolveRequirements })`
+([`app.ts:361`](../../../../../examples/resource-server/src/app.ts#L361));
+with no `X-PAYMENT` header it answers `402` whose body is
+`{ x402Version, accepts: [EscrowPaymentRequirements] }`.
+`resolveRequirements` calls `server.buildPaymentRequirements(...)`
+([`app.ts:261`](../../../../../examples/resource-server/src/app.ts#L261)),
+which freshly signs a `FullOffer` with the seller's key — the result is
+cached per `X-SESSION-ID` so the retry settles the *same* signed offer.
+See the [402 payload](#402-paymentrequirements) below.
+
+**4–6 · Sign & retry.** `wrapFetchWithPayment` (wired in
+[`buyer-actor.ts:101`](../../src/harness/buyer-actor.ts#L101)) catches the
+402 and calls `client.handle402(requirements)`
+([`client.ts:104`](../../../client/src/client.ts#L104)). That:
+
+- parses the requirements (`parseEscrowPaymentRequirements`),
+- picks the action via `pickAction(...)`
+  ([`action.ts:34`](../../../client/src/action.ts#L34)) — with the default
+  `policy.redeemMode: "auto"` it prefers Flow A,
+  `"boson-createOfferAndCommit"`,
+- signs a Boson **meta-transaction** over that call (Diamond EIP-712
+  domain) and, unless `tokenAuthStrategy: "none"`, a **token-transfer
+  authorization** (the variant depends on the strategy — see
+  [Token-auth variants](#token-auth-variants-a1-a3-a4-a5)),
+- returns the base64 string set as the `X-PAYMENT` header on the retry.
+
+The retry is `GET /resource` again, now carrying `X-PAYMENT` (decoded
+shape in the [appendix](#x-payment-payload)).
+
+**7–13 · Validate, settle, verify.** The middleware re-runs
+`resolveRequirements` (hits the session cache), validates the payload
+(deep-equals `payload.offerRef.fullOffer` against the cached
+`requirements.offer.fullOffer` and strict-equals `sellerSig`), then calls
+`server.handlers.commit`, which `POST`s `/verify` then `/settle` to the
+facilitator. The facilitator submits
+`executeMetaTransactionWithTokenTransferAuthorization` (or plain
+`executeMetaTransaction` for `none`) to the Diamond; inside one tx the
+Diamond runs `createOfferAndCommit`, pulls funds via `transferFundsIn`,
+and mints the voucher → `COMMITTED`. The facilitator returns
+`{ exchangeId, txHash }`; the server reads the exchange back through its
+`ExchangeReader` and runs `verifyExchangeSnapshot` before responding.
+
+**14 · Success response.** `200` with:
+
+- body `{ ok: true, x402b: { exchangeId, txHash, … }, resource: "example resource bytes" }`
+  (the `x402b` object is `res.locals.x402b`, set by the middleware), and
+- an `X-PAYMENT-RESPONSE` header — base64 of
+  `{ exchangeId, txHash, nextActions }`, stamped by
+  `stampXPaymentResponseIfOk`
+  ([`mount.ts:328`](../../../server-express/src/mount.ts#L328)).
+
+**Assertions (A1, [`commit.test.ts:81–104`](../../test/scenarios/commit.test.ts#L81-L104)):**
+
+- `res.status === 200`, `body.ok === true`, `body.x402b.exchangeId` is a string;
+- `readXPaymentResponse(res.headers)` decodes non-null, its `exchangeId`
+  equals the body's, and `txHash` matches `TX_HASH_REGEX`
+  ([`x-payment-response-asserter.ts`](../../src/harness/x-payment-response-asserter.ts));
+- `ctx.asserter.expect(exchangeId, { state: ExchangeState.COMMITTED, seller, exchangeToken: testErc20, price: EXPECTED_PRICE })`
+  — polls the subgraph (≤20×, 500 ms) until `verifyExchangeSnapshot`
+  matches.
+
+### Redeem leg (B1)
+
+**15–16 · Sign the redeem.** `performBuyerPostCommitAction({ actionId: "boson-redeem", … })`
+([`post-commit.test.ts:111`](../../test/scenarios/post-commit.test.ts#L111))
+calls `buyer.client.signAction({ actionId, exchangeId, network, escrowAddress })`
+([`post-commit-http.ts:144`](../../src/harness/post-commit-http.ts#L144)),
+which returns `{ metaTx, signedPayload }` — `signedPayload` is the
+ABI-encoded `BosonMetaTx`.
+
+**17 · POST to the server.** `POST ${resourceServerUrl}/x402B/redeem`
+with body **`{ exchangeId, signedPayload }`** (no `X-PAYMENT-RESPONSE`
+header is set on post-commit routes — see
+[`mount.ts:138`](../../../server-express/src/mount.ts#L138)). Route table:
+[`mount.ts:51`](../../../server-express/src/mount.ts#L51).
+
+**18–22 · Relay & respond.** The server forwards to the facilitator's
+perform-action path; the facilitator simulates then submits
+`executeMetaTransaction` → `redeemVoucher` → `REDEEMED`, and the server
+replies `{ txHash, nextActions: { exchangeId, exchangeState: "REDEEMED", next: [...] } }`.
+The harness flattens that into `PostCommitActionResult`
+(`{ txHash, newExchangeState, newDisputeState?, nextActionIds, fulfillment? }`)
+in `flattenServerResponse`
+([`post-commit-http.ts:183`](../../src/harness/post-commit-http.ts#L183)).
+
+**Assertions (B1, [`post-commit.test.ts:119–127`](../../test/scenarios/post-commit.test.ts#L119-L127)):**
+`result.txHash` matches `TX_HASH_REGEX`, `result.newExchangeState === ExchangeState.REDEEMED`,
+and `asserter.expect(..., { state: REDEEMED, … })`.
+
+### Cancel-before-redeem variant (B7)
+
+`boson-cancelVoucher` is buyer-initiated but the example server mounts no
+`/x402B/cancel` route, so B7
+([`post-commit.test.ts:311`](../../test/scenarios/post-commit.test.ts#L311))
+goes **straight to the facilitator** via `performCancelVoucher`
+([`facilitator-perform-action.ts:72`](../../src/harness/facilitator-perform-action.ts#L72)):
+
+- `buyer.client.signAction({ actionId: "boson-cancelVoucher", … })`, then
+- `POST ${facilitatorUrl}/perform-action` with body
+  **`{ action: "boson-cancelVoucher", exchangeId, network, escrowAddress, signedPayload }`**
+  ([`facilitator-perform-action.ts:110`](../../src/harness/facilitator-perform-action.ts#L110)),
+- response `{ ok: true, txHash, newExchangeState: "CANCELLED" }`.
+
+Assertion: `cancelled.newExchangeState === ExchangeState.CANCELLED` and
+`asserter.expect(..., { state: CANCELLED, … })`. This is the
+censorship-resistance guarantee in action — the buyer ends their own
+commitment without the seller's cooperation.
+
+## Token-auth variants (A1 / A3 / A4 / A5)
+
+All four reach the same `COMMITTED` end state; they differ only in how the
+buyer authorizes the token pull. Once settled, the strategy is invisible
+on-chain, so the assertions are identical except for `exchangeToken`.
+
+| Scenario | `tokenAuthStrategies` advertised | Buyer pre-req | What's signed | Token |
+|---|---|---|---|---|
+| **A1** | `["none"]` | Standing ERC-20 allowance to the Diamond (`ensureBuyerCanPay`) | meta-tx only; `transferFundsIn` pulls via allowance | `testErc20` |
+| **A3** | `["erc3009"]` | Balance only (`ensureBuyerHasBalance`) | meta-tx + ERC-3009 `ReceiveWithAuthorization` (inline transfer) | `testErc3009` |
+| **A4** | `["permit"]` | Balance only | meta-tx + EIP-2612 `Permit` (settle calls `permit()` then `transferFrom`) | `testErc2612` |
+| **A5** | `["permit2"]` | Allowance to the **canonical Permit2** contract | meta-tx + Permit2 `PermitTransferFrom` (canonical Permit2 domain) | `testErc20` |
+
+Notes carried straight from the tests:
+
+- The `none` pin matters: without it the client dispatcher defaults to
+  `permit2` and the `transferFrom` would revert with `ERC20: insufficient
+  allowance`, because the buyer only approved the Diamond, not Permit2.
+  See `NONE_TOKEN_AUTH_SCENARIO`
+  ([`_setup.ts:171`](../../test/scenarios/_setup.ts#L171)).
+- A3/A4/A5 set `maxTimeoutSeconds: 24 * 60 * 60`. The local stack mines at
+  ~20× wall-clock, so the default 1-hour `validBefore` / `deadline` can
+  already be in the past by the time `settle` simulates against
+  `block.timestamp`.
+- ERC-3009 and Permit require a `tokenDomainResolver`
+  (`createChainTokenDomainResolver(publicClient)`) so the client can sign
+  against the token's own EIP-712 domain; Permit2 uses the canonical
+  Permit2 domain and needs no resolver.
+
+## Payload appendix
+
+### 402 `PaymentRequirements`
+
+Emitted inside `accepts[0]`; type
+[`EscrowPaymentRequirements`](../../../core/src/schemes/escrow/payment-requirements.ts).
+
+```jsonc
+{
+  "scheme": "escrow",
+  "network": "eip155:31337",
+  "asset": "0x…",                     // testErc20 (or testErc3009/testErc2612)
+  "amount": "1000000",                // atomic units, decimal string (1 USDC @ 6dp)
+  "escrowAddress": "0x…",             // Boson Diamond — the custodian
+  "recipientId": "12",                // routing-only seller id
+  "maxTimeoutSeconds": 3600,          // 86400 for A3/A4/A5
+  "offer": {
+    "fullOffer": { /* signed Boson FullOffer template */ },
+    "sellerSig": "0x…",
+    "creator": "0x…"                  // seller address
+  },
+  "tokenAuthStrategies": ["none"],    // narrowed per scenario
+  "fulfillment": { "required": false, "options": [] },
+  "actions": {
+    "next": [
+      { "id": "boson-createOfferAndCommit",       "channels": ["server", "facilitator", "onchain"] },
+      { "id": "boson-createOfferCommitAndRedeem", "channels": ["server", "facilitator", "onchain"] }
+    ],
+    "fallback": { /* onchainHints, … */ }
+  }
+}
+```
+
+### `X-PAYMENT` payload
+
+Base64 of [`EscrowPaymentPayload`](../../../core/src/schemes/escrow/payment-payload.ts);
+decoded shape for the `none` strategy (no `tokenAuth`):
+
+```jsonc
+{
+  "x402Version": 1,
+  "scheme": "escrow",
+  "network": "eip155:31337",
+  "payload": {
+    "action": "boson-createOfferAndCommit",
+    "tokenAuthStrategy": "none",
+    "offerRef": { "fullOffer": { /* … */ }, "sellerSig": "0x…" },
+    "buyer": "0x…",
+    "metaTx": {
+      "from": "0x…",
+      "nonce": "…",
+      "functionName": "createOfferAndCommit",
+      "functionSignature": "0x…",      // ABI-encoded inner call
+      "sig": { "v": 27, "r": "0x…", "s": "0x…" }
+    }
+    // "tokenAuth": { "kind": "erc3009" | "permit" | "permit2", "data": { … } }  // present iff strategy ≠ "none"
+  }
+  // "fulfillment": { "option": "…", "data": … }  // Flow A omits data — it travels at redeem time
+}
+```
+
+### `X-PAYMENT-RESPONSE` (commit 200)
+
+Base64 of the commit handler body; the harness decodes it with
+`readXPaymentResponse`:
+
+```jsonc
+{ "exchangeId": "13", "txHash": "0x…", "nextActions": { "exchangeState": "COMMITTED", "next": [ /* … */ ] } }
+```
+
+### Redeem request / response (B1)
+
+```jsonc
+// POST /x402B/redeem
+{ "exchangeId": "13", "signedPayload": "0x…" }
+
+// 200
+{ "txHash": "0x…", "nextActions": { "exchangeId": "13", "exchangeState": "REDEEMED", "next": [ /* completeExchange, raiseDispute, … */ ] } }
+```
+
+## Code map
+
+| Step | Harness | SDK / server / facilitator | Boson Diamond |
+|---|---|---|---|
+| GET → 402 | `buyer.fetch` | `expressMiddleware` → `buildPaymentRequirements` → `signFullOffer` | — |
+| Sign X-PAYMENT | `wrapFetchWithPayment` | `client.handle402` → `pickAction` → meta-tx + token-auth signing | — |
+| Settle commit | — | `server.handlers.commit` → facilitator `/verify` + `/settle` | `executeMetaTransaction[WithTokenTransferAuthorization]` → `createOfferAndCommit` → `transferFundsIn` |
+| Verify state | `asserter.expect` | `verifyExchangeSnapshot` (via `ExchangeReader`) | — |
+| Redeem | `performBuyerPostCommitAction` | `client.signAction` → `POST /x402B/redeem` → `performAction` | `executeMetaTransaction` → `redeemVoucher` |
+| Cancel (B7) | `performCancelVoucher` | `client.signAction` → facilitator `POST /perform-action` | `executeMetaTransaction` → `cancelVoucher` |
+
+Action IDs and their on-chain primitives:
+[`docs/boson-impl-04-state-machine-and-next-actions.md` § Action IDs](../../../../../docs/boson-impl-04-state-machine-and-next-actions.md).
+
+## Failure modes
+
+Commit-time guards live in
+[`validation-commit.test.ts`](../../test/scenarios/validation-commit.test.ts);
+each tampers with one part of the commit payload and asserts a structured
+error rather than an accidental settle:
+
+| ID | Tampered input | Expected |
+|---|---|---|
+| **C1** | `functionSignature` calldata altered after signing | `CALLDATA_MISMATCH` |
+| **C2** | meta-tx signature doesn't recover to `metaTx.from` | `BAD_META_TX_SIGNATURE` |
+| **C3** | replayed meta-tx nonce | nonce-replay rejection |
+| **C4** | expired ERC-3009 `validBefore` | rejected |
+| **C5** | token-auth deadline exceeded | `TOKEN_AUTH_DEADLINE_EXCEEDED` |
+| **C8** | non-allowlisted escrow address | rejected (facilitator escrow allowlist, [`perform-action/index.ts:172`](../../../facilitator/src/perform-action/index.ts#L172)) |
+
+Post-commit illegal transitions (e.g. C10 redeem-after-cancel) live in
+[`validation-post-commit.test.ts`](../../test/scenarios/validation-post-commit.test.ts).

--- a/typescript/packages/x402-e2e/docs/scenarios/flow-a-deferred-commit.md
+++ b/typescript/packages/x402-e2e/docs/scenarios/flow-a-deferred-commit.md
@@ -122,7 +122,7 @@ See the [402 payload](#402-paymentrequirements) below.
 - signs a Boson **meta-transaction** over that call (Diamond EIP-712
   domain) and, unless `tokenAuthStrategy: "none"`, a **token-transfer
   authorization** (the variant depends on the strategy — see
-  [Token-auth variants](#token-auth-variants-a1-a3-a4-a5)),
+  [Token-auth variants](#token-auth-variants-a1--a3--a4--a5)),
 - returns the base64 string set as the `X-PAYMENT` header on the retry.
 
 The retry is `GET /resource` again, now carrying `X-PAYMENT` (decoded

--- a/typescript/packages/x402-e2e/docs/scenarios/flow-b-atomic-commit-redeem.md
+++ b/typescript/packages/x402-e2e/docs/scenarios/flow-b-atomic-commit-redeem.md
@@ -1,0 +1,210 @@
+# Flow B — Atomic commit-and-redeem (single transaction)
+
+> Walkthrough of the one-transaction purchase as exercised by the e2e
+> suite. Spec counterpart:
+> [`docs/boson-impl-02-flows.md` § Flow B](../../../../../docs/boson-impl-02-flows.md).
+
+## Overview & context
+
+Flow B collapses the **commit** and **redeem** state transitions into a
+single on-chain transaction: the exchange lands directly in `REDEEMED`
+rather than passing through `COMMITTED` first. Everything else about the
+HTTP handshake is identical to [Flow A](./flow-a-deferred-commit.md) — the
+only difference is which Boson action the client signs.
+
+The choice is purely about *when the on-chain redeem happens*; it is
+independent of when the resource is delivered. Because there is no later
+redeem round-trip, any buyer-supplied delivery data must travel **with the
+`X-PAYMENT`** at commit time (see
+[Fulfillment timing](#fulfillment-timing-vs-flow-a)).
+
+From `REDEEMED`, the exchange's terminal happy-path step is
+`completeExchange`, which releases the escrowed funds to the seller —
+the same step whether the exchange reached `REDEEMED` atomically (Flow B)
+or via a separate redeem (Flow A).
+
+### Scenarios on this flow
+
+| ID | What it pins | Test |
+|---|---|---|
+| **A2** | Atomic commit-and-redeem, `none` token-auth → `REDEEMED` | [`commit.test.ts:111`](../../test/scenarios/commit.test.ts#L111) |
+| **B2** | `completeExchange` after redeem → `COMPLETED`, escrow released | [`post-commit.test.ts:130`](../../test/scenarios/post-commit.test.ts#L130) |
+
+> B2's test reaches `REDEEMED` via Flow A legs (commit → redeem) and then
+> completes; the completion mechanics are identical for a Flow B exchange,
+> so it's documented here as the terminal step of the atomic flow.
+
+## Actors
+
+Same cast as [Flow A](./flow-a-deferred-commit.md#actors): `BuyerActor`
+(wrapping `X402bClient`), the in-process resource server, the facilitator,
+the Boson Diamond, and the subgraph (via `OnchainAsserter`). The only
+behavioural change is the buyer's `Policy`.
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as BuyerActor (X402bClient)
+    participant S as Resource Server
+    participant F as Facilitator
+    participant D as Boson Diamond
+    participant G as Subgraph
+
+    B->>S: GET /resource  (no X-PAYMENT)
+    S-->>B: 402 { accepts: [EscrowPaymentRequirements] }
+
+    Note over B: policy.redeemMode = "commit-and-redeem"<br/>→ handle402 → pickAction() picks Flow B
+    B->>B: sign BosonMetaTx for "boson-createOfferCommitAndRedeem"<br/>(+ token-auth, skipped for "none") → base64 X-PAYMENT
+    B->>S: GET /resource + X-PAYMENT
+    S->>F: POST /verify, POST /settle
+    F->>D: executeMetaTransaction[WithTokenTransferAuthorization](metaTx, …)
+    D->>D: createOfferCommitAndRedeem<br/>(createOffer + commitToOffer + redeemVoucher in ONE tx)<br/>state = REDEEMED
+    D-->>F: exchangeId, txHash
+    F-->>S: { exchangeId, txHash }
+    S->>G: read exchange → verifyExchangeSnapshot()
+    S-->>B: 200 { ok, x402b:{exchangeId,txHash}, resource }<br/>X-PAYMENT-RESPONSE: base64{ exchangeId, txHash, nextActions }
+    B->>G: asserter.expect(state=REDEEMED, …)
+
+    Note over B,D: ── Terminal step (B2) ──
+    B->>B: client.signAction({ actionId:"boson-completeExchange", … })
+    B->>S: POST /x402B/complete { exchangeId, signedPayload }
+    S->>F: POST /perform-action
+    F->>D: executeMetaTransaction → completeExchange
+    D->>D: state = COMPLETED, releaseFunds() → seller
+    S-->>B: { txHash, nextActions:{ exchangeState:"COMPLETED", next:[] } }
+    B->>G: asserter.expect(state=COMPLETED, …)
+```
+
+## Step-by-step walkthrough
+
+### A2 — the atomic commit
+
+The only setup difference from A1 is the buyer's policy
+([`commit.test.ts:116`](../../test/scenarios/commit.test.ts#L116)):
+
+```ts
+const atomicBuyer = createBuyerActor({
+  account: buyerAccount,
+  publicClient: ctx.buyer.publicClient,
+  policy: { ...NONE_TOKEN_AUTH_SCENARIO.buyerPolicy, redeemMode: "commit-and-redeem" },
+});
+```
+
+When `wrapFetchWithPayment` calls `client.handle402(requirements)`,
+`pickAction(...)` ([`action.ts:47`](../../../client/src/action.ts#L47))
+sees `redeemMode === "commit-and-redeem"` and selects
+`"boson-createOfferCommitAndRedeem"` (Flow B), throwing
+`NoCompatibleActionError` if the server hadn't advertised it. The
+`X-PAYMENT` is otherwise built exactly as in Flow A — the
+`payload.action` field is the only change on the wire.
+
+The facilitator settles via the Diamond's
+`OrchestrationHandlerFacet2.createOfferCommitAndRedeem`, which performs
+create-offer + commit + redeem in a single transaction (emitting
+`OfferCreated`, `BuyerCommitted`, and `VoucherRedeemed`). The committer —
+and therefore the redeemer — is `_msgSender()`, which under the meta-tx
+entrypoint is the buyer recovered from the meta-tx signature, so no
+separate redeem signature is required.
+
+**Assertions ([`commit.test.ts:122–144`](../../test/scenarios/commit.test.ts#L122-L144)):**
+`res.status === 200`, `body.ok`, `body.x402b.exchangeId` a string; the
+decoded `X-PAYMENT-RESPONSE` `exchangeId` matches and `txHash` matches
+`TX_HASH_REGEX`; and crucially
+`asserter.expect(exchangeId, { state: ExchangeState.REDEEMED, … })` —
+**`REDEEMED`, not `COMMITTED`** — is the one assertion that distinguishes
+Flow B from Flow A.
+
+### B2 — complete the exchange
+
+`performBuyerPostCommitAction({ actionId: "boson-completeExchange", … })`
+([`post-commit.test.ts:140`](../../test/scenarios/post-commit.test.ts#L140))
+signs the meta-tx and `POST`s `/x402B/complete`
+([route table `mount.ts:52`](../../../server-express/src/mount.ts#L52))
+with `{ exchangeId, signedPayload }`. The facilitator submits
+`completeExchange`; the Diamond moves the exchange to `COMPLETED` and
+releases the escrowed funds to the seller's available-funds balance.
+
+**Assertions ([`post-commit.test.ts:148–155`](../../test/scenarios/post-commit.test.ts#L148-L155)):**
+`completed.newExchangeState === ExchangeState.COMPLETED` and
+`asserter.expect(..., { state: COMPLETED, … })`.
+
+## Fulfillment timing vs Flow A
+
+The wire schema treats `fulfillment.data` as action-conditional
+([`payment-payload.ts:106`](../../../core/src/schemes/escrow/payment-payload.ts#L106)):
+
+- **Flow B (`boson-createOfferCommitAndRedeem`):** `data` MUST be present
+  (or `null` when the chosen option's schema is `null`). The redeem
+  completes inside the commit transaction, so there's no later round-trip
+  in which the buyer could hand over delivery data — it must ride the
+  `X-PAYMENT`.
+- **Flow A (`boson-createOfferAndCommit`):** `data` MUST be omitted at
+  commit; the buyer attaches it to the redeem-time POST body.
+
+A2 advertises no fulfillment channels, so its `X-PAYMENT` omits the block
+entirely; the rule above is what an inline/atomic-delivery scenario (A6
+under Flow A's fulfillment work) exercises.
+
+## Payload appendix
+
+### `X-PAYMENT` payload (Flow B)
+
+Identical to the [Flow A payload](./flow-a-deferred-commit.md#x-payment-payload)
+except for `payload.action`:
+
+```jsonc
+{
+  "x402Version": 1,
+  "scheme": "escrow",
+  "network": "eip155:31337",
+  "payload": {
+    "action": "boson-createOfferCommitAndRedeem",
+    "tokenAuthStrategy": "none",
+    "offerRef": { "fullOffer": { /* … */ }, "sellerSig": "0x…" },
+    "buyer": "0x…",
+    "metaTx": { "from": "0x…", "nonce": "…", "functionName": "createOfferCommitAndRedeem", "functionSignature": "0x…", "sig": { "v": 27, "r": "0x…", "s": "0x…" } }
+  }
+  // "fulfillment": { "option": "inline", "data": { … } }  // REQUIRED for atomic delivery
+}
+```
+
+### Complete request / response (B2)
+
+```jsonc
+// POST /x402B/complete
+{ "exchangeId": "13", "signedPayload": "0x…" }
+
+// 200
+{ "txHash": "0x…", "nextActions": { "exchangeId": "13", "exchangeState": "COMPLETED", "next": [] } }
+```
+
+`next` is the empty array on the terminal `COMPLETED` state — the harness
+rejects a response that omits `next` or stamps a non-array
+([`post-commit-http.ts:206`](../../src/harness/post-commit-http.ts#L206)).
+
+## Code map
+
+| Step | Harness | SDK / server / facilitator | Boson Diamond |
+|---|---|---|---|
+| GET → 402 | `buyer.fetch` | `expressMiddleware` → `buildPaymentRequirements` → `signFullOffer` | — |
+| Sign X-PAYMENT (Flow B) | `wrapFetchWithPayment` | `client.handle402` → `pickAction` (redeemMode `commit-and-redeem`) | — |
+| Settle atomically | — | `server.handlers.commitAndRedeem` → facilitator `/verify` + `/settle` | `OrchestrationHandlerFacet2.createOfferCommitAndRedeem` |
+| Verify REDEEMED | `asserter.expect` | `verifyExchangeSnapshot` | — |
+| Complete (B2) | `performBuyerPostCommitAction("boson-completeExchange")` | `client.signAction` → `POST /x402B/complete` → `performAction` | `completeExchange` → `releaseFunds` |
+
+Action IDs and their on-chain primitives:
+[`docs/boson-impl-04-state-machine-and-next-actions.md` § Action IDs](../../../../../docs/boson-impl-04-state-machine-and-next-actions.md).
+
+## Failure modes
+
+- **`commit-and-redeem` not advertised:** if the server's `accepts[].actions.next`
+  doesn't list `boson-createOfferCommitAndRedeem` on the `server` channel,
+  `pickAction` throws `NoCompatibleActionError` client-side
+  ([`action.ts:48`](../../../client/src/action.ts#L48)) — the buyer never
+  sends a doomed `X-PAYMENT`.
+- The commit-time validation negatives (C1–C5, C8 — see
+  [Flow A § Failure modes](./flow-a-deferred-commit.md#failure-modes))
+  apply identically to the Flow B `X-PAYMENT`, since both flows share the
+  settle path.

--- a/typescript/packages/x402-e2e/docs/scenarios/flow-c-dispute.md
+++ b/typescript/packages/x402-e2e/docs/scenarios/flow-c-dispute.md
@@ -1,0 +1,248 @@
+# Flow C — Dispute path
+
+> Walkthrough of the post-redeem dispute lifecycle as exercised by the
+> e2e suite. Spec counterpart:
+> [`docs/boson-impl-02-flows.md` § Flow C](../../../../../docs/boson-impl-02-flows.md)
+> and the dispute state machine in
+> [`docs/boson-impl-04-state-machine-and-next-actions.md`](../../../../../docs/boson-impl-04-state-machine-and-next-actions.md).
+
+## Overview & context
+
+Once an exchange is `REDEEMED`, the buyer has a dispute window. Raising a
+dispute moves the **exchange** to `DISPUTED` and starts a separate
+**dispute** state machine in `RESOLVING`. From `RESOLVING` the buyer can:
+
+- **resolve** — a mutual settlement that needs *both* the buyer's and the
+  seller's signature over the same split (`RESOLVED`),
+- **retract** — drop the dispute, releasing funds to the seller
+  (`RETRACTED`), or
+- **escalate** — hand it to the registered dispute resolver
+  (`ESCALATED` → `DECIDED`/`REFUSED`; not yet implemented in the suite).
+
+The defining property the tests pin is the **dual-signature** requirement
+on `resolveDispute`: the buyer assembles the seller's signature as a
+`counterpartySig` before submitting, and a signature from anyone other
+than the seller reverts on-chain.
+
+### Scenarios on this flow
+
+| ID | What it pins | Test |
+|---|---|---|
+| **B3** | `raiseDispute` after redeem → `DISPUTED` + `RESOLVING` | [`post-commit.test.ts:158`](../../test/scenarios/post-commit.test.ts#L158) |
+| **B4** | Mutual `resolveDispute` 50/50 (dual-sig) → `RESOLVED` | [`post-commit.test.ts:188`](../../test/scenarios/post-commit.test.ts#L188) |
+| **B6** | `retractDispute` by buyer → `RETRACTED` (seller wins) | [`post-commit.test.ts:273`](../../test/scenarios/post-commit.test.ts#L273) |
+| **E3** | `resolveDispute` rejects a non-seller counterparty sig, accepts the seller's | [`multi-party.test.ts:163`](../../test/scenarios/multi-party.test.ts#L163) |
+
+Each starts from a fresh `commitFreshExchange(...)` → `boson-redeem`
+sequence (the Flow A legs) to reach `REDEEMED` before raising the dispute.
+
+## Actors
+
+| Actor | Played by | Defined in |
+|---|---|---|
+| **Buyer / client** | `BuyerActor` — drives every transition via `client.signAction` | [`src/harness/buyer-actor.ts`](../../src/harness/buyer-actor.ts) |
+| **Seller** | `SellerActor.signResolutionProposal` — signs the `Resolution` proposal the buyer needs as `counterpartySig` | [`src/harness/seller-actor.ts`](../../src/harness/seller-actor.ts#L122) |
+| **Resource server** | In-process app; mounts `POST /x402B/dispute/{raise,resolve,retract,escalate}` | [`server-express/src/mount.ts:53`](../../../server-express/src/mount.ts#L53) |
+| **Facilitator** | Relays each signed meta-tx; on-chain revert surfaces as HTTP 502 | [`facilitator/src/perform-action/index.ts`](../../../facilitator/src/perform-action/index.ts) |
+| **Dispute resolver** | `ResolverActor` — present in the cast for the escalation branch (B5/B9), **not yet exercised** | [`src/harness/resolver-actor.ts`](../../src/harness/resolver-actor.ts) |
+| **Boson Diamond / Subgraph** | `DisputeHandlerFacet` transitions; asserted via `OnchainAsserter` with a `disputeState` field | [`src/harness/onchain-asserter.ts`](../../src/harness/onchain-asserter.ts) |
+
+## Sequence diagram
+
+The mutual-resolution path (B4 / E3), which subsumes the raise (B3) step:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as BuyerActor
+    participant Sv as Resource Server
+    participant Se as SellerActor
+    participant F as Facilitator
+    participant D as Boson Diamond
+    participant G as Subgraph
+
+    Note over B,D: Precondition: exchange REDEEMED (Flow A legs)
+
+    B->>B: client.signAction({ actionId:"boson-raiseDispute", … })
+    B->>Sv: POST /x402B/dispute/raise { exchangeId, signedPayload }
+    Sv->>F: POST /perform-action
+    F->>D: executeMetaTransaction → raiseDispute
+    D->>D: exchange = DISPUTED, dispute = RESOLVING
+    Sv-->>B: { txHash, nextActions:{ exchangeState:"DISPUTED", disputeState:"RESOLVING", next:[resolve, retract, escalate] } }
+    B->>G: asserter.expect(DISPUTED + RESOLVING)
+
+    Note over B,Se: Mutual resolution needs BOTH signatures
+    Se->>Se: signResolutionProposal({ exchangeId, buyerPercentBasisPoints:5000 })<br/>→ { r, s, v } (core-sdk signDisputeResolutionProposal)
+    B->>B: client.signAction({ actionId:"boson-resolveDispute",<br/>buyerPercent:5000, counterpartySig:{r,s,v} })<br/>→ both sigs baked into metaTx.functionSignature
+    B->>Sv: POST /x402B/dispute/resolve { exchangeId, signedPayload }
+    Sv->>F: POST /perform-action
+    F->>D: executeMetaTransaction → resolveDispute
+    D->>D: dispute = RESOLVED, releaseFunds() per split
+    Sv-->>B: { txHash, nextActions:{ disputeState:"RESOLVED", next:[withdrawFunds] } }
+    B->>G: asserter.expect(DISPUTED + RESOLVED)
+```
+
+## Step-by-step walkthrough
+
+### B3 — raise the dispute
+
+After `boson-redeem`,
+`performBuyerPostCommitAction({ actionId: "boson-raiseDispute", … })`
+([`post-commit.test.ts:168`](../../test/scenarios/post-commit.test.ts#L168))
+signs the meta-tx (`client.signAction`) and `POST`s
+`/x402B/dispute/raise` with `{ exchangeId, signedPayload }`. The
+facilitator submits `raiseDispute`; the Diamond moves the exchange to
+`DISPUTED` and opens the dispute in `RESOLVING`.
+
+The flattened response carries both states
+([`post-commit-http.ts:218`](../../src/harness/post-commit-http.ts#L218)):
+
+**Assertions ([`post-commit.test.ts:176–185`](../../test/scenarios/post-commit.test.ts#L176-L185)):**
+`disputed.newExchangeState === ExchangeState.DISPUTED`,
+`disputed.newDisputeState === DisputeState.RESOLVING`, and
+`asserter.expect(..., { state: DISPUTED, disputeState: RESOLVING, … })`.
+The asserter forwards `disputeState` into `verifyExchangeSnapshot`
+([`onchain-asserter.ts:59`](../../src/harness/onchain-asserter.ts#L59)).
+
+### B4 — mutual resolution (50/50)
+
+The buyer can't resolve alone. The seller first signs the split:
+
+```ts
+const sellerSig = await ctx.seller.signResolutionProposal({
+  exchangeId,
+  buyerPercentBasisPoints: 5000n, // 10000 = 100%
+});
+```
+
+`signResolutionProposal`
+([`seller-actor.ts:122`](../../src/harness/seller-actor.ts#L122)) routes
+through core-sdk's `signDisputeResolutionProposal` (so the EIP-712
+`Resolution(uint256 exchangeId, uint256 buyerPercentBasisPoints)`
+type-list stays in lock-step with the deployed protocol) and returns
+`{ r, s, v, signature }`.
+
+The buyer then aggregates it:
+
+```ts
+performBuyerPostCommitAction({
+  actionId: "boson-resolveDispute",
+  exchangeId, escrowAddress: ctx.escrowAddress, network: ctx.network,
+  buyer: ctx.buyer, resourceServerUrl: ctx.resourceServerUrl,
+  buyerPercent: 5000n,
+  counterpartySig: { r: sellerSig.r, s: sellerSig.s, v: sellerSig.v },
+});
+```
+
+`buyerPercent` and `counterpartySig` are passed to
+`client.signAction({ actionId: "boson-resolveDispute", … })`
+([`post-commit-http.ts:136`](../../src/harness/post-commit-http.ts#L136))
+and **baked into the meta-tx's `functionSignature`** — they are *not*
+separate wire fields. The POST body is still just
+**`{ exchangeId, signedPayload }`**
+([`post-commit-http.ts:153`](../../src/harness/post-commit-http.ts#L153)).
+The facilitator submits `resolveDispute`; the Diamond verifies both
+recovered signers (buyer = `metaTx.from`, seller = the proposal signer),
+moves the dispute to `RESOLVED`, and releases each party's share to their
+available funds balance.
+
+**Assertions ([`post-commit.test.ts:232–240`](../../test/scenarios/post-commit.test.ts#L232-L240)):**
+`resolved.newDisputeState === DisputeState.RESOLVED` and
+`asserter.expect(..., { state: DISPUTED, disputeState: RESOLVED, … })`.
+(The exchange stays `DISPUTED`; the dispute entity transitions
+independently.) The post-`RESOLVED` `next[]` carries the lone
+`boson-withdrawFunds` entry — see
+[boson-impl-04 § nextActions integration](../../../../../docs/boson-impl-04-state-machine-and-next-actions.md).
+
+### B6 — retract
+
+`performBuyerPostCommitAction({ actionId: "boson-retractDispute", … })`
+([`post-commit.test.ts:292`](../../test/scenarios/post-commit.test.ts#L292))
+`POST`s `/x402B/dispute/retract` with `{ exchangeId, signedPayload }`. No
+counterparty signature is needed — the buyer is dropping their own
+dispute, so the funds release to the seller. Result: dispute `RETRACTED`.
+
+**Assertions ([`post-commit.test.ts:300–308`](../../test/scenarios/post-commit.test.ts#L300-L308)):**
+`retracted.newDisputeState === DisputeState.RETRACTED` and
+`asserter.expect(..., { state: DISPUTED, disputeState: RETRACTED, … })`.
+
+### E3 — the dual-signature regression
+
+E3 ([`multi-party.test.ts:163`](../../test/scenarios/multi-party.test.ts#L163))
+isolates "both signatures are required" by changing **only the signer**
+between a failing and a succeeding attempt against the same
+`buyerPercentBasisPoints`:
+
+1. **Negative.** The buyer submits `resolveDispute` with a proposal signed
+   by a throwaway key (a `SellerActor` wrapping a random account, not the
+   real seller). The Diamond recovers the counterparty signer, finds it
+   isn't the seller, and reverts. The facilitator's `ONCHAIN_REVERT`
+   surfaces as HTTP **502**, which the harness throws as
+   `PostCommitActionError` (`rejected.status === 502`). The asserter then
+   confirms the dispute is untouched — still `DISPUTED` + `RESOLVING`.
+2. **Positive.** The real seller signs the identical split; the resolve
+   now succeeds → `RESOLVED`.
+
+This is the clearest worked example of why `resolveDispute` needs the
+counterparty's cooperation, in contrast to `retract`/`raise` which the
+buyer drives alone.
+
+## Payload appendix
+
+### Dispute action request (raise / resolve / retract)
+
+Every buyer-driven dispute transition POSTs the same minimal body; the
+action and (for resolve) the split + counterparty signature are encoded
+*inside* `signedPayload`:
+
+```jsonc
+// POST /x402B/dispute/{raise|resolve|retract}
+{ "exchangeId": "13", "signedPayload": "0x…" }
+```
+
+### Dispute action response
+
+```jsonc
+// raiseDispute → 200
+{ "txHash": "0x…", "nextActions": { "exchangeId": "13", "exchangeState": "DISPUTED", "disputeState": "RESOLVING",
+  "next": [ { "id": "boson-resolveDispute", … }, { "id": "boson-escalateDispute", … }, { "id": "boson-retractDispute", … } ] } }
+
+// resolveDispute → 200
+{ "txHash": "0x…", "nextActions": { "exchangeState": "DISPUTED", "disputeState": "RESOLVED",
+  "next": [ { "id": "boson-withdrawFunds", … } ] } }
+```
+
+### Seller resolution proposal
+
+`SellerActor.signResolutionProposal` returns:
+
+```jsonc
+{ "r": "0x…", "s": "0x…", "v": 27, "signature": "0x…" }  // 65-byte concatenated sig also provided
+```
+
+The buyer passes `{ r, s, v }` as `counterpartySig`; `signature` is the
+equivalent concatenated form (`client.signAction` accepts either).
+
+## Code map
+
+| Step | Harness | SDK / server / facilitator | Boson Diamond |
+|---|---|---|---|
+| Reach `REDEEMED` | `performBuyerPostCommitAction("boson-redeem")` | see Flow A | `redeemVoucher` |
+| Raise dispute | `performBuyerPostCommitAction("boson-raiseDispute")` | `client.signAction` → `POST /x402B/dispute/raise` → `performAction` | `DisputeHandlerFacet.raiseDispute` |
+| Sign seller proposal | `seller.signResolutionProposal` | core-sdk `signDisputeResolutionProposal` (EIP-712 `Resolution`) | — |
+| Mutual resolve | `performBuyerPostCommitAction("boson-resolveDispute", buyerPercent, counterpartySig)` | `client.signAction` (aggregates both sigs) → `POST /x402B/dispute/resolve` | `DisputeHandlerFacet.resolveDispute` |
+| Retract | `performBuyerPostCommitAction("boson-retractDispute")` | `client.signAction` → `POST /x402B/dispute/retract` | `DisputeHandlerFacet.retractDispute` |
+| Verify state | `asserter.expect({ disputeState })` | `verifyExchangeSnapshot` | — |
+
+## Failure modes
+
+| ID | Condition | Expected | Where |
+|---|---|---|---|
+| **E3 (negative)** | `resolveDispute` with a non-seller counterparty sig | on-chain revert → HTTP 502 → `PostCommitActionError`; dispute unchanged | [`multi-party.test.ts:199`](../../test/scenarios/multi-party.test.ts#L199) |
+| **C9** | seller signature mismatch on resolution | rejected | [`validation-post-commit.test.ts`](../../test/scenarios/validation-post-commit.test.ts) |
+| **C10** | redeem after cancel (illegal transition) | rejected | [`validation-post-commit.test.ts`](../../test/scenarios/validation-post-commit.test.ts) |
+
+The escalation branch (`escalateDispute` → resolver `decideDispute`,
+scenarios B5/B9) is specced in the dispute state machine but parked in
+[`_skeletons.test.ts`](../../test/scenarios/_skeletons.test.ts) pending
+dispute-resolver-deposit handling and `ResolverActor` wallet signing.

--- a/typescript/packages/x402-e2e/docs/scenarios/flow-d-channels-nextactions.md
+++ b/typescript/packages/x402-e2e/docs/scenarios/flow-d-channels-nextactions.md
@@ -1,0 +1,206 @@
+# Flow D — Channels & `nextActions`
+
+> Walkthrough of how the protocol stays self-describing and how the buyer
+> reaches each action through more than one transport. Spec counterparts:
+> [`docs/boson-impl-02-flows.md` § Flow D](../../../../../docs/boson-impl-02-flows.md)
+> and [`docs/boson-impl-04-state-machine-and-next-actions.md`](../../../../../docs/boson-impl-04-state-machine-and-next-actions.md).
+
+## Overview & context
+
+x402B is a long-lived protocol: after commit, the buyer may redeem,
+dispute, complete, etc. across many round-trips. Two properties keep that
+robust, and both are what this flow documents:
+
+1. **Self-description.** Every server response carries a `nextActions`
+   envelope listing exactly the legal transitions from the current state,
+   each tagged with the **channels** through which it can be invoked
+   (`server`, `facilitator`, `onchain`, `mcp`, `xmtp`). The client never
+   hard-codes the state machine.
+2. **Channel independence.** The same protocol action can be invoked
+   through different transports. A server that withholds an endpoint or
+   disappears doesn't strand the buyer — `onchain` is always available.
+
+The e2e suite proves both with concrete evidence rather than the abstract
+model: the **D-series** asserts that the envelope on the wire matches the
+protocol's `clientLegalActions(state)` table, and the **B7 cancel** path
+shows the *same* action class travelling a *different* channel
+(facilitator) when the server has no route for it.
+
+### Scenarios on this flow
+
+| ID | What it pins | Test |
+|---|---|---|
+| **D1** | Post-commit `nextActions[]` == `clientLegalActions(COMMITTED)`, carried on the `X-PAYMENT-RESPONSE` header | [`next-actions.test.ts:66`](../../test/scenarios/next-actions.test.ts#L66) |
+| **D2** | Post-redeem `nextActions[]` shrinks to `clientLegalActions(REDEEMED)`, carried on the redeem response body | [`next-actions.test.ts:86`](../../test/scenarios/next-actions.test.ts#L86) |
+| **B7** | Same action class, facilitator channel: `cancelVoucher` via the facilitator's generic `/perform-action` (no server route) | [`post-commit.test.ts:311`](../../test/scenarios/post-commit.test.ts#L311) |
+
+## Actors
+
+| Actor | Role in this flow | Defined in |
+|---|---|---|
+| **Buyer / client** | Reads `nextActions`, picks a channel for each transition | [`src/harness/buyer-actor.ts`](../../src/harness/buyer-actor.ts) |
+| **Resource server** (`server` channel) | Derives `nextActions` (`deriveNextActions`); exposes `/x402B/*` convenience routes | [`actions/src/derive.ts`](../../../actions/src/derive.ts), [`server-express/src/mount.ts`](../../../server-express/src/mount.ts) |
+| **Facilitator** (`facilitator` channel) | Generic `POST /perform-action` relay for any signed meta-tx | [`facilitator/src/perform-action/index.ts`](../../../facilitator/src/perform-action/index.ts) |
+| **Boson Diamond** (`onchain` channel) | Direct submission — the always-available fallback | — |
+| **MCP / XMTP** | Registry channels advertised in `fallback`; not exercised by the suite | — |
+
+## Sequence diagram
+
+The envelope on each hop (D1/D2), and the same action reaching the Diamond
+through two different channels (B-series server route vs B7 facilitator):
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as BuyerActor
+    participant S as Resource Server
+    participant F as Facilitator
+    participant D as Boson Diamond
+
+    Note over B,S: D1 — commit envelope rides the X-PAYMENT-RESPONSE header
+    B->>S: GET /resource + X-PAYMENT
+    S->>S: deriveNextActions(exchange) → clientLegalActions(COMMITTED)
+    S-->>B: 200 + X-PAYMENT-RESPONSE: base64{ exchangeState:"COMMITTED",<br/>next:[redeem, cancelVoucher, raiseDispute*…] }
+    Note over B: assert next[] == clientLegalActions(COMMITTED)
+
+    Note over B,S: D2 — redeem envelope rides the response body; set shrinks
+    B->>S: POST /x402B/redeem  (server channel)
+    S-->>B: { nextActions:{ exchangeState:"REDEEMED",<br/>next:[completeExchange, raiseDispute] } }
+    Note over B: assert next[] == clientLegalActions(REDEEMED)
+
+    Note over B,D: Same action, different channels
+    alt server channel (B1–B6)
+        B->>S: POST /x402B/redeem | /complete | /dispute/*
+        S->>F: POST /perform-action
+        F->>D: executeMetaTransaction → <primitive>
+    else facilitator channel (B7 cancelVoucher — no server route)
+        B->>F: POST /perform-action { action, exchangeId, network, escrowAddress, signedPayload }
+        F->>D: executeMetaTransaction → cancelVoucher
+    else onchain channel (always available)
+        B->>D: executeMetaTransaction(...) directly
+    end
+```
+
+## Step-by-step walkthrough
+
+### D1 — the post-commit envelope matches the legal-action table
+
+After a successful commit, `readXPaymentResponse(res.headers)` decodes the
+`X-PAYMENT-RESPONSE` header into `{ exchangeId, txHash, nextActions }`
+([`next-actions.test.ts:70`](../../test/scenarios/next-actions.test.ts#L70)).
+The test asserts:
+
+- `decoded.nextActions.exchangeState === ExchangeState.COMMITTED`, and
+- the set of `decoded.nextActions.next[].id` equals
+  `clientLegalActions({ exchange: ExchangeState.COMMITTED })`
+  ([`next-actions.test.ts:81`](../../test/scenarios/next-actions.test.ts#L81)).
+
+`clientLegalActions` ([`transitions.ts:98`](../../../core/src/state-machine/transitions.ts#L98))
+is the same source `deriveNextActions` reads on the server, so D1 proves
+the live server stamped the correct state and emitted the matching action
+set across the HTTP hop — not just that a unit-level helper returns the
+right list.
+
+### D2 — the set shrinks after redeem
+
+The test commits then redeems, and asserts
+`redeemed.nextActionIds` (the ids the harness pulls from the redeem
+response's `nextActions.next[]`, [`post-commit-http.ts:96`](../../src/harness/post-commit-http.ts#L96))
+equals `clientLegalActions({ exchange: ExchangeState.REDEEMED })`
+([`next-actions.test.ts:111`](../../test/scenarios/next-actions.test.ts#L111)).
+`redeem` and `cancelVoucher` have dropped off; `completeExchange` and
+`raiseDispute` have appeared — the envelope tracks the state machine, hop
+by hop. Note the two envelopes ride different parts of the response: the
+commit envelope is on the `X-PAYMENT-RESPONSE` **header**, the redeem
+envelope is in the response **body**.
+
+### Channel independence in practice
+
+The suite drives post-commit actions through two channels, proving the
+transport is interchangeable for a given protocol action:
+
+- **`server` channel** — `performBuyerPostCommitAction`
+  ([`post-commit-http.ts:129`](../../src/harness/post-commit-http.ts#L129))
+  `POST`s to the seller's `/x402B/<route>`; the server relays to the
+  facilitator. Used by B1–B6 (redeem, complete, dispute family).
+- **`facilitator` channel** — `performCancelVoucher`
+  ([`facilitator-perform-action.ts:72`](../../src/harness/facilitator-perform-action.ts#L72))
+  `POST`s straight to the facilitator's generic `/perform-action`. B7
+  uses it precisely because the example server mounts **no** `/x402B/cancel`
+  route — yet the action still completes, because the facilitator accepts
+  any well-formed signed meta-tx and the `onchain`/facilitator paths don't
+  depend on the seller's cooperation.
+
+Both channels carry the **same** `signedPayload` (the ABI-encoded
+`BosonMetaTx` from `client.signAction`) and land at the same Diamond
+entrypoint; only the URL and the request envelope differ — compare the
+server body `{ exchangeId, signedPayload }`
+([`mount.ts:106`](../../../server-express/src/mount.ts#L106)) with the
+facilitator body `{ action, exchangeId, network, escrowAddress, signedPayload }`
+([`facilitator-perform-action.ts:110`](../../src/harness/facilitator-perform-action.ts#L110)).
+The `onchain` fallback (the buyer submitting the meta-tx directly) is the
+final guarantee and isn't a separate e2e scenario.
+
+## Payload appendix
+
+### `nextActions` envelope
+
+The full envelope shape (channels, endpoints, `fallback.onchainHints`) is
+specced in
+[`boson-impl-04` § nextActions envelope](../../../../../docs/boson-impl-04-state-machine-and-next-actions.md).
+The fields the D-series pins:
+
+```jsonc
+{
+  "exchangeId": "13",
+  "exchangeState": "COMMITTED",        // or "REDEEMED" after the redeem hop
+  "next": [
+    { "id": "boson-redeem",        "channels": ["server", "facilitator", "onchain"] },
+    { "id": "boson-cancelVoucher", "channels": ["facilitator", "onchain"] }
+    // … exactly clientLegalActions(exchangeState) …
+  ],
+  "fallback": {
+    "onchainHints": {
+      "escrow": "0x…",
+      "metaTxEntrypoints": { "none": "executeMetaTransaction", "erc3009": "executeMetaTransactionWithTokenTransferAuthorization", … },
+      "actionFacets": { "boson-redeem": "ExchangeHandlerFacet", … }
+    }
+  }
+}
+```
+
+### Facilitator-channel request (B7)
+
+```jsonc
+// POST <facilitatorUrl>/perform-action
+{ "action": "boson-cancelVoucher", "exchangeId": "13", "network": "eip155:31337", "escrowAddress": "0x…", "signedPayload": "0x…" }
+
+// 200
+{ "ok": true, "txHash": "0x…", "newExchangeState": "CANCELLED" }
+```
+
+## Code map
+
+| Concern | Harness | SDK / server / facilitator |
+|---|---|---|
+| Derive legal transitions (server) | — | `deriveNextActions` ([`actions/src/derive.ts`](../../../actions/src/derive.ts)) → `clientLegalActions` ([`transitions.ts:98`](../../../core/src/state-machine/transitions.ts#L98)) |
+| Read commit envelope (D1) | `readXPaymentResponse` | decodes `X-PAYMENT-RESPONSE` header |
+| Read redeem envelope (D2) | `performBuyerPostCommitAction` → `result.nextActionIds` | `nextActions.next[]` in the response body |
+| `server` channel | `performBuyerPostCommitAction` | `POST /x402B/<route>` → server relay → facilitator |
+| `facilitator` channel | `performCancelVoucher` | `POST /perform-action` → `performAction` |
+| `onchain` channel | — (buyer submits directly) | `metaTxEntrypoints` from `fallback.onchainHints` |
+
+## Notes & gaps
+
+- The suite asserts envelope **content** (D1/D2) and demonstrates **two
+  usable channels** (server, facilitator) for post-commit actions. It does
+  **not** yet drive an automatic server→facilitator→onchain **fallback on
+  failure** end-to-end; that client-side `tryAllChannels`-style behaviour
+  is the D3 scenario, parked in
+  [`_skeletons.test.ts`](../../test/scenarios/_skeletons.test.ts).
+- The `mcp` channel (D4) awaits `@bosonprotocol/x402-agent`; `xmtp` is
+  advertised in `fallback` but not exercised.
+- Channel ordering in `next[].channels` is the seller's *preferred* order;
+  a client is free to override it (e.g. an agent that always prefers
+  `onchain`). See
+  [`boson-impl-04` § Channels](../../../../../docs/boson-impl-04-state-machine-and-next-actions.md).


### PR DESCRIPTION
## What

Adds standalone Markdown documentation that explains **how x402B actually behaves**, using the e2e suite as the worked example. Each protocol flow becomes a timeline a reader can follow without reverse-engineering the TypeScript: who talks to whom, in what order, with what payloads — and a map back to the real method that runs each step.

New docs under [`typescript/packages/x402-e2e/docs/scenarios/`](typescript/packages/x402-e2e/docs/scenarios/), one per protocol flow:

- **`README.md`** — index: how to read the docs, the per-doc template, and the flow → scenario table.
- **`flow-a-deferred-commit.md`** — A1/A3/A4/A5 commit (all four token-auth strategies), B1 redeem, B7 cancel.
- **`flow-b-atomic-commit-redeem.md`** — A2 atomic commit-and-redeem (single tx → `REDEEMED`), B2 `completeExchange`, and the Flow A↔B fulfillment-timing rule.
- **`flow-c-dispute.md`** — B3 raise, B4 mutual resolve (50/50 dual-sig), B6 retract, E3 dual-signature regression.
- **`flow-d-channels-nextactions.md`** — D1/D2 (envelope == `clientLegalActions`, on the `X-PAYMENT-RESPONSE` header then the redeem body) and the server-vs-facilitator channel evidence (B7), with the `onchain` fallback.

The package [`README.md`](typescript/packages/x402-e2e/README.md) gains a "Scenario walkthroughs" link under the existing scenario inventory.

## Per-doc structure

Overview + scenario table (linked to `test:line`) → actors mapped to code → annotated Mermaid sequence diagram → step-by-step walkthrough (method + request/response payload + assertion per step) → payload appendix (402 `PaymentRequirements`, decoded `X-PAYMENT`, `X-PAYMENT-RESPONSE`, post-commit bodies, `nextActions`) → code-map table → failure modes / gaps.

## Accuracy

Wire shapes are sourced from the packages that own them (core escrow schemas, `server-express` routes, facilitator perform-action, `state-machine` transitions) rather than restated. Grounding in source corrected a few points: the post-commit POST body is `{ exchangeId, signedPayload }` only (`buyerPercent`/`counterpartySig` are baked into the signed meta-tx, not separate fields); `handle402` returns the base64 string directly; and the docs only claim channel behaviours the suite actually exercises (D3 fallback-on-failure and D4 MCP are flagged as specced-but-not-yet-tested).

## Verification

- `prettier --check` passes on all new/edited files.
- All relative link targets and cross-doc anchors resolve on disk.
- Diagrams use the same Mermaid constructs as the already-rendering diagrams in `docs/boson-impl-02-flows.md` (no Mermaid CLI available to machine-render).

Docs-only — no code behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)