### PR TITLE
chore(release): add retroactive changeset for PR #68 server rollup

### DIFF
--- a/.changeset/server-production-readiness-rollup.md
+++ b/.changeset/server-production-readiness-rollup.md
@@ -1,0 +1,13 @@
+---
+"@bosonprotocol/x402-server": minor
+"@bosonprotocol/x402-facilitator-express": minor
+---
+
+Production-readiness rollup for the server SDK (PR #68): persistent Store with
+recovery, request mutex/concurrency guard, facilitator-client hardening,
+structured logger, production-mode config validation, recovery replay API, and
+health-check endpoint. `facilitator-express` mounts a `GET /healthz` liveness
+probe.
+
+This changeset is added retroactively: PR #68 merged without one, so its changes
+were never version-bumped or published.


### PR DESCRIPTION
## Why

PR #68 (production-readiness rollup) merged without a changeset, and the previously-queued changesets had just been consumed by a `latest` release immediately before it (`f2c19c3 chore(release): version packages [skip ci]`). So when #68 merged, `.changeset/` was empty and the alpha workflow logged **"No changesets queued — skipping alpha publish"** — its changes to `x402-server` and `x402-facilitator-express` were never version-bumped or published.

This adds the missing changeset retroactively so those packages publish.

## Effect

On merge to `main`, the push triggers the alpha publish:

| Package | Bump | Version |
|---|---|---|
| `@bosonprotocol/x402-server` | minor | `0.2.0` → `0.3.0-alpha-0` |
| `@bosonprotocol/x402-facilitator-express` | minor | `0.1.2` → `0.2.0-alpha-0` |
| `@bosonprotocol/x402-server-express` | patch (transitive) | `0.1.2` → `0.1.3-alpha-0` |

(Private packages — `x402-e2e`, the `examples/*` — are not published.)

A subsequent `latest` workflow_dispatch then ships clean `0.3.0` / `0.2.0` / `0.1.3`.

Verified against `@changesets/get-release-plan` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health-check endpoint for server monitoring.
  * Added recovery replay API for data persistence.
  * Introduced structured logging for improved observability.
  * Enhanced production-mode configuration validation.

* **Chores**
  * Server SDK packages (`@bosonprotocol/x402-server`, `@bosonprotocol/x402-facilitator-express`) updated with minor version bumps for production readiness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bosonprotocol/x402B/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->