### PR TITLE
docs: align spec docs and README with the shipped implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ All packages publish under `@bosonprotocol/`.
 | [`x402-paywall`](https://www.npmjs.com/package/@bosonprotocol/x402-paywall) | Browser paywall for the `escrow` scheme. `generateHtml(payload, config?)` plus an `evmEscrowPaywall: PaywallProvider` instance, both producing a self-contained HTML 402 body with the React app bundle (wagmi + viem inlined). Mirrors upstream `@x402/paywall`'s `PaywallProvider` contract. |
 | [`x402-facilitator`](https://www.npmjs.com/package/@bosonprotocol/x402-facilitator) | Reference verify + settle service for the `escrow` scheme. Submits via `MetaTransactionsHandlerFacet.executeMetaTransactionWithTokenTransferAuthorization`. Express adapter below. |
 | [`x402-facilitator-express`](https://www.npmjs.com/package/@bosonprotocol/x402-facilitator-express) | Express adapter for `x402-facilitator` — mountable router exposing `/verify`, `/settle`, and `/perform-action`. |
-| [`x402-fulfillment`](https://www.npmjs.com/package/@bosonprotocol/x402-fulfillment) | Pluggable `FulfillmentChannel` interface + atomic / email / XMTP / webhook / IPFS-pointer implementations. |
+| [`x402-fulfillment`](https://www.npmjs.com/package/@bosonprotocol/x402-fulfillment) | Pluggable `FulfillmentChannel` interface + inline / email / XMTP / webhook / IPFS-pointer implementations. |
 | [`x402-actions`](https://www.npmjs.com/package/@bosonprotocol/x402-actions) | Channel registry, `ChannelAdapter` contract, and the `nextActions` envelope builder. Drives off the state-machine tables in `x402-core` to advertise legal next transitions on every server response and powers the post-redeem endpoint set. |
 
 ---
@@ -58,8 +58,8 @@ This repo implements the [`x402-escrow-schema`](https://github.com/bosonprotocol
 | 02 | [boson-impl-02-flows.md](./docs/boson-impl-02-flows.md) | detailed — sequence diagrams |
 | 03 | [boson-impl-03-fulfillment-channels.md](./docs/boson-impl-03-fulfillment-channels.md) | detailed — pluggable fulfillment channels |
 | 04 | [boson-impl-04-state-machine-and-next-actions.md](./docs/boson-impl-04-state-machine-and-next-actions.md) | detailed — self-describing responses |
-| 05 | [boson-impl-05-server-sdk.md](./docs/boson-impl-05-server-sdk.md) | stub |
-| 06 | [boson-impl-06-client-sdk.md](./docs/boson-impl-06-client-sdk.md) | stub |
+| 05 | [boson-impl-05-server-sdk.md](./docs/boson-impl-05-server-sdk.md) | detailed — implemented server SDK surface |
+| 06 | [boson-impl-06-client-sdk.md](./docs/boson-impl-06-client-sdk.md) | detailed — implemented client SDK surface |
 | 07 | [boson-impl-07-facilitator.md](./docs/boson-impl-07-facilitator.md) | detailed — facilitator service contract |
 | 08 | [boson-impl-08-agent-mode.md](./docs/boson-impl-08-agent-mode.md) | stub |
 | 09 | [boson-impl-09-seller-metadata.md](./docs/boson-impl-09-seller-metadata.md) | stub |

--- a/docs/boson-impl-00-overview.md
+++ b/docs/boson-impl-00-overview.md
@@ -13,14 +13,14 @@ The SDK is designed so that **existing x402 servers and clients can adopt it as 
 ```mermaid
 flowchart LR
     subgraph Client side
-      App[App / Agent] --> CL[("@bosonprotocol/x402-client<br/>(+axios/fetch)")]
+      App[App / Agent] --> CL[("@bosonprotocol/x402-client<br/>(+fetch/browser)")]
       CL --> DEL[("@bosonprotocol/x402-fulfillment")]
       CL --> ACT[("@bosonprotocol/x402-actions")]
-      AGT[("@bosonprotocol/x402-agent")] -.MCP.-> CL
+      AGT[("@bosonprotocol/x402-agent<br/>(planned)")] -.MCP.-> CL
     end
 
     subgraph Server side
-      Resource[Resource server] --> SR[("@bosonprotocol/x402-server<br/>(+express/hono/next)")]
+      Resource[Resource server] --> SR[("@bosonprotocol/x402-server<br/>(+express; hono/next planned)")]
       SR --> DEL2[("@bosonprotocol/x402-fulfillment")]
       SR --> ACT2[("@bosonprotocol/x402-actions")]
     end
@@ -56,12 +56,27 @@ All packages publish under `@bosonprotocol/`.
 |---|---|
 | `x402-core` | `escrow` scheme JSON schemas + TypeScript types; EIP-712 builders for FullOffer (protocol domain), the protocol meta-tx envelope, and the four BPIP-12 token-auth strategies (ERC-3009 ReceiveWithAuthorization, EIP-2612 Permit, Permit2, plain approve); exchange state machine model. |
 | `x402-evm` | EVM-specific implementation. Calldata builders for `ExchangeCommitFacet.createOfferAndCommit` (deferred) and `OrchestrationHandlerFacet2.createOfferCommitAndRedeem` (atomic on-chain redeem), plus viem `Web3LibAdapter` bridges used by facilitator/core-sdk meta-transaction submission. Wraps `@bosonprotocol/core-sdk`. |
-| `x402-server` | Framework-agnostic resource server. 402 builder, FullOffer signer wrapper, fulfillment negotiator, `nextActions` emitter, post-redeem endpoint set. Adapter sub-packages: `x402-server-express`, `x402-server-hono`, `x402-server-next`. |
-| `x402-client` | Framework-agnostic client. Interceptor that parses the 402, picks a fulfillment channel option and a token-auth strategy, signs the meta-tx + token authorization(s), retries, then drives post-redeem actions through whichever channel is preferred. Adapters: `x402-client-axios`, `x402-client-fetch`. |
+| `x402-server` | Framework-agnostic resource server. 402 builder, FullOffer signer wrapper, fulfillment negotiator, `nextActions` emitter, post-redeem endpoint set. |
+| `x402-server-express` | Express adapter for `x402-server` — middleware + mountable router wiring the 402 builder and post-redeem endpoint set into an Express app. |
+| `x402-client` | Framework-agnostic client. Interceptor that parses the 402, picks a fulfillment channel option and a token-auth strategy, signs the meta-tx + token authorization(s), retries, then drives post-redeem actions through whichever channel is preferred. |
+| `x402-client-fetch` | Native-`fetch` adapter for `x402-client` — wraps `fetch` to intercept 402 escrow-scheme responses and retry with the generated `X-PAYMENT` header. |
+| `x402-client-browser` | Browser-environment adapters for the buyer SDK — `signerFromWalletClient` (viem `WalletClient`) and `signerFromEip1193` (raw EIP-1193 provider); re-exports the full `x402-client` surface. |
+| `x402-paywall` | Browser paywall for the `escrow` scheme. `generateHtml(payload, config?)` plus an `evmEscrowPaywall: PaywallProvider`, producing a self-contained HTML 402 body with the React app bundle (wagmi + viem inlined). Mirrors upstream `@x402/paywall`'s `PaywallProvider`. |
 | `x402-facilitator` | Reference verify + settle + perform-action service for the `escrow` scheme. Submits through `coreSdk.executeMetaTransaction(...)`, which routes to the bare meta-tx entrypoint or the BPIP-12 token-transfer-authorization entrypoint based on the chosen token-auth strategy. |
-| `x402-fulfillment` | Pluggable `FulfillmentChannel` interface + atomic / email / XMTP / webhook / IPFS-pointer implementations. |
+| `x402-facilitator-express` | Express adapter for `x402-facilitator` — mountable router exposing `/verify`, `/settle`, and `/perform-action`. |
+| `x402-fulfillment` | Pluggable `FulfillmentChannel` interface + inline / email / XMTP / webhook / IPFS-pointer implementations. |
 | `x402-actions` | Exchange state machine + channel registry. Powers the `nextActions` envelope on every server response and the post-redeem endpoint set. |
-| `x402-agent` | Thin glue layer for AI-agent clients. Bridges to `bosonprotocol/agentic-commerce` MCP and lets agents pick channel (server / facilitator / on-chain / MCP) per action. |
+
+### Planned (not yet implemented)
+
+These appear in the diagram above and elsewhere in this spec, but are not yet shipped:
+
+| Package | Purpose |
+|---|---|
+| `x402-client-axios` | Planned axios adapter for `x402-client` (counterpart to `x402-client-fetch`). |
+| `x402-server-hono` | Planned Hono adapter for `x402-server`. |
+| `x402-server-next` | Planned Next.js adapter for `x402-server`. |
+| `x402-agent` | Planned thin glue layer for AI-agent clients. Bridges to `bosonprotocol/agentic-commerce` MCP and lets agents pick channel (server / facilitator / on-chain / MCP) per action. See [08](./boson-impl-08-agent-mode.md). |
 
 ## What we reuse (do not rebuild)
 

--- a/docs/boson-impl-03-fulfillment-channels.md
+++ b/docs/boson-impl-03-fulfillment-channels.md
@@ -95,14 +95,14 @@ export interface FulfillmentChannel<TServerCfg = unknown, TBuyerData = unknown> 
   /** Stable identifier used in the wire format. */
   readonly id: string;
 
-  /** JSON Schema describing what the buyer must put in `fulfillment.data`. */
-  readonly buyerDataSchema: JSONSchema7 | null;
+  /** JSON-Schema-shaped description of what the buyer must put in `fulfillment.data`. */
+  readonly buyerDataSchema: Record<string, unknown> | null;
 
   /** Server-side config: keys, urls, etc. */
   configure(cfg: TServerCfg): void;
 
   /** Server: build the `options[]` entry for the 402 response. */
-  describe(): { id: string; schema: JSONSchema7 | null; metadata?: unknown };
+  describe(): FulfillmentOption; // { id: string; schema: Record<string, unknown> | null; metadata?: unknown }
 
   /** Server: validate the buyer's attached data. */
   validate(data: TBuyerData): { ok: true } | { ok: false; reason: string };
@@ -131,8 +131,8 @@ export type FulfillmentResult =
 | `xmtp` | Push to buyer's XMTP inbox | `{ xmtpAddress: string }` (EOA) | Useful for AI-agent buyers that already use XMTP for commerce. |
 | `webhook` | Push to buyer-controlled HTTPS endpoint | `{ url: string, authToken?: string, encryptionPubKey?: string }` | See [Webhook security](#webhook-security) below. Server signs the envelope with the key under `metadata.serverPublicKey`; client verifies signature. |
 | `ipfs-pointer` | Server uploads to IPFS, returns CID | `{ recipientPubKey?: string }` | Optional encryption to recipientPubKey. Returned on redeem. |
-| `widget` | Human buyer + physical goods (existing Boson Redemption Widget) | `null` (collected by widget) | `metadata.widgetUrl` points the human to the existing redemption widget. The widget's existing backend hook is reused unchanged. |
-| `mcp` | AI-agent buyer drives a server-exposed MCP tool | `{ mcpEndpoint?: string }` | The seller's MCP exposes a `submit_fulfillment_data(exchangeId, ...)` tool. The buyer's agent calls it post-commit. |
+| `widget` | Human buyer + physical goods (existing Boson Redemption Widget) | `null` (collected by widget) | **Planned / not yet implemented.** `metadata.widgetUrl` points the human to the existing redemption widget. The widget's existing backend hook is reused unchanged. |
+| `mcp` | AI-agent buyer drives a server-exposed MCP tool | `{ mcpEndpoint?: string }` | **Planned / not yet implemented.** The seller's MCP exposes a `submit_fulfillment_data(exchangeId, ...)` tool. The buyer's agent calls it post-commit. |
 
 The registry is open: third parties can ship additional channels as `@bosonprotocol/x402-fulfillment-<id>` packages and register them with the SDK at startup.
 

--- a/docs/boson-impl-05-server-sdk.md
+++ b/docs/boson-impl-05-server-sdk.md
@@ -69,6 +69,8 @@ so misconfiguration fails at boot rather than inside a 402 response. Field refer
 | `exchangeFulfillmentOptionStore` | optional | Per-exchange option allowlist (Flow A). Defaults to an in-memory `Map`; multi-instance hosts plug in a shared store. |
 | `fulfillmentRecoveryStore` | optional | Per-exchange retry log for redeem-side dispatch failures. See `FulfillmentRecoveryEntry.phase` for the two retry steps. |
 | `fulfillmentChannels` | optional | Subset of `@bosonprotocol/x402-fulfillment`'s `FulfillmentChannel`. Required only if the host accepts redeem-time fulfillment updates; absent means redeem requests carrying `fulfillment` are rejected with `FULFILLMENT_CHANNELS_NOT_CONFIGURED`. |
+| `logger` | optional | Structured logger threaded through the handlers and the facilitator HTTP client (recovery-store writes, channel-`onCommit` failures, facilitator retry attempts, boot diagnostics). Defaults to a no-op. |
+| `mode` | optional | `"development"` (default) or `"production"`. In `"production"` a boot-time `superRefine` upgrades the runtime-optional fields (`exchangeReader`, one of `coreSdkRead` / `subgraphUrl`, `exchangeFulfillmentOptionStore`, `fulfillmentRecoveryStore`) into synchronous `ZodError`s, so a misconfigured deploy fails at `createX402bServer` time rather than on the first request. |
 
 ## Factory surface
 


### PR DESCRIPTION
## What & why

Audited every `docs/boson-impl-*.md` against the packages under `typescript/packages/*` and corrected the docs that had drifted from the code. Per the repo's "production over spec" rule the implementation is ground truth, so the docs were brought in line with it (no protocol-level discrepancy surfaced). Docs-only — no package source touched.

8 of 10 spec docs were already accurate; the drift was concentrated in two files plus the root README.

## Changes

- **overview (00)** — package map split into **shipped** vs a new **Planned (not yet implemented)** section (`x402-client-axios`, `x402-server-hono`, `x402-server-next`, `x402-agent`); added the shipped `x402-server-express`, `x402-client-fetch`, `x402-client-browser`, `x402-paywall`, `x402-facilitator-express` rows; fulfillment channel id `atomic` → `inline`; mermaid adapter/agent annotations updated.
- **fulfillment-channels (03)** — `widget` and `mcp` channels marked planned (only `inline`/`email`/`xmtp`/`webhook`/`ipfs-pointer` ship); `FulfillmentChannel` interface types aligned with src (`buyerDataSchema: Record<string, unknown>`; `describe(): FulfillmentOption`).
- **server-sdk (05)** — documented the implemented `logger` and `mode` config fields.
- **README** — same `atomic` → `inline` fix; document-map rows 05/06 marked as implemented SDK surfaces.

## Verified accurate (no change)

Docs 01, 02, 04, 06, 07; docs 08/09 remain correct stubs.

## Testing

`npx prettier --check` passes on all four files. No changeset needed (docs-only PRs are exempt per `scripts/check-changeset-coverage.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)