### PR TITLE
fix(release): base alpha version on the next release line

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -14,7 +14,7 @@ Pick the affected packages, the bump type (patch / minor / major), and write a s
 
 A single workflow (`.github/workflows/release.yml`) handles two flows:
 
-- **Alpha** — on every push to `main`, queued changesets drive a snapshot publish. Each affected package gets a `<currentVersion>-alpha-<N>` version (counter incremented per publish; resets on the next `latest`). Queued `.md` files are **not** consumed; they stay around for the next `latest`.
+- **Alpha** — on every push to `main`, queued changesets drive a snapshot publish. Each affected package gets a `<nextVersion>-alpha-<N>` version, where `<nextVersion>` is the version the next `latest` will bump to (counter incremented per publish; resets once that `latest` ships and the next line begins). Queued `.md` files are **not** consumed; they stay around for the next `latest`.
 - **Latest** — triggered manually via the Actions UI (`workflow_dispatch`). The workflow runs `changeset version` (consuming queued changesets), commits the bumps + CHANGELOGs to `main`, publishes each bumped package with the default `latest` tag, and opens one GitHub Release per package.
 
 Publishing uses npm [trusted publishers](https://docs.npmjs.com/trusted-publishers) (OIDC). No `NPM_TOKEN` secret is configured — each package's npmjs.com settings must list this repo + `release.yml` as a trusted publisher (one-time setup per package).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,9 +173,9 @@ both publish flows so the npm
 - **Alpha** — every push to `main` triggers
   [`scripts/publish-alpha.mjs`](./scripts/publish-alpha.mjs). It uses
   `@changesets/get-release-plan` to find the packages affected by
-  currently-queued changesets, queries npm for any prior
-  `<currentVersion>-alpha-N` versions, and publishes
-  `<currentVersion>-alpha-<next-N>` for each affected package (transitive
+  currently-queued changesets (and the next version each will bump to),
+  queries npm for any prior `<nextVersion>-alpha-N` versions, and publishes
+  `<nextVersion>-alpha-<next-N>` for each affected package (transitive
   workspace dependents included so cross-package `workspace:*` references
   resolve to consistent alpha versions). Queued `.md` changesets are
   **not** consumed by the alpha flow.

--- a/scripts/publish-alpha.mjs
+++ b/scripts/publish-alpha.mjs
@@ -94,11 +94,14 @@ async function main() {
     }
     const pkgJsonPath = join(pkgDir, "package.json");
     const pkgJson = JSON.parse(await readFile(pkgJsonPath, "utf8"));
-    const baseVersion = pkgJson.version;
+    // Base the alpha line on the *next* release version (the bump implied by the
+    // queued changesets), not the currently-published version — so an alpha is a
+    // preview of the version the next `latest` will ship.
+    const baseVersion = release.newVersion;
     const existing = await npmVersions(release.name);
     const counter = nextAlphaCounter(existing, baseVersion);
     const newVersion = `${baseVersion}-alpha-${counter}`;
-    console.log(`${release.name}: ${baseVersion} -> ${newVersion}`);
+    console.log(`${release.name}: ${release.oldVersion} -> ${newVersion}`);
     pkgJson.version = newVersion;
     writes.push({
       path: pkgJsonPath,


### PR DESCRIPTION
## What

`scripts/publish-alpha.mjs` computed each package's alpha suffix from its **currently published** version (`pkgJson.version`). For a package sitting at a released `0.2.0`, a queued patch changeset produced `0.2.0-alpha-N` — re-using the already-released number instead of previewing the version the next `latest` will actually ship.

This bases the alpha line on `release.newVersion` from the changeset release plan, so an alpha reflects the bump implied by the queued changesets:

| package | bump | before | after |
|---|---|---|---|
| `x402-client` | minor | `0.2.0-alpha-N` | `0.3.0-alpha-N` |
| `x402-core` / `x402-paywall` / `x402-client-browser` | patch (incl. transitive) | `0.2.0-alpha-N` | `0.2.1-alpha-N` |
| `x402-client-fetch` | minor | `0.1.2-alpha-N` | `0.2.0-alpha-N` |

The `-alpha-N` counter logic is unchanged (starts at 0 / increments off prior npm versions), just keyed on the next-version line. The repo `version` field still stays clean between releases (alpha is never committed), so the next `latest` resolves to the clean `a.b.c`. No change to tag format, `publish-latest.mjs`, or `release.yml`.

The per-package log now prints `oldVersion -> newVersion`.

## Docs

`CLAUDE.md` and `.changeset/README.md` updated to describe the alpha format as `<nextVersion>-alpha-N` rather than `<currentVersion>-alpha-N`.

## Verification

- Computation verified against the currently-queued changesets (npm lookup stubbed, since this machine can't reach the registry over TLS): yields the `after` column above.
- `pnpm build && pnpm test && pnpm lint && pnpm format:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)