### PR TITLE
ci(release): verify every changed package has a changeset before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,24 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # Guards against under-publishing: the "Fail if no changesets were queued"
+      # step below only checks that *some* changeset exists, not that every
+      # package changed since the last release is covered. This re-runs the
+      # changeset-coverage check with the previous release commit as the base,
+      # before the changesets are consumed (so the .md files are still present).
+      # RELEASE_COVERAGE disables the PR-only `no-changeset` bypass.
+      - name: Verify every package changed since last release has a changeset
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_COVERAGE: "true"
+        run: |
+          BASE=$(git log -1 --format=%H --grep='chore(release): version packages' || true)
+          if [ -z "$BASE" ]; then
+            BASE=$(git rev-list --max-parents=0 HEAD | tail -1)
+          fi
+          echo "Coverage base (last release commit): ${BASE:-<none>}"
+          CHANGESET_BASE="$BASE" node scripts/check-changeset-coverage.mjs
+
       - name: Consume changesets (bump versions + CHANGELOG)
         if: github.event_name == 'workflow_dispatch'
         run: pnpm exec changeset version

--- a/scripts/check-changeset-coverage.mjs
+++ b/scripts/check-changeset-coverage.mjs
@@ -11,6 +11,14 @@
 //
 // Escape hatch: set the `no-changeset` label on the PR (the workflow forwards
 // it as HAS_OVERRIDE_LABEL=true) for a change that intentionally ships nothing.
+//
+// Two callers, both driven by CHANGESET_BASE:
+//   - PR CI (base = origin/<target>): does this PR cover what it changed?
+//   - Release (base = last release commit, RELEASE_COVERAGE=true): does every
+//     publishable package changed since the last release have a queued
+//     changeset? Catches the gap a per-PR `no-changeset` label can leave behind
+//     (e.g. PR #113). The label bypass is disabled here — there is no PR to
+//     label, and a release must never silently skip a package that changed.
 import { spawnSync } from "node:child_process";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join, sep } from "node:path";
@@ -67,7 +75,11 @@ function declaredPackages(dir) {
 }
 
 function main() {
-  if (process.env.HAS_OVERRIDE_LABEL === "true") {
+  // The `no-changeset` PR label is a per-PR escape hatch only; the release-time
+  // invocation ignores it (there is no PR to label).
+  const releaseMode = process.env.RELEASE_COVERAGE === "true";
+
+  if (!releaseMode && process.env.HAS_OVERRIDE_LABEL === "true") {
     console.log("`no-changeset` label present — skipping changeset coverage check.");
     return;
   }
@@ -106,11 +118,16 @@ function main() {
   }
 
   if (missing.length) {
+    const hint = releaseMode
+      ? `\n\nThese changed since the last release but were never queued for a\n` +
+        `version bump. Add a changeset for each (\`pnpm changeset\`), merge it,\n` +
+        `then re-run the release.`
+      : `\n\nRun \`pnpm changeset\` and select them. If this change intentionally\n` +
+        `ships no release, add the \`no-changeset\` label to the PR instead.`;
     console.error(
       `\n❌ These changed publishable packages have no changeset entry:\n` +
         missing.map((n) => `   - ${n}`).join("\n") +
-        `\n\nRun \`pnpm changeset\` and select them. If this change intentionally\n` +
-        `ships no release, add the \`no-changeset\` label to the PR instead.`,
+        hint,
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Why

The release flow's only changeset guard is [`Fail if no changesets were queued`](https://github.com/bosonprotocol/x402B/blob/main/.github/workflows/release.yml#L68-L74), which runs `git diff --quiet` after `changeset version`. It answers *"are there **any** changesets?"* — not *"is every package that changed since the last release covered?"*

So a `workflow_dispatch` release with one changeset but other uncovered packages would under-publish silently. This is the same class of gap that let #113 merge with no changeset (via the `no-changeset` PR label), which then surfaced only as a generic *"No queued changesets — nothing to release"* failure with no indication of *which* packages were missing.

## What

Adds a `workflow_dispatch` step that re-runs the existing [check-changeset-coverage.mjs](https://github.com/bosonprotocol/x402B/blob/main/scripts/check-changeset-coverage.mjs) with the **previous release commit** as the base, **before** the changesets are consumed (so the `.md` files are still readable).

- Reuses the script via its existing `CHANGESET_BASE` env — no duplicated logic.
- New `RELEASE_COVERAGE=true` flag **disables the `no-changeset` bypass** (that label only exists on PRs; a release must never silently skip a changed package) and tailors the failure hint to *"add a changeset, merge, re-run the release."*
- PR-mode behaviour is unchanged.

The two guards are complementary: this catches *"a package changed but isn't covered"*; the existing step still catches *"a dispatch with nothing queued at all."*

## Verification

Ran the script locally in every mode:

| Scenario | Result |
|---|---|
| Release mode, base where 5 pkgs changed + nothing queued | ❌ fails, lists the exact 5 packages (would have caught #113) |
| Release mode, base = current last-release commit | ✅ passes ("No publishable package changed") |
| Release mode **+ `no-changeset` label set** | ❌ still fails (bypass ignored) |
| PR mode + `no-changeset` label | ✅ skips (unchanged) |

`pnpm build && pnpm test && pnpm lint && pnpm format:check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)