### PR TITLE
ci: enforce changeset coverage on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,10 @@ name: CI
 on:
   pull_request:
     branches: ["**"]
-    types: [opened, synchronize, reopened, ready_for_review]
+    # `labeled`/`unlabeled` so the changeset-coverage check re-evaluates when the
+    # `no-changeset` escape-hatch label is toggled (the build/test/e2e jobs skip
+    # those events — see their `if:` — so a label change stays cheap).
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   push:
     branches: [main]
 
@@ -47,6 +50,8 @@ jobs:
   build-test-lint:
     name: build / test / lint (node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    # Skip on label-only events (they don't change code).
+    if: github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')
     strategy:
       fail-fast: false
       matrix:
@@ -87,7 +92,8 @@ jobs:
   e2e-pr:
     name: e2e (@p0 + @p1)
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
+    # Skip drafts, and label-only events (they don't change code).
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,32 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  # Fails a PR that changes a publishable package without a changeset that names
+  # it — the gap that let PR #68 merge without ever publishing. No `pnpm install`
+  # needed: the script reads package.json files + git directly. Bypass an
+  # intentional no-release change with the `no-changeset` label.
+  changeset-coverage:
+    name: changeset coverage
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+
+      - run: git fetch --no-tags origin ${{ github.event.pull_request.base.ref }}
+
+      - name: Check changeset coverage
+        env:
+          CHANGESET_BASE: origin/${{ github.event.pull_request.base.ref }}
+          HAS_OVERRIDE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no-changeset') }}
+        run: node scripts/check-changeset-coverage.mjs
+
   build-test-lint:
     name: build / test / lint (node ${{ matrix.node }})
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "format:check": "prettier --check .",
     "clean": "turbo run clean && rm -rf node_modules",
     "changeset": "changeset",
+    "changeset:coverage": "node scripts/check-changeset-coverage.mjs",
     "version": "changeset version",
     "release": "turbo run build && changeset publish",
     "publish:alpha": "node scripts/publish-alpha.mjs",

--- a/scripts/check-changeset-coverage.mjs
+++ b/scripts/check-changeset-coverage.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Fails when a PR changes a publishable workspace package but no queued
+// changeset declares that package — i.e. the change would silently never be
+// versioned or published (the class of miss that let PR #68 merge without an
+// alpha). `changeset status` only checks that *some* changeset exists; this
+// also checks the changeset names the *specific* packages that changed.
+//
+// Scope: only publishable packages (private packages and anything matched by a
+// workspace glob that has no package.json are ignored), so docs-only or
+// example-only / e2e-only PRs don't need a changeset.
+//
+// Escape hatch: set the `no-changeset` label on the PR (the workflow forwards
+// it as HAS_OVERRIDE_LABEL=true) for a change that intentionally ships nothing.
+import { spawnSync } from "node:child_process";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, sep } from "node:path";
+
+const ROOT = process.cwd();
+
+// Kept in sync with pnpm-workspace.yaml. Both entries are single-level `<dir>/*`
+// globs, so we just read each parent's immediate child directories.
+const WORKSPACE_GLOB_PARENTS = ["typescript/packages", "examples"];
+
+function git(args) {
+  const r = spawnSync("git", args, { cwd: ROOT, encoding: "utf8" });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${r.stderr || r.stdout}`);
+  }
+  return r.stdout;
+}
+
+const toPosix = (p) => p.split(sep).join("/");
+
+// All workspace packages -> { name, dir (posix, relative to ROOT), private }.
+function workspacePackages() {
+  const pkgs = [];
+  for (const parent of WORKSPACE_GLOB_PARENTS) {
+    const parentAbs = join(ROOT, parent);
+    if (!existsSync(parentAbs)) continue;
+    for (const entry of readdirSync(parentAbs, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const pkgJsonPath = join(parentAbs, entry.name, "package.json");
+      if (!existsSync(pkgJsonPath)) continue;
+      const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+      if (!pkg.name) continue;
+      pkgs.push({ name: pkg.name, dir: `${parent}/${entry.name}`, private: pkg.private === true });
+    }
+  }
+  return pkgs;
+}
+
+// Package names declared across every queued changeset's frontmatter.
+function declaredPackages(dir) {
+  const declared = new Set();
+  if (!existsSync(dir)) return declared;
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith(".md") || file.toLowerCase() === "readme.md") continue;
+    const content = readFileSync(join(dir, file), "utf8");
+    const fm = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!fm) continue;
+    for (const line of fm[1].split(/\r?\n/)) {
+      const m = line.match(/^\s*["']?(@?[^"':]+?)["']?\s*:\s*(patch|minor|major)\s*$/);
+      if (m) declared.add(m[1].trim());
+    }
+  }
+  return declared;
+}
+
+function main() {
+  if (process.env.HAS_OVERRIDE_LABEL === "true") {
+    console.log("`no-changeset` label present — skipping changeset coverage check.");
+    return;
+  }
+
+  const base = process.env.CHANGESET_BASE || "origin/main";
+  // Three-dot: files changed on HEAD since it diverged from base (the PR's diff).
+  const changedFiles = git(["diff", "--name-only", `${base}...HEAD`])
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(toPosix);
+
+  // Longest dir first so a nested path resolves to its most specific package.
+  const packages = workspacePackages().sort((a, b) => b.dir.length - a.dir.length);
+
+  const changedPublishable = new Set();
+  for (const file of changedFiles) {
+    const pkg = packages.find((p) => file === p.dir || file.startsWith(p.dir + "/"));
+    if (pkg && !pkg.private) changedPublishable.add(pkg.name);
+  }
+
+  if (changedPublishable.size === 0) {
+    console.log("No publishable package changed — changeset not required.");
+    return;
+  }
+
+  const declared = declaredPackages(join(ROOT, ".changeset"));
+  const missing = [...changedPublishable].filter((n) => !declared.has(n)).sort();
+  const extra = [...declared].filter((n) => !changedPublishable.has(n)).sort();
+
+  console.log(`Base ref:               ${base}`);
+  console.log(`Changed (publishable):  ${[...changedPublishable].sort().join(", ")}`);
+  console.log(`Declared in changesets: ${[...declared].sort().join(", ") || "(none)"}`);
+
+  if (extra.length) {
+    console.warn(`\n⚠️  Declared but unchanged in this PR: ${extra.join(", ")}`);
+  }
+
+  if (missing.length) {
+    console.error(
+      `\n❌ These changed publishable packages have no changeset entry:\n` +
+        missing.map((n) => `   - ${n}`).join("\n") +
+        `\n\nRun \`pnpm changeset\` and select them. If this change intentionally\n` +
+        `ships no release, add the \`no-changeset\` label to the PR instead.`,
+    );
+    process.exit(1);
+  }
+
+  console.log("\n✅ Every changed publishable package is covered by a changeset.");
+}
+
+main();


### PR DESCRIPTION
## Why

PR #68 merged without a changeset, so its `x402-server` / `x402-facilitator-express` changes were never versioned or published (the alpha run logged "No changesets queued — skipping"). The built-in `changeset status` only checks that *some* changeset exists — it does **not** verify the changeset names the packages a PR actually touched.

## What

`scripts/check-changeset-coverage.mjs` diffs the PR against its base, maps changed files to **publishable** workspace packages, and fails when a changed publishable package is not declared in any queued changeset.

- Private packages, docs, and `examples/*` are exempt (no false positives on docs-only / e2e-only PRs).
- Dependency-free: reads `package.json` + `git` directly, so the CI job needs no `pnpm install`.
- Runs as a PR-only `changeset coverage` job in `ci.yml`.
- **Escape hatch:** add the `no-changeset` label to bypass for a change that intentionally ships no release.
- Does **not** check bump *level* (patch/minor/major) — that stays reviewer judgment.

## Verification

Tested locally against real history (`base = 17cf93d`, just before PR #68):

| Case | Result |
|---|---|
| Only tooling files changed | `No publishable package changed` → exit 0 |
| server + facilitator-express changed, changeset present | covered → exit 0 |
| same, changeset removed (the PR #68 scenario) | lists both packages → **exit 1** |
| `no-changeset` label set | skipped → exit 0 |

This PR itself touches only tooling files, so the new check passes here (no publishable package changed).

## Follow-up (manual repo settings)

1. Create the **`no-changeset`** label so the override is selectable.
2. Mark **`changeset coverage`** a **required status check** in branch protection so it blocks merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)