### PR TITLE
chore: add missing changeset for the stable @bosonprotocol deps bump

### DIFF
--- a/.changeset/bump-bosonprotocol-deps-to-stable.md
+++ b/.changeset/bump-bosonprotocol-deps-to-stable.md
@@ -1,0 +1,15 @@
+---
+"@bosonprotocol/x402-core": patch
+"@bosonprotocol/x402-evm": patch
+"@bosonprotocol/x402-client": patch
+"@bosonprotocol/x402-facilitator": patch
+"@bosonprotocol/x402-server": patch
+---
+
+Bump `@bosonprotocol/core-sdk` (1.48.0-alpha.6 → 1.48.0) and
+`@bosonprotocol/common` (1.33.0-alpha.7 → 1.33.0) off the pre-release lines to
+their stable releases, so consumers of `@bosonprotocol/x402-*` resolve the
+matching stable peer chain (PR #113).
+
+This changeset is added retroactively: PR #113 merged without one, leaving the
+*latest* release flow with nothing to consume.


### PR DESCRIPTION
## Why

The **Release** workflow (`workflow_dispatch` / *latest* flow) [failed](https://github.com/bosonprotocol/x402B/actions/runs/27011920615/job/79717358702) at the `Fail if no changesets were queued` guard:

```
🦋  warn No unreleased changesets found, exiting.
##[error]No queued changesets — nothing to release.
```

#113 bumped `@bosonprotocol/core-sdk` (1.48.0-alpha.6 → 1.48.0) and `@bosonprotocol/common` (1.33.0-alpha.7 → 1.33.0) across five publishable packages, but merged without a changeset — so `changeset version` had nothing to consume and the release correctly refused to cut an empty publish.

## What

Adds one retroactive **patch** changeset covering the five packages whose `package.json` changed in #113:

- `@bosonprotocol/x402-core`, `x402-evm`, `x402-client`, `x402-facilitator`, `x402-server`

Patch is the right level: the change is a dependency-specifier move from pre-release to stable, with no API/source change in these packages. The seven internal dependents resolve their `workspace:^` ranges to the new patch versions, so they don't need republishing.

## Verification

- `pnpm exec changeset status` lists the five packages (no longer empty).
- `pnpm build && pnpm test && pnpm lint && pnpm format:check` all green.
- Dry-run `changeset version` (reverted) confirmed: core 0.2.1→0.2.2, evm 0.2.0→0.2.1, client 0.3.0→0.3.1, facilitator 1.0.0→1.0.1, server 0.3.0→0.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated core platform dependencies to stable versions, replacing pre-release builds with production-ready releases to ensure improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->